### PR TITLE
fix(ci): chain release build to release-please via workflow_call

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,21 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build-release:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,18 @@ on:
         description: "Version tag to release, e.g. v0.2.0. Leave empty to build artifacts only without creating a release."
         required: false
         default: ""
+  workflow_call:
+    inputs:
+      version:
+        description: "Version tag to release, e.g. v0.2.0."
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 env:
-  RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
+  RELEASE_VERSION: ${{ inputs.version || github.ref_name }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- `release-please-action` creates tags/releases using the default `GITHUB_TOKEN`, and tags created that way don't trigger other workflows — so `release.yml`'s `push: tags: v*` trigger never fired for release-please-created releases (v0.4.0, v0.5.0 shipped with no binary assets, breaking `installer.sh`).
- `release.yml` now also accepts a `workflow_call` trigger with a required `version` input.
- `release-please.yml` adds a `build-release` job that calls `release.yml` directly once `release-please` reports `release_created == 'true'`, passing the created tag as `version`.

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(open(...))"` for both workflow files.
- [x] Manually re-ran `release.yml` via `workflow_dispatch -f version=v0.5.0` to backfill missing assets on the existing v0.5.0 release.
- [ ] Next release-please PR merge should confirm `build-release` fires automatically and attaches binaries + installer.sh.