### PR TITLE
feat(update): rename binary to opencourse, add update command and reliable update checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,12 +73,12 @@ jobs:
         shell: bash
         run: |
           VERSION="${{ env.RELEASE_VERSION }}"
-          BINARY="target/${{ matrix.target }}/release/open-course-cli"
+          BINARY="target/${{ matrix.target }}/release/opencourse"
           mkdir -p dist
           if [ -f "$BINARY" ]; then
             cp "$BINARY" dist/
             cd dist
-            tar -czf "open-course-cli-${VERSION}-${{ matrix.target }}.tar.gz" open-course-cli
+            tar -czf "opencourse-${VERSION}-${{ matrix.target }}.tar.gz" opencourse
           else
             echo "Binary not found at $BINARY"
             exit 1
@@ -87,8 +87,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: open-course-cli-${{ env.RELEASE_VERSION }}-${{ matrix.target }}
-          path: dist/open-course-cli-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.tar.gz
+          name: opencourse-${{ env.RELEASE_VERSION }}-${{ matrix.target }}
+          path: dist/opencourse-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.tar.gz
 
   release:
     name: Create GitHub Release
@@ -113,12 +113,16 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: dist
-          pattern: open-course-cli-${{ steps.meta.outputs.version }}-*
+          pattern: opencourse-${{ steps.meta.outputs.version }}-*
           merge-multiple: true
 
       - name: Copy installer script
         if: startsWith(steps.meta.outputs.version, 'v')
-        run: cp installer.sh dist/open-course-cli-installer.sh
+        run: |
+          cp installer.sh dist/opencourse-installer.sh
+          # Keep the legacy asset name: opencourse <= 0.5.3 self-updates by
+          # downloading `open-course-cli-installer.sh` from the latest release.
+          cp installer.sh dist/open-course-cli-installer.sh
 
       - name: Create Release
         if: startsWith(steps.meta.outputs.version, 'v')
@@ -128,6 +132,7 @@ jobs:
           name: ${{ steps.meta.outputs.version }}
           files: |
             dist/*.tar.gz
+            dist/opencourse-installer.sh
             dist/open-course-cli-installer.sh
           generate_release_notes: true
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,11 +118,7 @@ jobs:
 
       - name: Copy installer script
         if: startsWith(steps.meta.outputs.version, 'v')
-        run: |
-          cp installer.sh dist/opencourse-installer.sh
-          # Keep the legacy asset name: opencourse <= 0.5.3 self-updates by
-          # downloading `open-course-cli-installer.sh` from the latest release.
-          cp installer.sh dist/open-course-cli-installer.sh
+        run: cp installer.sh dist/opencourse-installer.sh
 
       - name: Create Release
         if: startsWith(steps.meta.outputs.version, 'v')
@@ -133,7 +129,6 @@ jobs:
           files: |
             dist/*.tar.gz
             dist/opencourse-installer.sh
-            dist/open-course-cli-installer.sh
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "open-course-cli"
 version = "0.5.3"
 edition = "2024"
 
+[[bin]]
+name = "opencourse"
+path = "src/main.rs"
+
 [dependencies]
 # TUI
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Onboarding fetches the list of available models automatically. For local Ollama 
 
 ## Updating
 
-On startup the app checks the latest GitHub release and, if a newer version is available, shows a prompt with the current and latest version (`y` installs by re-running the installer script, `n` skips and continues to the dashboard). If you skip, the dashboard header keeps showing the available version — press `u` there to reopen the prompt. The check works offline-first: any network or API error just skips the prompt.
+On startup the app checks the latest GitHub release and, if a newer version is available, shows a prompt with the current and latest version (`y` installs by re-running the installer script, `n` skips and continues to the dashboard). After skipping, the dashboard header keeps showing the available version under the current one. The check works offline-first: any network or API error just skips the prompt.
 
 To update manually at any time:
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,12 @@ Terminal AI tutor for language learning. Exercises, lessons, and answer analysis
 The fastest way to get the latest release:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/scriptology/open-course-cli/releases/latest/download/open-course-cli-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/scriptology/open-course-cli/releases/latest/download/opencourse-installer.sh | sh
 ```
 
-The installer detects macOS (Apple Silicon / Intel) and Linux x86_64, then downloads the matching binary into `~/.local/bin` (or `/usr/local/bin` if writable). It also creates a symlink `opencourse`, so both commands work:
+The installer detects macOS (Apple Silicon / Intel) and Linux x86_64, then downloads the matching binary into `~/.local/bin` (or `/usr/local/bin` if writable):
 
 ```bash
-open-course-cli
-# or
 opencourse
 ```
 
@@ -24,7 +22,7 @@ Add the directory to your PATH if needed:
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-You can also install with `cargo` if you already have the Rust toolchain:
+You can also install with `cargo` if you already have the Rust toolchain (the installed binary is called `opencourse`):
 
 ```bash
 cargo install open-course-cli
@@ -101,7 +99,15 @@ Onboarding fetches the list of available models automatically. For local Ollama 
 
 ## Updating
 
-On startup the app checks the latest GitHub release and, if a newer version is available, shows a prompt with the current and latest version (`y` installs by re-running the installer script, `n` skips and continues to the dashboard). The check fails silently and skips the prompt if there's no network access. To update manually at any time, re-run the install command from [Install](#install), or `cargo install open-course-cli` if you installed it that way.
+On startup the app checks the latest GitHub release and, if a newer version is available, shows a prompt with the current and latest version (`y` installs by re-running the installer script, `n` skips and continues to the dashboard). If you skip, the dashboard header keeps showing the available version — press `u` there to reopen the prompt. The check works offline-first: any network or API error just skips the prompt.
+
+To update manually at any time:
+
+```bash
+opencourse update
+```
+
+or re-run the install command from [Install](#install), or `cargo install open-course-cli` if you installed it that way.
 
 ## Architecture
 

--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,8 @@
 set -eu
 
 REPO="scriptology/open-course-cli"
-BIN_NAME="open-course-cli"
+BIN_NAME="opencourse"
+LEGACY_BIN_NAME="open-course-cli"
 
 main() {
     detect_platform
@@ -38,11 +39,11 @@ main() {
 
     if [ -w "$INSTALL_DIR" ]; then
         mv "$TMP_DIR/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
-        ln -sf "$INSTALL_DIR/$BIN_NAME" "$INSTALL_DIR/opencourse"
+        rm -f "$INSTALL_DIR/$LEGACY_BIN_NAME"
     else
         say "Installing to $INSTALL_DIR requires sudo."
         sudo mv "$TMP_DIR/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
-        sudo ln -sf "$INSTALL_DIR/$BIN_NAME" "$INSTALL_DIR/opencourse"
+        sudo rm -f "$INSTALL_DIR/$LEGACY_BIN_NAME"
     fi
 
     rm -rf "$TMP_DIR"
@@ -50,11 +51,11 @@ main() {
     case ":$PATH:" in
         *":$INSTALL_DIR:"*)
             say "Installed $BIN_NAME $RELEASE to $INSTALL_DIR"
-            say "You can run: open-course-cli or opencourse"
+            say "You can run: opencourse"
             ;;
         *)
             say "Installed $BIN_NAME $RELEASE to $INSTALL_DIR"
-            say "You can run: open-course-cli or opencourse"
+            say "You can run: opencourse"
             say "Add it to your PATH:"
             say "  export PATH=\"$INSTALL_DIR:\$PATH\""
             ;;

--- a/src/app/llm_results.rs
+++ b/src/app/llm_results.rs
@@ -28,6 +28,13 @@ pub async fn apply_llm_result(state: &mut AppState, result: LlmResult) {
         log_debug_event(tag, &message, Some(state.data_dir.as_path()));
     }
 
+    // The update check is UI-independent: it must apply even when a previous
+    // background task was cancelled.
+    if let LlmResult::UpdateCheck(latest) = result {
+        handle_update_check(state, latest);
+        return;
+    }
+
     if state.cancelled {
         state.cancelled = false;
         clear_loading(state);
@@ -57,6 +64,8 @@ pub async fn apply_llm_result(state: &mut AppState, result: LlmResult) {
         }
         LlmResult::OnboardingModels(res) => handle_onboarding_models(state, res),
         LlmResult::SimpleText(_) => {}
+        // Handled above, before the cancellation check.
+        LlmResult::UpdateCheck(_) => {}
     }
 }
 
@@ -104,6 +113,10 @@ fn debug_describe(result: &LlmResult) -> Option<(&'static str, String)> {
             "diagnostics",
             "apply_llm_result DiagnosticsDone".to_string(),
         ),
+        LlmResult::UpdateCheck(latest) => (
+            "update",
+            format!("apply_llm_result UpdateCheck: {latest:?}"),
+        ),
         LlmResult::StreamChunk(_) | LlmResult::CurriculumStreamChunk { .. } => return None,
     };
     Some((tag, message))
@@ -113,6 +126,22 @@ fn result_str<T: std::fmt::Debug>(res: &Result<T>) -> String {
     match res {
         Ok(_) => "Ok".to_string(),
         Err(e) => format!("Err({e})"),
+    }
+}
+
+/// Store the latest release version and, when the user is on a top-level
+/// screen, show the update prompt. During a session or on other focused
+/// screens only the dashboard badge is armed.
+fn handle_update_check(state: &mut AppState, latest: Option<String>) {
+    let Some(latest) = latest else {
+        return;
+    };
+    if !crate::update::is_newer(crate::update::CURRENT_VERSION, &latest) {
+        return;
+    }
+    state.update.latest_version = Some(latest);
+    if matches!(state.view, View::Dashboard | View::Onboarding) {
+        state.view = View::UpdateAvailable;
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -60,6 +60,7 @@ pub enum LlmResult {
     CurriculumStreamChunk { level: String, status: String },
     DiagnosticUpdate(CheckResult),
     DiagnosticsDone,
+    UpdateCheck(Option<String>),
 }
 
 pub struct AppState {
@@ -140,24 +141,34 @@ pub async fn run_app(
     let (llm_tx, mut llm_rx) = mpsc::channel::<LlmResult>(16);
     let mut state = AppState::new(data_dir, db, config, quit_requested.clone(), llm_tx)?;
 
-    if let Some(latest) = crate::update::latest_release_version().await?
-        && crate::update::is_newer(crate::update::CURRENT_VERSION, &latest)
+    // Check for a newer release in the background so startup never blocks on
+    // the network; the result arrives through the regular event loop.
     {
-        state.view = View::UpdateAvailable;
-        state.update.latest_version = Some(latest);
+        let tx = state.llm_tx.clone();
+        let data_dir = state.data_dir.clone();
+        tokio::spawn(async move {
+            let latest = crate::update::latest_release_version().await.ok().flatten();
+            crate::llm::pipeline::log_debug_event(
+                "update",
+                &format!(
+                    "update check: current {}, latest {latest:?}",
+                    crate::update::CURRENT_VERSION
+                ),
+                Some(&data_dir),
+            );
+            let _ = tx.send(LlmResult::UpdateCheck(latest)).await;
+        });
     }
 
-    if state.view != View::UpdateAvailable {
-        state
-            .dashboard
-            .refresh(&state.db, state.config.as_ref())
-            .await?;
-        if let Err(e) = state.curriculum.load(&state.db).await {
-            state.error = Some(e.to_string());
-        }
-        if state.view == View::Dashboard && state.curriculum.topics.is_empty() {
-            state.view = View::Curriculum;
-        }
+    state
+        .dashboard
+        .refresh(&state.db, state.config.as_ref())
+        .await?;
+    if let Err(e) = state.curriculum.load(&state.db).await {
+        state.error = Some(e.to_string());
+    }
+    if state.view == View::Dashboard && state.curriculum.topics.is_empty() {
+        state.view = View::Curriculum;
     }
 
     let mut events = EventStream::new();
@@ -431,7 +442,7 @@ async fn run_installer_and_exit(state: &mut AppState) -> Result<()> {
     execute!(stdout(), LeaveAlternateScreen)?;
     stdout().flush()?;
 
-    println!("Installing open-course-cli {latest}...");
+    println!("Installing opencourse {latest}...");
 
     let status = std::process::Command::new("sh")
         .arg("-c")
@@ -449,7 +460,8 @@ async fn run_installer_and_exit(state: &mut AppState) -> Result<()> {
 }
 
 async fn continue_to_app(state: &mut AppState) -> Result<()> {
-    state.update.latest_version = None;
+    // Keep `latest_version` so the dashboard can keep showing the update badge
+    // after the user skips the prompt.
     if state.config.is_some() {
         state.view = View::Dashboard;
         state

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use ratatui::crossterm::{
     cursor::MoveTo,
     event::DisableMouseCapture,
@@ -15,14 +15,13 @@ use open_course_cli::config;
 use open_course_cli::db::Database;
 use open_course_cli::db::curriculum::cleanup_topics;
 use open_course_cli::llm::pipeline::log_debug_event;
+use open_course_cli::update;
 
 #[derive(Parser)]
-#[command(
-    name = "open-course-cli",
-    version,
-    about = "AI language learning terminal"
-)]
+#[command(name = "opencourse", version, about = "AI language learning terminal")]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
     /// Use this directory's `.open-course-cli` for data instead of the global
     /// `~/.open-course-cli`.
     #[arg(long)]
@@ -31,9 +30,20 @@ struct Cli {
     data_dir: Option<PathBuf>,
 }
 
+#[derive(Subcommand)]
+enum Command {
+    /// Check for a newer release and install it.
+    Update,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+
+    if let Some(Command::Update) = cli.command {
+        return run_update().await;
+    }
+
     let data_dir = match (cli.data_dir, cli.cwd) {
         (Some(dir), _) => dir,
         (None, Some(cwd)) => cwd.canonicalize()?,
@@ -133,6 +143,40 @@ fn setup_panic_hook() {
         println!();
         original(info);
     }));
+}
+
+/// `opencourse update`: check GitHub for a newer release and install it via
+/// the same installer script the in-app prompt uses.
+async fn run_update() -> anyhow::Result<()> {
+    let latest = update::latest_release_version().await?;
+
+    match latest {
+        Some(latest) if update::is_newer(update::CURRENT_VERSION, &latest) => {
+            println!("Updating v{} → v{latest}...", update::CURRENT_VERSION);
+            let status = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(update::install_command())
+                .status()?;
+            if !status.success() {
+                anyhow::bail!("Installer failed with status {status}");
+            }
+            println!("Updated to v{latest}. Run `opencourse` to start the new version.");
+        }
+        Some(latest) => {
+            println!(
+                "Already up to date (v{}, latest release v{latest}).",
+                update::CURRENT_VERSION
+            );
+        }
+        None => {
+            println!(
+                "Could not check for updates (network unavailable?). Current version: v{}.",
+                update::CURRENT_VERSION
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// One-off startup maintenance: removes fuzzy-duplicate learning items and

--- a/src/ui/labels.rs
+++ b/src/ui/labels.rs
@@ -75,6 +75,7 @@ pub struct ReportLabels {
     pub new_topic_session_label: &'static str,
     pub topic_label: &'static str,
     pub invalid_value: &'static str,
+    pub update_label: &'static str,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -163,6 +164,7 @@ const EN_REPORT: ReportLabels = ReportLabels {
     new_topic_session_label: "New topic",
     topic_label: "Topic",
     invalid_value: "invalid value",
+    update_label: "update",
 };
 
 const RU_REPORT: ReportLabels = ReportLabels {
@@ -239,6 +241,7 @@ const RU_REPORT: ReportLabels = ReportLabels {
     new_topic_session_label: "Новая тема",
     topic_label: "Тема",
     invalid_value: "недопустимое значение",
+    update_label: "обновить",
 };
 
 const EN_DOCS: DocsLabels = DocsLabels {

--- a/src/ui/labels.rs
+++ b/src/ui/labels.rs
@@ -75,7 +75,7 @@ pub struct ReportLabels {
     pub new_topic_session_label: &'static str,
     pub topic_label: &'static str,
     pub invalid_value: &'static str,
-    pub update_label: &'static str,
+    pub update_available_label: &'static str,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -164,7 +164,7 @@ const EN_REPORT: ReportLabels = ReportLabels {
     new_topic_session_label: "New topic",
     topic_label: "Topic",
     invalid_value: "invalid value",
-    update_label: "update",
+    update_available_label: "new version v{} — opencourse update",
 };
 
 const RU_REPORT: ReportLabels = ReportLabels {
@@ -241,7 +241,7 @@ const RU_REPORT: ReportLabels = ReportLabels {
     new_topic_session_label: "Новая тема",
     topic_label: "Тема",
     invalid_value: "недопустимое значение",
-    update_label: "обновить",
+    update_available_label: "новая версия v{} — opencourse update",
 };
 
 const EN_DOCS: DocsLabels = DocsLabels {

--- a/src/ui/views/dashboard.rs
+++ b/src/ui/views/dashboard.rs
@@ -259,9 +259,16 @@ fn draw_top(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportLabels
             .constraints([Constraint::Min(0), Constraint::Length(10)])
             .split(rows[0]);
         Logo::new(Alignment::Center).render(logo_row[0], buf);
-        Paragraph::new(version_line(state))
+        Paragraph::new(version_line())
             .alignment(Alignment::Right)
             .render(logo_row[1], buf);
+
+        // The spare row under the logo doubles as the update notice slot.
+        if let Some(hint) = update_hint_line(state, labels) {
+            Paragraph::new(hint)
+                .alignment(Alignment::Center)
+                .render(rows[1], buf);
+        }
 
         let info_lines = profile_info_lines(state, labels);
         let cols = Layout::default()
@@ -283,32 +290,42 @@ fn draw_top(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportLabels
             .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
             .split(inner);
 
+        let left_col = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(0)])
+            .split(chunks[0]);
         let left_chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Length(22), Constraint::Min(0)])
-            .split(chunks[0]);
+            .split(left_col[0]);
         Logo::new(Alignment::Left).render(left_chunks[0], buf);
-        Paragraph::new(version_line(state))
+        Paragraph::new(version_line())
             .alignment(Alignment::Left)
             .render(left_chunks[1], buf);
+        // The notice spans the whole left column under the logo row.
+        if let Some(hint) = update_hint_line(state, labels) {
+            Paragraph::new(hint)
+                .alignment(Alignment::Left)
+                .render(left_col[1], buf);
+        }
         profile_info(state, labels).render(chunks[1], buf);
     }
 }
 
-fn version_line(state: &AppState) -> Line<'static> {
-    let mut spans = vec![Span::styled(
+fn version_line() -> Line<'static> {
+    Line::from(Span::styled(
         format!("v{}", env!("CARGO_PKG_VERSION")),
         Style::default().fg(Color::DarkGray),
-    )];
-    if let Some(latest) = state.update.latest_version.as_deref() {
-        spans.push(Span::styled(
-            format!("  ↑ v{latest}"),
-            Style::default()
-                .fg(colors::GREEN)
-                .add_modifier(Modifier::BOLD),
-        ));
-    }
-    Line::from(spans)
+    ))
+}
+
+/// Localized "new version available" notice shown under the current version.
+fn update_hint_line(state: &AppState, labels: ReportLabels) -> Option<Line<'static>> {
+    let latest = state.update.latest_version.as_deref()?;
+    Some(Line::from(Span::styled(
+        labels.update_available_label.replacen("{}", latest, 1),
+        Style::default().fg(colors::YELLOW),
+    )))
 }
 
 fn profile_info_lines(state: &AppState, labels: ReportLabels) -> Vec<Line<'static>> {
@@ -681,9 +698,6 @@ fn draw_hint_bar(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportL
         ("q", labels.quit),
         ("?", "help"),
     ];
-    if state.update.latest_version.is_some() {
-        hints.insert(0, ("u", labels.update_label));
-    }
     if state.dashboard.weak_visible_len() > 0 {
         hints.insert(0, ("Enter", labels.start_label));
         hints.insert(0, ("↑↓", labels.select_topic));
@@ -712,9 +726,6 @@ pub async fn handle_key(state: &mut AppState, code: KeyCode) -> Result<()> {
         KeyCode::Char('c') => state.view = View::Curriculum,
         KeyCode::Char('p') => state.view = View::Pairs,
         KeyCode::Char('s') => state.view = View::Settings,
-        KeyCode::Char('u') if state.update.latest_version.is_some() => {
-            state.view = View::UpdateAvailable;
-        }
         KeyCode::Down | KeyCode::Char('j') => state.dashboard.move_weak_selection(1),
         KeyCode::Up | KeyCode::Char('k') => state.dashboard.move_weak_selection(-1),
         KeyCode::Enter => {

--- a/src/ui/views/dashboard.rs
+++ b/src/ui/views/dashboard.rs
@@ -259,8 +259,7 @@ fn draw_top(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportLabels
             .constraints([Constraint::Min(0), Constraint::Length(10)])
             .split(rows[0]);
         Logo::new(Alignment::Center).render(logo_row[0], buf);
-        Paragraph::new(format!("v{}", env!("CARGO_PKG_VERSION")))
-            .style(Style::default().fg(Color::DarkGray))
+        Paragraph::new(version_line(state))
             .alignment(Alignment::Right)
             .render(logo_row[1], buf);
 
@@ -289,12 +288,27 @@ fn draw_top(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportLabels
             .constraints([Constraint::Length(22), Constraint::Min(0)])
             .split(chunks[0]);
         Logo::new(Alignment::Left).render(left_chunks[0], buf);
-        Paragraph::new(format!("v{}", env!("CARGO_PKG_VERSION")))
-            .style(Style::default().fg(Color::DarkGray))
+        Paragraph::new(version_line(state))
             .alignment(Alignment::Left)
             .render(left_chunks[1], buf);
         profile_info(state, labels).render(chunks[1], buf);
     }
+}
+
+fn version_line(state: &AppState) -> Line<'static> {
+    let mut spans = vec![Span::styled(
+        format!("v{}", env!("CARGO_PKG_VERSION")),
+        Style::default().fg(Color::DarkGray),
+    )];
+    if let Some(latest) = state.update.latest_version.as_deref() {
+        spans.push(Span::styled(
+            format!("  ↑ v{latest}"),
+            Style::default()
+                .fg(colors::GREEN)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    Line::from(spans)
 }
 
 fn profile_info_lines(state: &AppState, labels: ReportLabels) -> Vec<Line<'static>> {
@@ -667,6 +681,9 @@ fn draw_hint_bar(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportL
         ("q", labels.quit),
         ("?", "help"),
     ];
+    if state.update.latest_version.is_some() {
+        hints.insert(0, ("u", labels.update_label));
+    }
     if state.dashboard.weak_visible_len() > 0 {
         hints.insert(0, ("Enter", labels.start_label));
         hints.insert(0, ("↑↓", labels.select_topic));
@@ -695,6 +712,9 @@ pub async fn handle_key(state: &mut AppState, code: KeyCode) -> Result<()> {
         KeyCode::Char('c') => state.view = View::Curriculum,
         KeyCode::Char('p') => state.view = View::Pairs,
         KeyCode::Char('s') => state.view = View::Settings,
+        KeyCode::Char('u') if state.update.latest_version.is_some() => {
+            state.view = View::UpdateAvailable;
+        }
         KeyCode::Down | KeyCode::Char('j') => state.dashboard.move_weak_selection(1),
         KeyCode::Up | KeyCode::Char('k') => state.dashboard.move_weak_selection(-1),
         KeyCode::Enter => {

--- a/src/ui/views/update.rs
+++ b/src/ui/views/update.rs
@@ -38,7 +38,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, state: &AppState) {
     let latest = state.update.latest_version.as_deref().unwrap_or("unknown");
 
     let message = format!(
-        "A new version of open-course-cli is available.\n\nCurrent: v{}\nLatest: v{}\n\nInstall now?",
+        "A new version of opencourse is available.\n\nCurrent: v{}\nLatest: v{}\n\nInstall now?",
         CURRENT_VERSION, latest
     );
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -5,7 +5,9 @@ pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const GITHUB_LATEST_API: &str =
     "https://api.github.com/repos/scriptology/open-course-cli/releases/latest";
 
-const INSTALL_COMMAND: &str = "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/scriptology/open-course-cli/releases/latest/download/open-course-cli-installer.sh | sh";
+const GITHUB_LATEST_PAGE: &str = "https://github.com/scriptology/open-course-cli/releases/latest";
+
+const INSTALL_COMMAND: &str = "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/scriptology/open-course-cli/releases/latest/download/opencourse-installer.sh | sh";
 
 /// Query GitHub for the latest release tag and return it without the leading
 /// `v`. Any network or parse error is treated as "no update available" so the
@@ -16,30 +18,62 @@ pub async fn latest_release_version() -> Result<Option<String>> {
         .build()
         .map_err(|e| AppError::Config(format!("Failed to build HTTP client: {e}")))?;
 
-    let response = match client.get(GITHUB_LATEST_API).send().await {
-        Ok(r) => r,
-        Err(_) => return Ok(None),
-    };
-
-    if !response.status().is_success() {
-        return Ok(None);
+    if let Some(tag) = latest_via_api(&client).await {
+        return Ok(Some(tag));
     }
 
-    let body: serde_json::Value = match response.json().await {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
-    };
+    // Fallback: the REST API is rate-limited for unauthenticated clients, so
+    // resolve the `releases/latest` HTML redirect instead — it carries the tag
+    // in the `Location` header and is not throttled the same way.
+    Ok(latest_via_redirect().await)
+}
 
-    let tag = match body
+async fn latest_via_api(client: &reqwest::Client) -> Option<String> {
+    let response = client.get(GITHUB_LATEST_API).send().await.ok()?;
+
+    if !response.status().is_success() {
+        return None;
+    }
+
+    let body: serde_json::Value = response.json().await.ok()?;
+
+    match body
         .get("tag_name")
         .and_then(|v| v.as_str())
         .map(|s| s.trim_start_matches('v').to_string())
     {
-        Some(t) if !t.is_empty() => t,
-        _ => return Ok(None),
-    };
+        Some(t) if !t.is_empty() => Some(t),
+        _ => None,
+    }
+}
 
-    Ok(Some(tag))
+async fn latest_via_redirect() -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .ok()?;
+
+    let response = client.get(GITHUB_LATEST_PAGE).send().await.ok()?;
+
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)?
+        .to_str()
+        .ok()?;
+
+    version_from_location(location)
+}
+
+/// Extract the version from a `releases/latest` redirect target such as
+/// `https://github.com/owner/repo/releases/tag/v0.5.3`.
+pub fn version_from_location(location: &str) -> Option<String> {
+    let tag = location.rsplit("/tag/").next()?;
+    let version = tag.trim().trim_start_matches('v');
+    if version.is_empty() || location == tag {
+        return None;
+    }
+    Some(version.to_string())
 }
 
 /// Compare two dotted version strings (e.g. "0.1.0" vs "0.2.0"). The latest
@@ -109,5 +143,29 @@ mod tests {
     fn invalid_version_is_not_newer() {
         assert!(!is_newer("0.1.0", "not-a-version"));
         assert!(!is_newer("not-a-version", "0.2.0"));
+    }
+
+    #[test]
+    fn parses_version_from_redirect_location() {
+        assert_eq!(
+            version_from_location(
+                "https://github.com/scriptology/open-course-cli/releases/tag/v0.5.3"
+            ),
+            Some("0.5.3".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_version_without_v_prefix() {
+        assert_eq!(
+            version_from_location("/releases/tag/0.5.3"),
+            Some("0.5.3".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_location_without_tag() {
+        assert_eq!(version_from_location("https://github.com/"), None);
+        assert_eq!(version_from_location(""), None);
     }
 }

--- a/tests/settings_layout_test.rs
+++ b/tests/settings_layout_test.rs
@@ -237,6 +237,27 @@ async fn dashboard_header_shows_version() {
 }
 
 #[tokio::test]
+async fn dashboard_header_shows_update_hint() {
+    let mut state = setup_state().await;
+    state.view = View::Dashboard;
+    state.update.latest_version = Some("9.9.9".to_string());
+
+    for (width, height) in [(100, 24), (80, 24), (50, 30)] {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| dashboard::draw(f, f.area(), &mut state))
+            .unwrap();
+
+        let text = buffer_text(&terminal);
+        assert!(
+            text.contains("v9.9.9") && text.contains("opencourse update"),
+            "Dashboard header should show the update hint at {width}x{height}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn update_available_prompt_renders() {
     use open_course_cli::ui::views::update;
 


### PR DESCRIPTION
## Why

Users on older versions (e.g. v0.5.1 with v0.5.3 released) never saw the update prompt. The startup check swallowed every network/API error — most notably GitHub's unauthenticated API rate limit (60 req/hr per IP) — and silently skipped the prompt. It also blocked startup for up to 5s, and there was no manual way to update from the CLI.

## What

**Binary renamed to `opencourse`**
- `Cargo.toml` gains `[[bin]] name = "opencourse"`; the clap command, installer, release workflow, and README no longer mention `open-course-cli` as a command.
- `installer.sh` installs `opencourse` and removes the stale `open-course-cli` binary from previous installs.
- Releases ship the installer only as `opencourse-installer.sh` (no legacy asset name). Note: self-update from versions ≤ 0.5.3 (which hard-code the old asset name) will 404 — those users reinstall once via the README command.

**`opencourse update` command**
- New subcommand: checks the latest GitHub release, installs it via the same installer script the in-app prompt uses, or reports "Already up to date". Runs without entering the TUI.

**Reliable, non-blocking update check**
- The check now runs in a background task instead of blocking `run_app`; the result flows through the regular event loop (`LlmResult::UpdateCheck`).
- Fallback: when the REST API fails or is rate-limited, the version is parsed from the `releases/latest` redirect `Location` header, which is not throttled the same way.
- Results are logged in `OPEN_COURSE_CLI_DEBUG` mode so future failures are diagnosable.

**Persistent visibility**
- After skipping the prompt, the dashboard header keeps showing a localized orange notice under the current version — `new version vX.Y.Z — opencourse update` — in both wide and narrow layouts.
- The popup only interrupts Dashboard/Onboarding — it won't hijack an active exercise session.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all green, including a new header test covering wide and narrow layouts.
- `cargo run -- update` against the real API: `Already up to date (v0.5.3, latest release v0.5.3).`
- `opencourse --help` shows the new name and the `update` subcommand.
