### PR TITLE
fix(ci): run quality gate on pull_request only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Drop the `push` trigger on `main` from the CI workflow — fmt/clippy/test already gate every PR before merge, so re-running them again on push to main is redundant.

## Test plan
- [ ] CI passes on this PR