### PR TITLE
fix: terminal cleanup CPR leak + accept Enter on empty curriculum

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,6 @@ async fn main() -> anyhow::Result<()> {
     terminal.clear()?;
     let result = run_app(&mut terminal, data_dir, db, config, quit).await;
     let _ = execute!(terminal.backend_mut(), DisableMouseCapture);
-    let _ = terminal.clear();
     ratatui::restore();
     println!();
     result?;

--- a/src/ui/views/curriculum.rs
+++ b/src/ui/views/curriculum.rs
@@ -334,6 +334,9 @@ pub async fn handle_key(state: &mut AppState, code: KeyCode) -> Result<()> {
         KeyCode::Char('g') => {
             generate_curriculum(state).await?;
         }
+        KeyCode::Enter if state.curriculum.topics.is_empty() && !state.curriculum.loading => {
+            generate_curriculum(state).await?;
+        }
         KeyCode::Char('r') if !state.curriculum.topics.is_empty() => {
             state.curriculum.pending_reset = true;
         }


### PR DESCRIPTION
## Summary
- Drop the redundant `terminal.clear()` call right before `ratatui::restore()` in `main.rs`. `ratatui`'s `clear()` queries the terminal's cursor position (`ESC[6n`) and waits for the `ESC[row;colR` reply; when that reply arrives after raw mode is disabled, the shell echoes the tail as literal text (e.g. `;162R`) after quitting with `q`.
- On the empty-curriculum screen (reached right after onboarding), accept `Enter` as well as `g` to trigger course generation — previously `Enter` was silently a no-op there since it was gated to non-empty curriculums.

## Test plan
- [ ] `cargo build --all-targets --all-features` — passes
- [ ] Quit the app with `q` and confirm no `;NNR` garbage appears in the shell afterward
- [ ] On first run (empty curriculum), confirm both `g` and `Enter` trigger course generation