### PR TITLE
fix(ui): green selected options in selectors, onboarding logo margins

### DIFF
--- a/src/ui/views/curriculum.rs
+++ b/src/ui/views/curriculum.rs
@@ -251,7 +251,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
 
     let list = List::new(items).highlight_symbol("> ").highlight_style(
         Style::default()
-            .fg(colors::BLUE)
+            .fg(colors::GREEN)
             .add_modifier(Modifier::BOLD),
     );
 

--- a/src/ui/views/docs.rs
+++ b/src/ui/views/docs.rs
@@ -266,7 +266,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                 .collect();
             let list = List::new(items).highlight_symbol("> ").highlight_style(
                 Style::default()
-                    .fg(colors::BLUE)
+                    .fg(colors::GREEN)
                     .add_modifier(Modifier::BOLD),
             );
             frame.render_stateful_widget(list, chunks[1], &mut state.docs.list_state);

--- a/src/ui/views/onboarding/mod.rs
+++ b/src/ui/views/onboarding/mod.rs
@@ -5,7 +5,7 @@ mod steps;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Padding, Paragraph};
 use std::sync::Arc;
 
 use crate::app::{AppState, LlmResult, View};
@@ -100,11 +100,16 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         ])
         .split(area);
 
-    // Header: logo + subtitle + global hint.
+    // Header: logo + subtitle + global hint. The padding keeps the logo off
+    // the terminal edge and gives it the same margins as on the dashboard.
+    let header_block = Block::default().padding(Padding::new(1, 1, 1, 0));
+    let header_inner = header_block.inner(chunks[0]);
+    frame.render_widget(header_block, chunks[0]);
+
     let header_chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(4), Constraint::Length(2)])
-        .split(chunks[0]);
+        .constraints([Constraint::Length(1), Constraint::Length(2)])
+        .split(header_inner);
 
     frame.render_widget(
         Logo::new(ratatui::layout::Alignment::Left),
@@ -172,9 +177,9 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     } else {
         match step {
             Step::Provider | Step::Cefr | Step::BatchSize => {
-                let help_text = steps::step_help_text(step, state);
+                let text = steps::step_selector_text(step, state);
                 frame.render_widget(
-                    Paragraph::new(help_text).style(Style::default().fg(Color::White)),
+                    Paragraph::new(text).style(Style::default().fg(Color::White)),
                     card_inner,
                 );
             }

--- a/src/ui/views/onboarding/steps.rs
+++ b/src/ui/views/onboarding/steps.rs
@@ -91,10 +91,10 @@ pub(super) fn step_help_text(step: Step, state: &AppState) -> String {
 pub(super) fn step_selector_text(step: Step, state: &AppState) -> Text<'static> {
     let intro = match step {
         Step::Provider => "Available providers:",
-        Step::Cefr => "Select your CEFR level (required). Pick the level that best matches your current ability (self-assessment):",
-        Step::BatchSize => {
-            "Select batch size — number of exercises per session (required):"
+        Step::Cefr => {
+            "Select your CEFR level (required). Pick the level that best matches your current ability (self-assessment):"
         }
+        Step::BatchSize => "Select batch size — number of exercises per session (required):",
         _ => "",
     };
     let options: Vec<(String, bool)> = match step {
@@ -109,12 +109,7 @@ pub(super) fn step_selector_text(step: Step, state: &AppState) -> Text<'static> 
             .collect(),
         Step::Cefr => CEFR_LEVELS
             .iter()
-            .map(|level| {
-                (
-                    (*level).to_string(),
-                    *level == state.onboarding.cefr,
-                )
-            })
+            .map(|level| ((*level).to_string(), *level == state.onboarding.cefr))
             .collect(),
         Step::BatchSize => BATCH_SIZES
             .iter()

--- a/src/ui/views/onboarding/steps.rs
+++ b/src/ui/views/onboarding/steps.rs
@@ -1,7 +1,11 @@
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+
 use crate::app::AppState;
 use crate::config::provider::ProviderId;
 use crate::db::curriculum::CEFR_LEVELS;
 use crate::llm::provider::ProviderMeta;
+use crate::ui::colors;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Step {
@@ -69,7 +73,6 @@ pub(super) fn is_text_step(step: Step) -> bool {
 
 pub(super) fn step_help_text(step: Step, state: &AppState) -> String {
     match step {
-        Step::Provider => provider_help(state),
         Step::ApiKey => api_key_help(state),
         Step::BaseUrl => base_url_help(state),
         Step::NativeLanguage => {
@@ -79,23 +82,65 @@ pub(super) fn step_help_text(step: Step, state: &AppState) -> String {
             "Enter the language you want to learn (ISO 639-1, e.g. es, de)".to_string()
         }
         Step::Age => "Enter your age (optional, used to pick age-appropriate contexts)".to_string(),
-        Step::Cefr => cefr_help(state),
-        Step::BatchSize => batch_size_help(state),
-        Step::Model => String::new(),
+        _ => String::new(),
     }
 }
 
-fn provider_help(state: &AppState) -> String {
-    let mut text = String::from("Available providers:\n");
-    for p in ProviderId::all() {
-        let marker = if *p == state.onboarding.provider {
-            "> "
+/// Options list for selector steps (provider, CEFR, batch size) with the
+/// currently selected option highlighted in the design-system green.
+pub(super) fn step_selector_text(step: Step, state: &AppState) -> Text<'static> {
+    let intro = match step {
+        Step::Provider => "Available providers:",
+        Step::Cefr => "Select your CEFR level (required). Pick the level that best matches your current ability (self-assessment):",
+        Step::BatchSize => {
+            "Select batch size — number of exercises per session (required):"
+        }
+        _ => "",
+    };
+    let options: Vec<(String, bool)> = match step {
+        Step::Provider => ProviderId::all()
+            .iter()
+            .map(|p| {
+                (
+                    format!("{} - {}", p.as_str(), p.label()),
+                    *p == state.onboarding.provider,
+                )
+            })
+            .collect(),
+        Step::Cefr => CEFR_LEVELS
+            .iter()
+            .map(|level| {
+                (
+                    (*level).to_string(),
+                    *level == state.onboarding.cefr,
+                )
+            })
+            .collect(),
+        Step::BatchSize => BATCH_SIZES
+            .iter()
+            .map(|size| {
+                (
+                    (*size).to_string(),
+                    *size == state.onboarding.batch_size.to_string().as_str(),
+                )
+            })
+            .collect(),
+        _ => vec![],
+    };
+
+    let mut lines = vec![Line::from(intro.to_string())];
+    for (label, selected) in options {
+        let marker = if selected { "> " } else { "  " };
+        let style = if selected {
+            Style::default()
+                .fg(colors::GREEN)
+                .add_modifier(Modifier::BOLD)
         } else {
-            "  "
+            Style::default().fg(Color::White)
         };
-        text.push_str(&format!("{}{} - {}\n", marker, p.as_str(), p.label()));
+        lines.push(Line::from(Span::styled(format!("{marker}{label}"), style)));
     }
-    text
+    Text::from(lines)
 }
 
 fn api_key_help(state: &AppState) -> String {
@@ -135,33 +180,4 @@ fn base_url_help(state: &AppState) -> String {
             state.onboarding.provider.label()
         )
     }
-}
-
-fn cefr_help(state: &AppState) -> String {
-    let mut text = String::from(
-        "Select your CEFR level (required). Pick the level that best matches your current ability (self-assessment):\n",
-    );
-    for level in CEFR_LEVELS {
-        let marker = if *level == state.onboarding.cefr {
-            "> "
-        } else {
-            "  "
-        };
-        text.push_str(&format!("{}{}\n", marker, level));
-    }
-    text
-}
-
-fn batch_size_help(state: &AppState) -> String {
-    let mut text =
-        String::from("Select batch size — number of exercises per session (required):\n");
-    for size in BATCH_SIZES {
-        let marker = if *size == state.onboarding.batch_size.to_string().as_str() {
-            "> "
-        } else {
-            "  "
-        };
-        text.push_str(&format!("{}{}\n", marker, size));
-    }
-    text
 }

--- a/src/ui/views/pairs.rs
+++ b/src/ui/views/pairs.rs
@@ -58,24 +58,28 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     let items: Vec<ListItem> = pairs
         .iter()
         .map(|pair| {
-            let is_active = pair.id == active_id;
             let label = format!(
                 "{} → {}",
                 pair.profile.native_language, pair.profile.target_language
             );
-            let style = if is_active {
-                Style::default().fg(accent).add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(Color::White)
-            };
-            if is_active {
-                let suffix = format!(" [{}]", labels.current);
+            if pair.id == active_id {
+                // The active pair is marked with a localized gray tag instead
+                // of a color, so it is not confused with the cursor row.
+                let suffix = format!("[{}]", labels.current);
                 let padding =
                     list_width.saturating_sub(label.chars().count() + suffix.chars().count());
-                let line = format!("{}{}{}", label, " ".repeat(padding), suffix);
-                ListItem::new(Line::from(Span::styled(line, style)))
+                ListItem::new(Line::from(vec![
+                    Span::styled(
+                        format!("{}{}", label, " ".repeat(padding)),
+                        Style::default().fg(Color::White),
+                    ),
+                    Span::styled(suffix, Style::default().fg(Color::DarkGray)),
+                ]))
             } else {
-                ListItem::new(Line::from(Span::styled(label, style)))
+                ListItem::new(Line::from(Span::styled(
+                    label,
+                    Style::default().fg(Color::White),
+                )))
             }
         })
         .collect();

--- a/src/ui/views/pairs.rs
+++ b/src/ui/views/pairs.rs
@@ -54,7 +54,6 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         .map(|c| c.active_pair.as_str())
         .unwrap_or("");
 
-    let list_width = chunks[1].width as usize;
     let items: Vec<ListItem> = pairs
         .iter()
         .map(|pair| {
@@ -63,17 +62,14 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                 pair.profile.native_language, pair.profile.target_language
             );
             if pair.id == active_id {
-                // The active pair is marked with a localized gray tag instead
-                // of a color, so it is not confused with the cursor row.
-                let suffix = format!("[{}]", labels.current);
-                let padding =
-                    list_width.saturating_sub(label.chars().count() + suffix.chars().count());
+                // The active pair is marked with a localized gray tag right
+                // after the label, so it is not confused with the cursor row.
                 ListItem::new(Line::from(vec![
+                    Span::styled(label, Style::default().fg(Color::White)),
                     Span::styled(
-                        format!("{}{}", label, " ".repeat(padding)),
-                        Style::default().fg(Color::White),
+                        format!(" [{}]", labels.current),
+                        Style::default().fg(Color::DarkGray),
                     ),
-                    Span::styled(suffix, Style::default().fg(Color::DarkGray)),
                 ]))
             } else {
                 ListItem::new(Line::from(Span::styled(

--- a/src/ui/views/pairs.rs
+++ b/src/ui/views/pairs.rs
@@ -23,7 +23,7 @@ impl PairsState {
 }
 
 pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut AppState) {
-    let accent = colors::BLUE;
+    let accent = colors::GREEN;
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/src/ui/views/session.rs
+++ b/src/ui/views/session.rs
@@ -124,7 +124,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
 
             let list = List::new(items).highlight_symbol("> ").highlight_style(
                 Style::default()
-                    .fg(colors::BLUE)
+                    .fg(colors::GREEN)
                     .add_modifier(Modifier::BOLD),
             );
 

--- a/src/ui/views/settings/mod.rs
+++ b/src/ui/views/settings/mod.rs
@@ -168,7 +168,7 @@ fn build_body(state: &AppState, labels: ReportLabels) -> Text<'static> {
             if is_saved {
                 lines.push(Line::from(Span::styled(
                     content,
-                    Style::default().bg(colors::BLUE).fg(Color::White),
+                    Style::default().bg(colors::GREEN).fg(Color::Black),
                 )));
             } else if is_cursor {
                 lines.push(Line::from(Span::styled(
@@ -308,7 +308,7 @@ fn draw_section_picker(
 
     let list = List::new(items).highlight_symbol("> ").highlight_style(
         Style::default()
-            .fg(colors::BLUE)
+            .fg(colors::GREEN)
             .add_modifier(Modifier::BOLD),
     );
 

--- a/src/ui/widgets/model_picker.rs
+++ b/src/ui/widgets/model_picker.rs
@@ -251,7 +251,7 @@ pub fn draw_model_list(
 
     let list = List::new(items).highlight_symbol("> ").highlight_style(
         Style::default()
-            .fg(colors::BLUE)
+            .fg(colors::GREEN)
             .add_modifier(Modifier::BOLD),
     );
 


### PR DESCRIPTION
## Changes

**Selector highlight: blue → green (design-system `colors::GREEN`)**

- List selectors now highlight the selected option in green bold instead of blue: model picker, session, docs, curriculum, settings section list.
- Pairs view: the selected/active pair accent is green.
- Settings → batch size: the saved value uses a green background with black text (white on the light-mint green would be unreadable).
- Onboarding selector steps (provider, CEFR, batch size): the selected option was plain white text with a `>` marker — it is now rendered green bold via styled lines instead of a plain string.

Blue accents that are not selectors (card borders, titles, markdown styles, sparkline, progress bars) are unchanged.

**Onboarding logo margins**

- The logo rendered flush against the top-left terminal edge in a 4-row area. The header is now wrapped in the same padding as the dashboard (`Padding::new(1, 1, 1, 0)`) and the logo area is trimmed to a single row, removing the awkward empty gap below it.

## Release note

This is a `fix:` commit — merging it will make release-please propose **0.5.3**, unblocking the release pipeline after the manual v0.5.2 release.

Full `cargo test` is green.