### PR TITLE
fix: graduate learning items by error association instead of text occurrence

### DIFF
--- a/src/core/session/apply.rs
+++ b/src/core/session/apply.rs
@@ -215,13 +215,19 @@ pub async fn apply_analysis_to_db(
     let now = Utc::now().to_rfc3339();
     for id in &practiced_item_ids {
         if let Some(item) = learning_items.get_mut(id) {
-            // Items that never occurred in the session keep their score and
-            // practice stats untouched.
-            if let Some(exercise_score) = learning_item_exercise_score(item, analysis, session) {
-                item.score = ema_update(item.score, exercise_score);
-                item.last_practiced = Some(now.clone());
-                item.practice_count += 1;
-            }
+            // Every practiced item gets credit: 0 when a session error is
+            // associated with it, 100 otherwise. Practiced means the item was
+            // forced into the exercise prompt or matched by a reported error,
+            // so no occurrence detection in the session text is needed — the
+            // item name's language often differs from the exercise texts.
+            let session_score = if item_has_error(item, analysis) {
+                0.0
+            } else {
+                100.0
+            };
+            item.score = ema_update(item.score, session_score);
+            item.last_practiced = Some(now.clone());
+            item.practice_count += 1;
         }
     }
 
@@ -270,97 +276,43 @@ fn find_duplicate_topic(known_topics: &[(String, String)], topic: &Topic) -> Opt
     is_duplicate_name(&names, &topic.name).map(|pos| known_topics[pos].0.clone())
 }
 
-/// Scores how the session practiced a learning item: 0 when an error
-/// mentions it, 100 when it occurred without errors, and None when the item
-/// did not occur in the session at all (the caller then leaves its score and
-/// practice stats untouched).
-///
-/// Occurrence is matched on whole normalized significant words of the item
-/// name (falling back to the description, then to the legacy full-name
-/// substring match when neither yields any words) against the exercise
-/// target sentence and the expected/student translations.
-fn learning_item_exercise_score(
-    item: &LearningItem,
-    analysis: &AnalysisResult,
-    session: &MentorSession,
-) -> Option<f64> {
+/// Whether any session error is associated with the learning item: an
+/// error's new topic is a fuzzy name duplicate of the item, or the error's
+/// pattern/explanation mentions a significant word of the item name
+/// (falling back to the description, then to the legacy full-name substring
+/// match when neither yields any words).
+fn item_has_error(item: &LearningItem, analysis: &AnalysisResult) -> bool {
     let mut key_words = significant_words(&item.name);
     if key_words.is_empty() {
         key_words = significant_words(&item.description);
     }
-    if key_words.is_empty() {
-        // No usable words at all: keep the legacy full-name matching.
-        return Some(legacy_item_exercise_score(item, analysis, session));
-    }
 
-    let mut encountered = false;
-    let mut mentioned_in_error = false;
-    for (i, exercise) in session.exercises.iter().enumerate() {
-        let sentence_number = (i + 1) as i32;
-        let sentence = analysis
-            .sentences
-            .iter()
-            .find(|s| s.sentence_number == sentence_number);
-
-        if text_contains_any_word(&exercise.target_sentence, &key_words) {
-            encountered = true;
-        }
-        if let Some(s) = sentence {
-            if text_contains_any_word(&s.expected_translation, &key_words)
-                || text_contains_any_word(&s.student_translation, &key_words)
+    for sentence in &analysis.sentences {
+        for error in &sentence.errors {
+            if key_words.is_empty() {
+                // No usable words at all: legacy full-name matching.
+                let name = item.name.to_lowercase();
+                if error.pattern.to_lowercase().contains(&name)
+                    || error.explanation.to_lowercase().contains(&name)
+                    || error
+                        .new_topics
+                        .iter()
+                        .any(|nt| nt.name.to_lowercase().contains(&name))
+                {
+                    return true;
+                }
+                continue;
+            }
+            if text_contains_any_word(&error.pattern, &key_words)
+                || text_contains_any_word(&error.explanation, &key_words)
+                || error.new_topics.iter().any(|nt| {
+                    text_contains_any_word(&nt.name, &key_words)
+                        || is_duplicate_name(std::slice::from_ref(&item.name), &nt.name).is_some()
+                })
             {
-                encountered = true;
-            }
-            for error in &s.errors {
-                if text_contains_any_word(&error.pattern, &key_words)
-                    || text_contains_any_word(&error.explanation, &key_words)
-                    || error
-                        .new_topics
-                        .iter()
-                        .any(|nt| text_contains_any_word(&nt.name, &key_words))
-                {
-                    mentioned_in_error = true;
-                }
+                return true;
             }
         }
     }
-
-    if !encountered {
-        return None;
-    }
-    Some(if mentioned_in_error { 0.0 } else { 100.0 })
-}
-
-/// Pre-word-matching behaviour: the full lowercased item name must appear
-/// in the error text. Used only when neither the item's name nor its
-/// description yields any significant words.
-fn legacy_item_exercise_score(
-    item: &LearningItem,
-    analysis: &AnalysisResult,
-    session: &MentorSession,
-) -> f64 {
-    let item_name_lower = item.name.to_lowercase();
-    for (i, _exercise) in session.exercises.iter().enumerate() {
-        let sentence_number = (i + 1) as i32;
-        let sentence = analysis
-            .sentences
-            .iter()
-            .find(|s| s.sentence_number == sentence_number);
-        if let Some(s) = sentence {
-            for error in &s.errors {
-                let pattern_lower = error.pattern.to_lowercase();
-                let explanation_lower = error.explanation.to_lowercase();
-                if pattern_lower.contains(&item_name_lower)
-                    || explanation_lower.contains(&item_name_lower)
-                    || error
-                        .new_topics
-                        .iter()
-                        .any(|nt| nt.name.to_lowercase().contains(&item_name_lower))
-                {
-                    return 0.0;
-                }
-            }
-        }
-    }
-    100.0
+    false
 }

--- a/src/core/session/scoring.rs
+++ b/src/core/session/scoring.rs
@@ -6,7 +6,7 @@
 //!
 //! - Topic mastery (session-level): `adaptive_alpha` with alpha in 0.1..=0.45
 //!   depending on current mastery, fed by `topic_exercise_scores`.
-//! - Learning items (item-level): `ema_update` with a fixed alpha of 0.12.
+//! - Learning items (item-level): `ema_update` with a fixed alpha of 0.34.
 //!
 //! - "Acceptable" sentences: per-exercise penalties of 10/5/2/0.5 inside
 //!   `exercise_score_for_sentence`, keeping the score in the 70..=90 band.
@@ -202,11 +202,12 @@ pub(super) fn adaptive_alpha(mastery: f64) -> f64 {
     TOPIC_SCORE_ALPHA_BASE + TOPIC_SCORE_ALPHA_RANGE * normalized.clamp(0.0, 1.0)
 }
 
-/// Learning-item EMA (item-level): fixed alpha of 0.12. Parallel to the
-/// topic-mastery EMA (`adaptive_alpha`), but on an independent scale — do
-/// not unify.
+/// Learning-item EMA (item-level): fixed alpha of 0.34, so a clean session
+/// moves a weak item from 0 to 34 and a second one past the mastery
+/// threshold of 50. Parallel to the topic-mastery EMA (`adaptive_alpha`),
+/// but on an independent scale — do not unify.
 pub(super) fn ema_update(base: f64, session_score: f64) -> f64 {
-    let alpha = 0.12;
+    let alpha = 0.34;
     let raw = base * (1.0 - alpha) + session_score * alpha;
     raw.round().clamp(0.0, 100.0)
 }

--- a/src/llm/prompts.rs
+++ b/src/llm/prompts.rs
@@ -79,7 +79,7 @@ pub fn build_exercise_prompt(
             .collect::<Vec<_>>()
             .join("\n");
         format!(
-            "\nThe following learning items need extra practice. Try to naturally include ONE of them in each exercise, without distorting the target topics:\n{items}\n"
+            "\nThe following learning items need extra practice. Naturally include EACH of them in at least one exercise, distributing them across different exercises, without distorting the target topics:\n{items}\n"
         )
     };
 

--- a/tests/session_test.rs
+++ b/tests/session_test.rs
@@ -9,7 +9,7 @@ use open_course_cli::core::session::{
 };
 use open_course_cli::db::Database;
 use open_course_cli::db::curriculum::{Curriculum, Difficulty, Topic};
-use open_course_cli::db::learning_items::LearningItem;
+use open_course_cli::db::learning_items::{LearningItem, LearningItemsTable};
 use open_course_cli::db::progress::{ProgressData, ProgressTopic};
 
 fn make_topic(id: &str, difficulty: Difficulty) -> Topic {
@@ -654,27 +654,23 @@ fn exercise_analysis(
 }
 
 #[tokio::test]
-async fn learning_item_not_in_session_keeps_stats_untouched() {
+async fn learning_item_not_practiced_keeps_stats_untouched() {
     let dir = TempDir::new().unwrap();
     let db = Database::connect(&dir.path().join("db")).await.unwrap();
 
     let item = make_learning_item("es-pequeno-pequena", "pequeño/pequeña");
     db.learning_items().upsert(&item).await.unwrap();
 
-    // The exercise never mentions the item's words.
+    // The item exists but is not forced this session and no new learning
+    // item dedupes into it.
     let (session, analysis) = exercise_analysis("Hello", "Привет", "Привет", vec![]);
-    apply_analysis_to_db(
-        &analysis,
-        &session,
-        &["es-pequeno-pequena".to_string()],
-        &db,
-    )
-    .await
-    .unwrap();
+    apply_analysis_to_db(&analysis, &session, &[], &db)
+        .await
+        .unwrap();
 
     let updated = db.learning_items().read_all().await.unwrap();
     assert_eq!(updated.len(), 1);
-    // No occurrence -> no practice credit at all.
+    // Not practiced -> no practice credit at all.
     assert_eq!(updated[0].score, 0.0);
     assert_eq!(updated[0].practice_count, 0);
     assert!(updated[0].last_practiced.is_none());
@@ -701,8 +697,8 @@ async fn learning_item_in_session_without_errors_scores_100() {
 
     let updated = db.learning_items().read_all().await.unwrap();
     assert_eq!(updated.len(), 1);
-    // EMA from 0 towards 100 with alpha 0.12 -> 12.
-    assert_eq!(updated[0].score, 12.0);
+    // EMA from 0 towards 100 with alpha 0.34 -> 34.
+    assert_eq!(updated[0].score, 34.0);
     assert_eq!(updated[0].practice_count, 1);
     assert!(updated[0].last_practiced.is_some());
 }
@@ -769,6 +765,67 @@ async fn learning_item_matches_by_significant_words_not_full_name() {
     assert_eq!(updated.len(), 1);
     assert_eq!(updated[0].score, 0.0);
     assert_eq!(updated[0].practice_count, 1);
+}
+
+#[tokio::test]
+async fn forced_item_with_foreign_name_still_gets_credit() {
+    // Regression test: an item whose name never literally appears in the
+    // exercise texts (e.g. an English word in a ru->es pair) used to be
+    // undetectable, so its score never grew and it was forced into every
+    // session forever. A forced item without associated errors must score
+    // 100 regardless of text occurrence.
+    let dir = TempDir::new().unwrap();
+    let db = Database::connect(&dir.path().join("db")).await.unwrap();
+
+    let item = make_learning_item("es-colleague", "colleague");
+    db.learning_items().upsert(&item).await.unwrap();
+
+    let (session, analysis) = exercise_analysis(
+        "Мой коллега купил стол",
+        "Mi colega compró una mesa",
+        "Mi colega compró una mesa",
+        vec![],
+    );
+    apply_analysis_to_db(&analysis, &session, &["es-colleague".to_string()], &db)
+        .await
+        .unwrap();
+
+    let updated = db.learning_items().read_all().await.unwrap();
+    assert_eq!(updated.len(), 1);
+    assert_eq!(updated[0].score, 34.0);
+    assert_eq!(updated[0].practice_count, 1);
+    assert!(updated[0].last_practiced.is_some());
+}
+
+#[tokio::test]
+async fn clean_sessions_graduate_item_out_of_weakest() {
+    let dir = TempDir::new().unwrap();
+    let db = Database::connect(&dir.path().join("db")).await.unwrap();
+
+    let item = make_learning_item("es-colleague", "colleague");
+    db.learning_items().upsert(&item).await.unwrap();
+
+    // Two clean sessions: 0 -> 34 -> 56, crossing the mastery threshold (50).
+    for _ in 0..2 {
+        let (session, analysis) = exercise_analysis(
+            "Мой коллега купил стол",
+            "Mi colega compró una mesa",
+            "Mi colega compró una mesa",
+            vec![],
+        );
+        apply_analysis_to_db(&analysis, &session, &["es-colleague".to_string()], &db)
+            .await
+            .unwrap();
+    }
+
+    let updated = db.learning_items().read_all().await.unwrap();
+    assert_eq!(updated.len(), 1);
+    assert_eq!(updated[0].score, 56.0);
+    assert_eq!(updated[0].practice_count, 2);
+
+    // The graduated item is no longer offered for forced practice.
+    let weak = LearningItemsTable::weakest(&updated, 3);
+    assert!(weak.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

Learning items (word-level review entries, e.g. a stored "colleague") were forced into the exercise prompt every session but never graduated:

- Scoring depended on detecting the item name's words literally in the exercise texts (`learning_item_exercise_score`). The item name's language often differs from the exercise texts (e.g. an English word in a ru→es pair), so detection never fired, the score stayed 0, and the item remained the weakest forever — appearing in session after session even with no further mistakes.
- Even when detection worked, the EMA alpha of 0.12 required ~6 clean sessions to cross the mastery threshold of 50.

## Fix

- `src/core/session/apply.rs`: replaced occurrence-based scoring with error-association scoring. A practiced item (forced into the prompt or matched by a reported error) now always gets credit: **0** when a session error is associated with it (error pattern/explanation mentions a significant word, or an error's newTopic is a fuzzy name duplicate), **100** otherwise. No more dependence on literal text occurrence.
- `src/core/session/scoring.rs`: learning-item EMA alpha 0.12 → **0.34**, so a weak item graduates after two clean sessions (0 → 34 → 56 ≥ 50); a new error drops it back and the cycle repeats.
- `src/llm/prompts.rs`: the generator prompt now asks to include EACH learning item in at least one exercise, distributed across exercises, instead of ONE item per exercise — so a single word no longer dominates every sentence.

Already-stuck items self-heal: two clean sessions push them past the mastery threshold and they stop being forced. No DB migration needed.

## Tests

- New regression test: forced item whose name never appears in exercise texts still gets credit.
- New test: two clean sessions graduate an item out of `weakest()`.
- Updated EMA expectations (12 → 34) and the not-practiced-untouched test.
- Full suite green; `cargo fmt` / `clippy -D warnings` clean.