### PR TITLE
fix(ui): capture the mouse only when content overflows so text stays selectable

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -224,7 +224,9 @@ pub async fn run_app(
             break;
         }
 
-        let desired_capture = state.mouse_capture && view_supports_mouse(state.view);
+        let desired_capture = state.mouse_capture
+            && view_supports_mouse(state.view)
+            && view_content_overflows(&state);
         if desired_capture != mouse_captured {
             apply_mouse_capture(desired_capture)?;
             mouse_captured = desired_capture;
@@ -353,6 +355,22 @@ fn view_supports_mouse(view: View) -> bool {
         view,
         View::Dashboard | View::Report | View::Docs | View::Curriculum
     )
+}
+
+/// Whether the current view's content is taller than its viewport. Mouse
+/// capture is enabled only then: while the terminal owns the mouse, native
+/// drag-selection is impossible, so capturing on content that fits the screen
+/// would block text selection for no benefit. The overflow flags are computed
+/// during `draw`, which runs before this check in the event loop.
+fn view_content_overflows(state: &AppState) -> bool {
+    match state.view {
+        View::Dashboard => state.dashboard.max_scroll > 0,
+        View::Report => state.report.max_scroll_offset > 0,
+        View::Docs if state.docs.viewing_topic.is_some() => state.docs.max_scroll_offset > 0,
+        View::Docs => state.docs.list_overflows,
+        View::Curriculum => state.curriculum.list_overflows,
+        _ => false,
+    }
 }
 
 /// Whether the 100ms tick needs to trigger a redraw: only while a view is
@@ -547,5 +565,52 @@ fn draw(frame: &mut ratatui::Frame, state: &mut AppState) {
 
     if let Some(toast) = &state.toast {
         frame.render_widget(ToastWidget::new(toast), area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_state() -> AppState {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = Database::connect(&dir.path().join("db")).await.unwrap();
+        let (tx, _rx) = mpsc::channel(1);
+        AppState::new(
+            dir.path().to_path_buf(),
+            Arc::new(db),
+            None,
+            Arc::new(AtomicBool::new(false)),
+            tx,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn capture_only_when_content_overflows() {
+        let mut state = test_state().await;
+
+        state.view = View::Dashboard;
+        assert!(!view_content_overflows(&state));
+        state.dashboard.max_scroll = 3;
+        assert!(view_content_overflows(&state));
+
+        state.view = View::Report;
+        assert!(!view_content_overflows(&state));
+        state.report.max_scroll_offset = 5;
+        assert!(view_content_overflows(&state));
+
+        state.view = View::Docs;
+        assert!(!view_content_overflows(&state));
+        state.docs.list_overflows = true;
+        assert!(view_content_overflows(&state));
+
+        state.view = View::Curriculum;
+        assert!(!view_content_overflows(&state));
+        state.curriculum.list_overflows = true;
+        assert!(view_content_overflows(&state));
+
+        state.view = View::Session;
+        assert!(!view_content_overflows(&state));
     }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -27,16 +27,17 @@ fn group(title: &'static str, entries: Vec<HelpEntry>) -> HelpGroup {
     HelpGroup { title, entries }
 }
 
-fn mouse_entries(state: &AppState) -> Vec<HelpEntry> {
+fn mouse_entries(state: &AppState, labels: ReportLabels) -> Vec<HelpEntry> {
     if state.mouse_capture {
         vec![
-            entry("wheel", "scroll"),
-            entry("m", "switch to text selection"),
+            entry("wheel", labels.wheel_scroll),
+            entry("m", labels.select_text),
+            entry("Shift+drag", labels.select_text),
         ]
     } else {
         vec![
-            entry("mouse", "select text"),
-            entry("m", "switch to wheel scroll"),
+            entry("mouse", labels.select_text),
+            entry("m", labels.wheel_mode),
         ]
     }
 }
@@ -46,10 +47,10 @@ pub fn groups_for(state: &AppState) -> Vec<HelpGroup> {
     match state.view {
         View::Dashboard => dashboard_groups(state, labels),
         View::Curriculum => curriculum_groups(state, labels),
-        View::Docs => docs_groups(state),
+        View::Docs => docs_groups(state, labels),
         View::Session => session_groups(state, labels),
         View::Pairs => pairs_groups(labels),
-        View::Report => report_groups(state),
+        View::Report => report_groups(state, labels),
         View::ModelCheck => model_check_groups(state),
         View::Settings => settings_groups(state),
         View::Onboarding => onboarding_groups(state),
@@ -64,6 +65,9 @@ fn dashboard_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
     if state.dashboard.weak_visible_len() > 0 {
         nav.push(entry("↑↓", labels.select_topic));
         actions.push(entry("Enter", labels.start_label));
+    }
+    if state.dashboard.max_scroll > 0 {
+        nav.extend(mouse_entries(state, labels));
     }
     nav.push(entry("Esc", "clear topic selection"));
     actions.push(entry("n", labels.start_next_label));
@@ -101,8 +105,12 @@ fn curriculum_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
         CurriculumSortBy::Progression => labels.sort_progression,
         CurriculumSortBy::Score => labels.sort_score,
     };
+    let mut nav = vec![entry("↑↓", labels.navigate)];
+    if state.curriculum.list_overflows {
+        nav.extend(mouse_entries(state, labels));
+    }
     vec![
-        group("Navigation", vec![entry("↑↓ / wheel", labels.navigate)]),
+        group("Navigation", nav),
         group(
             "Actions",
             vec![
@@ -117,11 +125,13 @@ fn curriculum_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
     ]
 }
 
-fn docs_groups(state: &AppState) -> Vec<HelpGroup> {
+fn docs_groups(state: &AppState, report_labels: ReportLabels) -> Vec<HelpGroup> {
     let labels = get_docs_labels(native_language_code(state.config.as_ref()));
     if state.docs.viewing_topic.is_some() {
-        let mut nav = vec![entry("↑/↓", "scroll")];
-        nav.extend(mouse_entries(state));
+        let mut nav = vec![entry("↑/↓", report_labels.wheel_scroll)];
+        if state.docs.max_scroll_offset > 0 {
+            nav.extend(mouse_entries(state, report_labels));
+        }
         return vec![
             group("Navigation", nav),
             group(
@@ -131,11 +141,15 @@ fn docs_groups(state: &AppState) -> Vec<HelpGroup> {
             group("Exit", vec![entry("Esc", "back to list")]),
         ];
     }
+    let mut nav = vec![
+        entry("↑/↓", report_labels.navigate),
+        entry("s", labels.sort),
+    ];
+    if state.docs.list_overflows {
+        nav.extend(mouse_entries(state, report_labels));
+    }
     vec![
-        group(
-            "Navigation",
-            vec![entry("↑/↓ / wheel", "navigate"), entry("s", labels.sort)],
-        ),
+        group("Navigation", nav),
         group(
             "Actions",
             vec![entry("Enter", "view"), entry("p", labels.practice)],
@@ -178,9 +192,11 @@ fn pairs_groups(labels: ReportLabels) -> Vec<HelpGroup> {
     ]
 }
 
-fn report_groups(state: &AppState) -> Vec<HelpGroup> {
-    let mut nav = vec![entry("↑/↓", "scroll")];
-    nav.extend(mouse_entries(state));
+fn report_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
+    let mut nav = vec![entry("↑/↓", labels.wheel_scroll)];
+    if state.report.max_scroll_offset > 0 {
+        nav.extend(mouse_entries(state, labels));
+    }
     vec![
         group("Navigation", nav),
         group(

--- a/src/ui/labels.rs
+++ b/src/ui/labels.rs
@@ -76,6 +76,9 @@ pub struct ReportLabels {
     pub topic_label: &'static str,
     pub invalid_value: &'static str,
     pub update_available_label: &'static str,
+    pub wheel_scroll: &'static str,
+    pub select_text: &'static str,
+    pub wheel_mode: &'static str,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -165,6 +168,9 @@ const EN_REPORT: ReportLabels = ReportLabels {
     topic_label: "Topic",
     invalid_value: "invalid value",
     update_available_label: "new version v{} — opencourse update",
+    wheel_scroll: "scroll",
+    select_text: "select text",
+    wheel_mode: "wheel scroll",
 };
 
 const RU_REPORT: ReportLabels = ReportLabels {
@@ -242,6 +248,9 @@ const RU_REPORT: ReportLabels = ReportLabels {
     topic_label: "Тема",
     invalid_value: "недопустимое значение",
     update_available_label: "новая версия v{} — opencourse update",
+    wheel_scroll: "скролл",
+    select_text: "выделение текста",
+    wheel_mode: "скролл колесом",
 };
 
 const EN_DOCS: DocsLabels = DocsLabels {

--- a/src/ui/views/curriculum.rs
+++ b/src/ui/views/curriculum.rs
@@ -16,7 +16,7 @@ use crate::ui::colors;
 use crate::ui::labels::{get_report_labels, native_language_code};
 use crate::ui::views::docs;
 use crate::ui::views::utils::{select_next_wrapping, select_previous_wrapping};
-use crate::ui::widgets::{build_footer, draw_confirmation};
+use crate::ui::widgets::{build_footer, draw_confirmation, mouse_footer_entries};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum CurriculumSortBy {
@@ -43,6 +43,9 @@ pub struct CurriculumState {
     pub pending_reset: bool,
     pub pending_delete: Option<Topic>,
     pub sort_by: CurriculumSortBy,
+    /// Whether the topic list is taller than its viewport (set during draw);
+    /// drives adaptive mouse capture.
+    pub list_overflows: bool,
 }
 
 impl CurriculumState {
@@ -255,6 +258,9 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
             .add_modifier(Modifier::BOLD),
     );
 
+    state.curriculum.list_overflows = !state.curriculum.topics.is_empty()
+        && state.curriculum.topics.len() > chunks[1].height as usize;
+
     frame.render_stateful_widget(list, chunks[1], &mut state.curriculum.list_state);
 
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
@@ -270,16 +276,18 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         ])
     } else {
         let sort_entry = format!("{} ({})", labels.sort, sort_label);
-        build_footer(&[
-            ("↑↓/wheel", labels.navigate),
-            ("Enter", labels.docs),
-            ("s", sort_entry.as_str()),
-            ("a", labels.add_topics_label),
-            ("x", labels.delete_label),
-            ("r", labels.reset_label),
-            ("Esc", labels.back),
-            ("?", "help"),
-        ])
+        let mut entries: Vec<(&str, &str)> = vec![("↑↓", labels.navigate)];
+        if state.curriculum.list_overflows {
+            entries.extend(mouse_footer_entries(state.mouse_capture, &labels));
+        }
+        entries.push(("Enter", labels.docs));
+        entries.push(("s", sort_entry.as_str()));
+        entries.push(("a", labels.add_topics_label));
+        entries.push(("x", labels.delete_label));
+        entries.push(("r", labels.reset_label));
+        entries.push(("Esc", labels.back));
+        entries.push(("?", "help"));
+        build_footer(&entries)
     };
     frame.render_widget(
         Paragraph::new(help).style(Style::default().fg(Color::DarkGray)),

--- a/src/ui/views/dashboard.rs
+++ b/src/ui/views/dashboard.rs
@@ -20,7 +20,7 @@ use crate::ui::colors;
 use crate::ui::labels::{ReportLabels, get_report_labels, native_language_code};
 use crate::ui::views::{docs, session};
 use crate::ui::widgets::activity_calendar;
-use crate::ui::widgets::{HintBar, Logo, StackedProgressBar};
+use crate::ui::widgets::{HintBar, Logo, StackedProgressBar, mouse_footer_entries};
 
 #[derive(Debug, Clone)]
 pub struct DashboardState {
@@ -689,7 +689,11 @@ fn draw_weak_topics(buf: &mut Buffer, area: Rect, state: &AppState, labels: Repo
 }
 
 fn draw_hint_bar(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportLabels) {
-    let mut hints: Vec<(&str, &str)> = vec![
+    let mut hints: Vec<(&str, &str)> = Vec::new();
+    if state.dashboard.max_scroll > 0 {
+        hints.extend(mouse_footer_entries(state.mouse_capture, &labels));
+    }
+    hints.extend([
         ("n", labels.start_next_label),
         ("d", labels.docs),
         ("c", labels.curriculum),
@@ -697,7 +701,7 @@ fn draw_hint_bar(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportL
         ("s", labels.settings),
         ("q", labels.quit),
         ("?", "help"),
-    ];
+    ]);
     if state.dashboard.weak_visible_len() > 0 {
         hints.insert(0, ("Enter", labels.start_label));
         hints.insert(0, ("↑↓", labels.select_topic));

--- a/src/ui/views/docs.rs
+++ b/src/ui/views/docs.rs
@@ -22,9 +22,9 @@ use crate::llm::factory::create_llm_model;
 use crate::llm::pipeline::generate_topic_review;
 use crate::llm::prompts::build_topic_review_prompt;
 use crate::ui::colors;
-use crate::ui::labels::{get_docs_labels, native_language_code};
+use crate::ui::labels::{get_docs_labels, get_report_labels, native_language_code};
 use crate::ui::views::utils::{select_next_wrapping, select_previous_wrapping};
-use crate::ui::widgets::{OpenCourseStyleSheet, build_footer};
+use crate::ui::widgets::{OpenCourseStyleSheet, build_footer, mouse_footer_entries};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SortBy {
@@ -60,6 +60,9 @@ pub struct DocsState {
     pub saved: bool,
     pub scroll_offset: u16,
     pub max_scroll_offset: u16,
+    /// Whether the topic list is taller than its viewport (set during draw);
+    /// drives adaptive mouse capture.
+    pub list_overflows: bool,
     /// Where to go on Esc from the topic view when docs was opened directly
     /// (e.g. from the curriculum list). `None` means the usual docs list flow.
     pub return_to: Option<crate::app::View>,
@@ -84,6 +87,7 @@ impl DocsState {
         self.saved = false;
         self.scroll_offset = 0;
         self.max_scroll_offset = 0;
+        self.list_overflows = false;
         self.return_to = None;
     }
 }
@@ -200,11 +204,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
 
         frame.render_widget(body, chunks[1]);
 
-        let mouse_entries: [(&str, &str); 2] = if state.mouse_capture {
-            [("wheel", "scroll"), ("m", "select text")]
-        } else {
-            [("mouse", "select text"), ("m", "wheel scroll")]
-        };
+        let report_labels = get_report_labels(native_language_code(state.config.as_ref()));
         let help = if state.docs.content.is_empty() {
             build_footer(&[
                 ("Esc", "back to list"),
@@ -213,8 +213,10 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                 ("?", "help"),
             ])
         } else {
-            let mut entries = vec![("↑/↓", "scroll")];
-            entries.extend(mouse_entries);
+            let mut entries = vec![("↑/↓", report_labels.wheel_scroll)];
+            if state.docs.max_scroll_offset > 0 {
+                entries.extend(mouse_footer_entries(state.mouse_capture, &report_labels));
+            }
             entries.push(("Esc", "back to list"));
             entries.push(("e", labels.regenerate));
             entries.push(("p", labels.practice));
@@ -269,19 +271,24 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                     .fg(colors::GREEN)
                     .add_modifier(Modifier::BOLD),
             );
+            state.docs.list_overflows = state.docs.topics.len() > chunks[1].height as usize;
             frame.render_stateful_widget(list, chunks[1], &mut state.docs.list_state);
+        } else {
+            state.docs.list_overflows = false;
         }
 
+        let report_labels = get_report_labels(native_language_code(state.config.as_ref()));
+        let mut entries: Vec<(&str, &str)> = vec![("↑/↓", "navigate")];
+        if state.docs.list_overflows {
+            entries.extend(mouse_footer_entries(state.mouse_capture, &report_labels));
+        }
+        entries.push(("s", "sort"));
+        entries.push(("Enter", "view"));
+        entries.push(("p", labels.practice));
+        entries.push(("Esc", "back"));
+        entries.push(("?", "help"));
         frame.render_widget(
-            Paragraph::new(build_footer(&[
-                ("↑/↓/wheel", "navigate"),
-                ("s", "sort"),
-                ("Enter", "view"),
-                ("p", labels.practice),
-                ("Esc", "back"),
-                ("?", "help"),
-            ]))
-            .style(Style::default().fg(Color::DarkGray)),
+            Paragraph::new(build_footer(&entries)).style(Style::default().fg(Color::DarkGray)),
             chunks[2],
         );
     }

--- a/src/ui/views/report.rs
+++ b/src/ui/views/report.rs
@@ -12,7 +12,7 @@ use crate::error::Result;
 use crate::ui::colors;
 use crate::ui::labels::{ReportLabels, get_report_labels, native_language_code};
 use crate::ui::views::{docs, session};
-use crate::ui::widgets::build_footer;
+use crate::ui::widgets::{build_footer, mouse_footer_entries};
 
 #[derive(Debug, Clone)]
 pub struct ReportState {
@@ -98,13 +98,10 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
 
     frame.render_widget(paragraph.scroll((state.report.scroll_offset, 0)), chunks[0]);
 
-    let mouse_entries: [(&str, &str); 2] = if state.mouse_capture {
-        [("wheel", "scroll"), ("m", "native select")]
-    } else {
-        [("mouse", "select text"), ("m", "wheel scroll")]
-    };
-    let mut entries = vec![("↑/↓", "scroll")];
-    entries.extend(mouse_entries);
+    let mut entries = vec![("↑/↓", labels.wheel_scroll)];
+    if state.report.max_scroll_offset > 0 {
+        entries.extend(mouse_footer_entries(state.mouse_capture, &labels));
+    }
     entries.push(("n", "new topic"));
     entries.push(("r", "repeat"));
     entries.push(("d", "docs"));

--- a/src/ui/widgets/footer.rs
+++ b/src/ui/widgets/footer.rs
@@ -1,7 +1,51 @@
+use crate::ui::labels::ReportLabels;
+
 pub fn build_footer(entries: &[(&str, &str)]) -> String {
     entries
         .iter()
         .map(|(key, action)| format!("{key}: {action}"))
         .collect::<Vec<_>>()
         .join(" | ")
+}
+
+/// Footer entries describing the current mouse mode on scrollable views.
+/// While the app captures the mouse the wheel scrolls and `m` switches to
+/// native text selection; otherwise the mouse selects text and `m`
+/// re-enables wheel scrolling.
+pub fn mouse_footer_entries(
+    capture_on: bool,
+    labels: &ReportLabels,
+) -> [(&'static str, &'static str); 2] {
+    if capture_on {
+        [("wheel", labels.wheel_scroll), ("m", labels.select_text)]
+    } else {
+        [("mouse", labels.select_text), ("m", labels.wheel_mode)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::labels::get_report_labels;
+
+    #[test]
+    fn capture_on_shows_wheel_and_select_toggle() {
+        let labels = get_report_labels("en");
+        let entries = mouse_footer_entries(true, &labels);
+        assert_eq!(entries, [("wheel", "scroll"), ("m", "select text")]);
+    }
+
+    #[test]
+    fn capture_off_shows_select_and_wheel_toggle() {
+        let labels = get_report_labels("en");
+        let entries = mouse_footer_entries(false, &labels);
+        assert_eq!(entries, [("mouse", "select text"), ("m", "wheel scroll")]);
+    }
+
+    #[test]
+    fn entries_are_localized() {
+        let labels = get_report_labels("ru");
+        let entries = mouse_footer_entries(true, &labels);
+        assert_eq!(entries[1], ("m", "выделение текста"));
+    }
 }

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -18,7 +18,7 @@ pub mod logo;
 pub use cards::Card;
 pub use confirmation::draw_confirmation;
 pub use error_box::ErrorBox;
-pub use footer::build_footer;
+pub use footer::{build_footer, mouse_footer_entries};
 pub use help_overlay::HelpOverlay;
 pub use hint_bar::HintBar;
 pub use logo::Logo;


### PR DESCRIPTION
## Problem

Text selection was blocked on every mouse-enabled screen (dashboard, analysis report, docs, curriculum). Root cause: crossterm's `EnableMouseCapture` redirects **all** mouse events to the app, so the terminal's native drag-selection is disabled. Capture was switched on permanently for those views — even when the content fit the screen and there was nothing to scroll. Crossterm cannot capture wheel events only, so the fix is to capture adaptively.

## Changes

- **Adaptive capture** (`src/app/mod.rs`): mouse capture is now enabled only when the current view's content is taller than its viewport. New `view_content_overflows` check uses the `max_scroll` / `max_scroll_offset` values already computed during `draw`, plus new `list_overflows` flags for the docs and curriculum topic lists.
  - Content fits the screen → no capture → text selection works natively, right away.
  - Content overflows → wheel scrolls immediately; press `m` to release the mouse and select text, `m` again to resume scrolling. (Shift+drag also works in most terminals even while captured — now documented in the help overlay.)
- **Localized footer hints**: new `mouse_footer_entries` helper (`src/ui/widgets/footer.rs`) with EN/RU labels shows the current mode and the `m` toggle on the report, docs (topic and list), curriculum and dashboard views — only while the content overflows.
- **Help overlay**: mouse entries localized via `ReportLabels`; added the `Shift+drag` native-selection hint.

## Tests

- Unit tests for `mouse_footer_entries` (EN/RU, both modes) and `view_content_overflows` (all mouse views).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` — all green.

## Manual check

Long analysis report: wheel scrolls, `m` releases the mouse and plain drag-selection works. Short screens: selection works immediately, no mouse hint shown.