### PR TITLE
fix: store data globally in ~/.open-course-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,6 +4495,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "dirs",
  "futures-util",
  "lancedb",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ clap = { version = "4", features = ["derive"] }
 
 # Utils
 anyhow = "1"
+dirs = "6"
 thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
 time = "0.3"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cargo install open-course-cli
 cargo run
 ```
 
-Data is stored in `.open-course-cli/` under the current directory. Use `--data-dir` to change the location:
+Data is stored globally in `~/.open-course-cli/`, so you can launch the app from any directory and always see the same data. On first run after upgrading, an existing local `.open-course-cli/` in the current directory is migrated to the global location automatically. Use `--data-dir` (or `--cwd`) to override the location:
 
 ```bash
 cargo run -- --data-dir /path/to/project

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -63,7 +63,7 @@ The **Activity** block is a GitHub-style calendar of the current month: quiet da
 
 Switch between language pairs or add a new one.
 
-- Each pair has its own isolated database folder: `.open-course-cli/pairs/{native-target}/db`.
+- Each pair has its own isolated database folder: `~/.open-course-cli/pairs/{native-target}/db`.
 - Progress, session history, curriculum, and reviews are stored per pair.
 - Provider settings and preferences are shared across all pairs.
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -144,6 +144,67 @@ pub fn open_course_dir(cwd: &std::path::Path) -> std::path::PathBuf {
     cwd.join(".open-course-cli")
 }
 
+/// Default data directory: `~/.open-course-cli`, so the same data is used no
+/// matter where the binary is launched from.
+///
+/// If the global directory has no config yet but the current directory has a
+/// local `.open-course-cli/config.json` (pre-global-layout install), the local
+/// directory is moved to the global location. Falls back to the current
+/// directory when the home directory cannot be determined.
+pub fn resolve_data_dir(cwd: &std::path::Path) -> std::path::PathBuf {
+    resolve_data_dir_with_home(cwd, dirs::home_dir().as_deref())
+}
+
+pub fn resolve_data_dir_with_home(
+    cwd: &std::path::Path,
+    home: Option<&std::path::Path>,
+) -> std::path::PathBuf {
+    let Some(home) = home else {
+        return cwd.to_path_buf();
+    };
+    if cwd == home {
+        return home.to_path_buf();
+    }
+    let global = open_course_dir(home);
+    if !has_config(home) && has_config(cwd) {
+        migrate_local_data(&open_course_dir(cwd), &global);
+    }
+    home.to_path_buf()
+}
+
+/// Move entries from a legacy local data dir into the global one. Never
+/// overwrites existing global entries; removes the local dir if it ends up
+/// empty.
+fn migrate_local_data(local: &std::path::Path, global: &std::path::Path) {
+    if std::fs::create_dir_all(global).is_err() {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(local) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let target = global.join(entry.file_name());
+        if target.exists() {
+            continue;
+        }
+        let _ = std::fs::rename(entry.path(), &target);
+    }
+    if std::fs::read_dir(local).is_ok_and(|mut e| e.next().is_none()) {
+        let _ = std::fs::remove_dir(local);
+        eprintln!(
+            "Migrated data from {} to {}",
+            local.display(),
+            global.display()
+        );
+    } else {
+        eprintln!(
+            "Partially migrated data from {} to {}; some entries were left behind",
+            local.display(),
+            global.display()
+        );
+    }
+}
+
 pub fn pair_db_path(cwd: &std::path::Path, pair_id: &str) -> std::path::PathBuf {
     open_course_dir(cwd).join("pairs").join(pair_id).join("db")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,10 @@ use open_course_cli::llm::pipeline::log_debug_event;
     about = "AI language learning terminal"
 )]
 struct Cli {
-    #[arg(long, default_value = ".")]
-    cwd: PathBuf,
+    /// Use this directory's `.open-course-cli` for data instead of the global
+    /// `~/.open-course-cli`.
+    #[arg(long)]
+    cwd: Option<PathBuf>,
     #[arg(long = "data-dir")]
     data_dir: Option<PathBuf>,
 }
@@ -32,8 +34,14 @@ struct Cli {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let cwd = cli.cwd.canonicalize()?;
-    let data_dir = cli.data_dir.unwrap_or_else(|| cwd.clone());
+    let data_dir = match (cli.data_dir, cli.cwd) {
+        (Some(dir), _) => dir,
+        (None, Some(cwd)) => cwd.canonicalize()?,
+        (None, None) => {
+            let cwd = std::env::current_dir()?.canonicalize()?;
+            config::resolve_data_dir(&cwd)
+        }
+    };
 
     let config = config::read_config(&data_dir)?;
 

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -140,3 +140,78 @@ fn opencode_to_custom_migration() {
     let provider = read.providers.get(&ProviderId::Custom).unwrap();
     assert_eq!(provider.model(), "claude-sonnet");
 }
+
+#[test]
+fn resolve_data_dir_prefers_global_home() {
+    let cwd = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    // Local config exists, global does not: local data is migrated to global.
+    let local_dir = cwd.path().join(".open-course-cli");
+    fs::create_dir_all(&local_dir).unwrap();
+    fs::write(local_dir.join("config.json"), "{}").unwrap();
+    fs::write(local_dir.join("marker.txt"), "data").unwrap();
+
+    let resolved = config::resolve_data_dir_with_home(cwd.path(), Some(home.path()));
+    assert_eq!(resolved, home.path());
+
+    let global_dir = home.path().join(".open-course-cli");
+    assert!(global_dir.join("config.json").exists());
+    assert!(global_dir.join("marker.txt").exists());
+    assert!(!local_dir.exists());
+}
+
+#[test]
+fn resolve_data_dir_keeps_global_when_it_already_has_config() {
+    let cwd = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    let local_dir = cwd.path().join(".open-course-cli");
+    fs::create_dir_all(&local_dir).unwrap();
+    fs::write(local_dir.join("config.json"), "{\"local\":true}").unwrap();
+    let global_dir = home.path().join(".open-course-cli");
+    fs::create_dir_all(&global_dir).unwrap();
+    fs::write(global_dir.join("config.json"), "{\"global\":true}").unwrap();
+
+    let resolved = config::resolve_data_dir_with_home(cwd.path(), Some(home.path()));
+    assert_eq!(resolved, home.path());
+    // Global config is untouched, local stays in place.
+    assert_eq!(
+        fs::read_to_string(global_dir.join("config.json")).unwrap(),
+        "{\"global\":true}"
+    );
+    assert!(local_dir.join("config.json").exists());
+}
+
+#[test]
+fn resolve_data_dir_returns_home_for_fresh_install() {
+    let cwd = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    let resolved = config::resolve_data_dir_with_home(cwd.path(), Some(home.path()));
+    assert_eq!(resolved, home.path());
+}
+
+#[test]
+fn resolve_data_dir_falls_back_to_cwd_without_home() {
+    let cwd = TempDir::new().unwrap();
+    let resolved = config::resolve_data_dir_with_home(cwd.path(), None);
+    assert_eq!(resolved, cwd.path());
+}
+
+#[test]
+fn resolve_data_dir_merges_into_existing_global_without_config() {
+    let cwd = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    // Global dir exists (e.g. fallback db) but has no config yet.
+    let global_dir = home.path().join(".open-course-cli");
+    fs::create_dir_all(global_dir.join("db")).unwrap();
+    // Local dir has a config plus an entry that conflicts with global.
+    let local_dir = cwd.path().join(".open-course-cli");
+    fs::create_dir_all(local_dir.join("db")).unwrap();
+    fs::write(local_dir.join("config.json"), "{}").unwrap();
+
+    let resolved = config::resolve_data_dir_with_home(cwd.path(), Some(home.path()));
+    assert_eq!(resolved, home.path());
+    assert!(global_dir.join("config.json").exists());
+    // Conflicting entry is not overwritten; local leftovers stay in place.
+    assert!(local_dir.join("db").exists());
+    assert!(!local_dir.join("config.json").exists());
+}


### PR DESCRIPTION
## Problem

Data was stored in `.open-course-cli/` under the **current working directory**. After installing the release binary, launching it from any other directory created/used an empty data store — the user saw an empty learning plan with a prompt to generate a new one (`g`), even though the plan existed elsewhere.

## Solution

- The default data dir is now the global `~/.open-course-cli` (via `dirs::home_dir()`): launching from any directory always sees the same data.
- On first run, an existing local `.open-course-cli/` containing `config.json` is automatically migrated to the global location (per-entry move; existing global entries are never overwritten).
- `--data-dir` / `--cwd` still override the location (`--cwd` is now an `Option`: when passed explicitly it behaves as before).
- Falls back to the previous cwd behavior when the home directory cannot be determined.

## Tests

4 new tests in `tests/config_test.rs`: local → global migration, existing global config takes precedence, fresh install, fallback without home, and merging into a global dir that has no config. Full `cargo test` is green.

README and `docs/flow.md` updated.
