### PR TITLE
feat(ui): localize all UI texts

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,6 +21,7 @@ use crate::error::{AppError, Result};
 use crate::llm::diagnostics::CheckResult;
 use crate::llm::model_listing::ModelInfo;
 use crate::ui::help;
+use crate::ui::labels::{get_report_labels, get_update_labels, native_language_code};
 use crate::ui::views::utils::{select_next_wrapping, select_previous_wrapping};
 use crate::ui::views::{
     CurriculumState, DashboardState, DocsState, ModelCheckState, OnboardingState, PairsState,
@@ -449,18 +450,19 @@ async fn run_installer_and_exit(state: &mut AppState) -> Result<()> {
     use ratatui::crossterm::terminal::{LeaveAlternateScreen, disable_raw_mode};
     use std::io::{Write, stdout};
 
+    let update_labels = get_update_labels(native_language_code(state.config.as_ref()));
     let latest = state
         .update
         .latest_version
         .clone()
-        .unwrap_or_else(|| "latest".to_string());
+        .unwrap_or_else(|| update_labels.latest_placeholder.to_string());
 
     // Restore the normal terminal before handing control to the installer.
     disable_raw_mode()?;
     execute!(stdout(), LeaveAlternateScreen)?;
     stdout().flush()?;
 
-    println!("Installing opencourse {latest}...");
+    println!("{}", update_labels.installing.replace("{latest}", &latest));
 
     let status = std::process::Command::new("sh")
         .arg("-c")
@@ -469,7 +471,7 @@ async fn run_installer_and_exit(state: &mut AppState) -> Result<()> {
 
     if !status.success() {
         ratatui::crossterm::terminal::enable_raw_mode()?;
-        state.error = Some("Installer failed. Press any key to continue.".to_string());
+        state.error = Some(update_labels.installer_failed.to_string());
         return Ok(());
     }
 
@@ -539,9 +541,13 @@ pub async fn switch_pair(state: &mut AppState, pair_id: &str) -> Result<()> {
 
 fn draw(frame: &mut ratatui::Frame, state: &mut AppState) {
     let area = frame.area();
+    let labels = get_report_labels(native_language_code(state.config.as_ref()));
 
     if let Some(err) = &state.error {
-        frame.render_widget(ErrorBox::new(err), area);
+        frame.render_widget(
+            ErrorBox::new(err, labels.error, labels.error_footer_hint),
+            area,
+        );
         return;
     }
 
@@ -560,11 +566,18 @@ fn draw(frame: &mut ratatui::Frame, state: &mut AppState) {
     }
 
     if state.help_open {
-        frame.render_widget(HelpOverlay::new(&help::groups_for(state)), area);
+        frame.render_widget(
+            HelpOverlay::new(
+                &help::groups_for(state),
+                labels.help_title,
+                labels.close_hint,
+            ),
+            area,
+        );
     }
 
     if let Some(toast) = &state.toast {
-        frame.render_widget(ToastWidget::new(toast), area);
+        frame.render_widget(ToastWidget::new(toast, labels), area);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use open_course_cli::config;
 use open_course_cli::db::Database;
 use open_course_cli::db::curriculum::cleanup_topics;
 use open_course_cli::llm::pipeline::log_debug_event;
+use open_course_cli::ui::labels::native_language_code;
 use open_course_cli::update;
 
 #[derive(Parser)]
@@ -54,6 +55,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let config = config::read_config(&data_dir)?;
+    let lang = native_language_code(config.as_ref()).to_string();
 
     let db = if let Some(ref cfg) = config {
         let db_path = config::pair_db_path(&data_dir, &cfg.active_pair);
@@ -74,13 +76,11 @@ async fn main() -> anyhow::Result<()> {
         }
         let (moved, removed) = cleanup_topics(&db).await?;
         if moved > 0 || removed > 0 {
-            eprintln!("Cleaned up {moved} micro-topics and removed {removed} stale topics");
+            eprintln!("{}", cleanup_message(&lang, moved, removed));
         }
         let (removed_items, removed_topics) = dedupe_tables(&db).await?;
         if removed_items > 0 || removed_topics > 0 {
-            eprintln!(
-                "Removed {removed_items} duplicate learning items and {removed_topics} duplicate topics"
-            );
+            eprintln!("{}", dedupe_message(&lang, removed_items, removed_topics));
         }
         Arc::new(db)
     } else {
@@ -88,13 +88,11 @@ async fn main() -> anyhow::Result<()> {
         let db = Database::connect(&fallback_db).await?;
         let (moved, removed) = cleanup_topics(&db).await?;
         if moved > 0 || removed > 0 {
-            eprintln!("Cleaned up {moved} micro-topics and removed {removed} stale topics");
+            eprintln!("{}", cleanup_message(&lang, moved, removed));
         }
         let (removed_items, removed_topics) = dedupe_tables(&db).await?;
         if removed_items > 0 || removed_topics > 0 {
-            eprintln!(
-                "Removed {removed_items} duplicate learning items and {removed_topics} duplicate topics"
-            );
+            eprintln!("{}", dedupe_message(&lang, removed_items, removed_topics));
         }
         Arc::new(db)
     };
@@ -148,35 +146,99 @@ fn setup_panic_hook() {
 /// `opencourse update`: check GitHub for a newer release and install it via
 /// the same installer script the in-app prompt uses.
 async fn run_update() -> anyhow::Result<()> {
+    // The config is not loaded for the `update` subcommand, so CLI messages
+    // fall back to English.
+    let lang = "en";
     let latest = update::latest_release_version().await?;
 
     match latest {
         Some(latest) if update::is_newer(update::CURRENT_VERSION, &latest) => {
-            println!("Updating v{} → v{latest}...", update::CURRENT_VERSION);
+            println!("{}", updating_message(lang, &latest));
             let status = std::process::Command::new("sh")
                 .arg("-c")
                 .arg(update::install_command())
                 .status()?;
             if !status.success() {
-                anyhow::bail!("Installer failed with status {status}");
+                anyhow::bail!("{}", installer_failed_message(lang, status));
             }
-            println!("Updated to v{latest}. Run `opencourse` to start the new version.");
+            println!("{}", updated_message(lang, &latest));
         }
         Some(latest) => {
-            println!(
-                "Already up to date (v{}, latest release v{latest}).",
-                update::CURRENT_VERSION
-            );
+            println!("{}", up_to_date_message(lang, &latest));
         }
         None => {
-            println!(
-                "Could not check for updates (network unavailable?). Current version: v{}.",
-                update::CURRENT_VERSION
-            );
+            println!("{}", check_failed_message(lang));
         }
     }
 
     Ok(())
+}
+
+fn cleanup_message(lang: &str, moved: usize, removed: usize) -> String {
+    match lang {
+        "ru" => format!("Очищено {moved} микро-тем и удалено {removed} устаревших тем"),
+        _ => format!("Cleaned up {moved} micro-topics and removed {removed} stale topics"),
+    }
+}
+
+fn dedupe_message(lang: &str, removed_items: usize, removed_topics: usize) -> String {
+    match lang {
+        "ru" => format!(
+            "Удалено {removed_items} дубликатов учебных элементов и {removed_topics} дубликатов тем"
+        ),
+        _ => format!(
+            "Removed {removed_items} duplicate learning items and {removed_topics} duplicate topics"
+        ),
+    }
+}
+
+fn updating_message(lang: &str, latest: &str) -> String {
+    match lang {
+        "ru" => format!("Обновление v{} → v{latest}...", update::CURRENT_VERSION),
+        _ => format!("Updating v{} → v{latest}...", update::CURRENT_VERSION),
+    }
+}
+
+fn installer_failed_message(lang: &str, status: std::process::ExitStatus) -> String {
+    match lang {
+        "ru" => format!("Установщик завершился с ошибкой: {status}"),
+        _ => format!("Installer failed with status {status}"),
+    }
+}
+
+fn updated_message(lang: &str, latest: &str) -> String {
+    match lang {
+        "ru" => {
+            format!("Обновлено до v{latest}. Запустите `opencourse`, чтобы начать новую версию.")
+        }
+        _ => format!("Updated to v{latest}. Run `opencourse` to start the new version."),
+    }
+}
+
+fn up_to_date_message(lang: &str, latest: &str) -> String {
+    match lang {
+        "ru" => format!(
+            "Уже последняя версия (v{}, последний релиз v{latest}).",
+            update::CURRENT_VERSION
+        ),
+        _ => format!(
+            "Already up to date (v{}, latest release v{latest}).",
+            update::CURRENT_VERSION
+        ),
+    }
+}
+
+fn check_failed_message(lang: &str) -> String {
+    match lang {
+        "ru" => format!(
+            "Не удалось проверить обновления (сеть недоступна?). Текущая версия: v{}.",
+            update::CURRENT_VERSION
+        ),
+        _ => format!(
+            "Could not check for updates (network unavailable?). Current version: v{}.",
+            update::CURRENT_VERSION
+        ),
+    }
 }
 
 /// One-off startup maintenance: removes fuzzy-duplicate learning items and

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -1,6 +1,9 @@
 use crate::app::{AppState, View};
 use crate::config::provider::ProviderId;
-use crate::ui::labels::{ReportLabels, get_docs_labels, get_report_labels, native_language_code};
+use crate::ui::labels::{
+    CommonLabels, ReportLabels, get_common_labels, get_docs_labels, get_report_labels,
+    native_language_code,
+};
 use crate::ui::views::curriculum::CurriculumSortBy;
 use crate::ui::views::onboarding::Step as OnboardingStep;
 use crate::ui::views::session::Mode as SessionMode;
@@ -43,23 +46,29 @@ fn mouse_entries(state: &AppState, labels: ReportLabels) -> Vec<HelpEntry> {
 }
 
 pub fn groups_for(state: &AppState) -> Vec<HelpGroup> {
-    let labels = get_report_labels(native_language_code(state.config.as_ref()));
+    let lang = native_language_code(state.config.as_ref());
+    let labels = get_report_labels(lang);
+    let common = get_common_labels(lang);
     match state.view {
-        View::Dashboard => dashboard_groups(state, labels),
-        View::Curriculum => curriculum_groups(state, labels),
-        View::Docs => docs_groups(state, labels),
-        View::Session => session_groups(state, labels),
-        View::Pairs => pairs_groups(labels),
-        View::Report => report_groups(state, labels),
-        View::ModelCheck => model_check_groups(state),
-        View::Settings => settings_groups(state),
-        View::Onboarding => onboarding_groups(state),
-        View::UpdateAvailable => update_groups(),
+        View::Dashboard => dashboard_groups(state, labels, common),
+        View::Curriculum => curriculum_groups(state, labels, common),
+        View::Docs => docs_groups(state, labels, common),
+        View::Session => session_groups(state, labels, common),
+        View::Pairs => pairs_groups(labels, common),
+        View::Report => report_groups(state, labels, common),
+        View::ModelCheck => model_check_groups(state, common),
+        View::Settings => settings_groups(state, common),
+        View::Onboarding => onboarding_groups(state, common),
+        View::UpdateAvailable => update_groups(common),
         View::Quitting => Vec::new(),
     }
 }
 
-fn dashboard_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
+fn dashboard_groups(
+    state: &AppState,
+    labels: ReportLabels,
+    common: CommonLabels,
+) -> Vec<HelpGroup> {
     let mut nav = Vec::new();
     let mut actions = Vec::new();
     if state.dashboard.weak_visible_len() > 0 {
@@ -69,36 +78,49 @@ fn dashboard_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
     if state.dashboard.max_scroll > 0 {
         nav.extend(mouse_entries(state, labels));
     }
-    nav.push(entry("Esc", "clear topic selection"));
+    nav.push(entry("Esc", common.clear_topic_selection));
     actions.push(entry("n", labels.start_next_label));
     actions.push(entry("d", labels.docs));
     actions.push(entry("c", labels.curriculum));
     actions.push(entry("p", labels.pairs));
     actions.push(entry("s", labels.settings));
     vec![
-        group("Navigation", nav),
-        group("Actions", actions),
-        group("Exit", vec![entry("q", labels.quit)]),
+        group(common.group_navigation, nav),
+        group(common.group_actions, actions),
+        group(common.group_exit, vec![entry("q", labels.quit)]),
     ]
 }
 
-fn curriculum_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
+fn curriculum_groups(
+    state: &AppState,
+    labels: ReportLabels,
+    common: CommonLabels,
+) -> Vec<HelpGroup> {
     if state.curriculum.pending_reset {
         return vec![group(
-            "Actions",
-            vec![entry("y", "confirm reset"), entry("n / Esc", "cancel")],
+            common.group_actions,
+            vec![
+                entry("y", format!("{} {}", common.confirm, common.reset)),
+                entry("n / Esc", common.cancel),
+            ],
         )];
     }
     if state.curriculum.pending_delete.is_some() {
         return vec![group(
-            "Actions",
-            vec![entry("y", "confirm delete"), entry("n / Esc", "cancel")],
+            common.group_actions,
+            vec![
+                entry("y", format!("{} {}", common.confirm, common.delete)),
+                entry("n / Esc", common.cancel),
+            ],
         )];
     }
     if state.curriculum.topics.is_empty() {
         return vec![
-            group("Actions", vec![entry("g / Enter", labels.generate_label)]),
-            group("Exit", vec![entry("Esc", labels.back)]),
+            group(
+                common.group_actions,
+                vec![entry("g / Enter", labels.generate_label)],
+            ),
+            group(common.group_exit, vec![entry("Esc", labels.back)]),
         ];
     }
     let sort_label = match state.curriculum.sort_by {
@@ -110,9 +132,9 @@ fn curriculum_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
         nav.extend(mouse_entries(state, labels));
     }
     vec![
-        group("Navigation", nav),
+        group(common.group_navigation, nav),
         group(
-            "Actions",
+            common.group_actions,
             vec![
                 entry("Enter", labels.docs),
                 entry("s", format!("{} ({})", labels.sort, sort_label)),
@@ -121,11 +143,15 @@ fn curriculum_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
                 entry("r", labels.reset_label),
             ],
         ),
-        group("Exit", vec![entry("Esc", labels.back)]),
+        group(common.group_exit, vec![entry("Esc", labels.back)]),
     ]
 }
 
-fn docs_groups(state: &AppState, report_labels: ReportLabels) -> Vec<HelpGroup> {
+fn docs_groups(
+    state: &AppState,
+    report_labels: ReportLabels,
+    common: CommonLabels,
+) -> Vec<HelpGroup> {
     let labels = get_docs_labels(native_language_code(state.config.as_ref()));
     if state.docs.viewing_topic.is_some() {
         let mut nav = vec![entry("↑/↓", report_labels.wheel_scroll)];
@@ -133,12 +159,12 @@ fn docs_groups(state: &AppState, report_labels: ReportLabels) -> Vec<HelpGroup> 
             nav.extend(mouse_entries(state, report_labels));
         }
         return vec![
-            group("Navigation", nav),
+            group(common.group_navigation, nav),
             group(
-                "Actions",
+                common.group_actions,
                 vec![entry("e", labels.regenerate), entry("p", labels.practice)],
             ),
-            group("Exit", vec![entry("Esc", "back to list")]),
+            group(common.group_exit, vec![entry("Esc", common.back_to_list)]),
         ];
     }
     let mut nav = vec![
@@ -149,236 +175,272 @@ fn docs_groups(state: &AppState, report_labels: ReportLabels) -> Vec<HelpGroup> 
         nav.extend(mouse_entries(state, report_labels));
     }
     vec![
-        group("Navigation", nav),
+        group(common.group_navigation, nav),
         group(
-            "Actions",
-            vec![entry("Enter", "view"), entry("p", labels.practice)],
+            common.group_actions,
+            vec![entry("Enter", common.view), entry("p", labels.practice)],
         ),
-        group("Exit", vec![entry("Esc", "back")]),
+        group(common.group_exit, vec![entry("Esc", common.back)]),
     ]
 }
 
-fn session_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
+fn session_groups(state: &AppState, labels: ReportLabels, common: CommonLabels) -> Vec<HelpGroup> {
     if state.session.loading {
-        return vec![group("Exit", vec![entry("Esc", labels.cancel)])];
+        return vec![group(common.group_exit, vec![entry("Esc", labels.cancel)])];
     }
     match state.session.mode {
         SessionMode::TopicSelection => vec![
-            group("Navigation", vec![entry("↑↓", labels.navigate)]),
-            group("Actions", vec![entry("Enter", labels.start_session)]),
-            group("Exit", vec![entry("Esc", labels.back)]),
+            group(common.group_navigation, vec![entry("↑↓", labels.navigate)]),
+            group(
+                common.group_actions,
+                vec![entry("Enter", labels.start_session)],
+            ),
+            group(common.group_exit, vec![entry("Esc", labels.back)]),
         ],
         SessionMode::Practicing => vec![
             group(
-                "Actions",
+                common.group_actions,
                 vec![
-                    entry("(type)", "write your answer"),
+                    entry("(type)", common.write_your_answer),
                     entry("Enter", labels.submit),
                 ],
             ),
-            group("Exit", vec![entry("Esc", labels.back)]),
+            group(common.group_exit, vec![entry("Esc", labels.back)]),
         ],
     }
 }
 
-fn pairs_groups(labels: ReportLabels) -> Vec<HelpGroup> {
+fn pairs_groups(labels: ReportLabels, common: CommonLabels) -> Vec<HelpGroup> {
     vec![
-        group("Navigation", vec![entry("↑/↓", labels.navigate)]),
+        group(common.group_navigation, vec![entry("↑/↓", labels.navigate)]),
         group(
-            "Actions",
+            common.group_actions,
             vec![entry("Enter", labels.switch), entry("a", labels.add_pair)],
         ),
-        group("Exit", vec![entry("Esc", labels.back)]),
+        group(common.group_exit, vec![entry("Esc", labels.back)]),
     ]
 }
 
-fn report_groups(state: &AppState, labels: ReportLabels) -> Vec<HelpGroup> {
+fn report_groups(state: &AppState, labels: ReportLabels, common: CommonLabels) -> Vec<HelpGroup> {
     let mut nav = vec![entry("↑/↓", labels.wheel_scroll)];
     if state.report.max_scroll_offset > 0 {
         nav.extend(mouse_entries(state, labels));
     }
     vec![
-        group("Navigation", nav),
+        group(common.group_navigation, nav),
         group(
-            "Actions",
+            common.group_actions,
             vec![
-                entry("n", "new topic"),
-                entry("r", "repeat"),
-                entry("d", "docs"),
+                entry("n", common.new_topic),
+                entry("r", common.repeat),
+                entry("d", common.docs),
             ],
         ),
-        group("Exit", vec![entry("Esc", "dashboard")]),
+        group(common.group_exit, vec![entry("Esc", common.dashboard)]),
     ]
 }
 
-fn model_check_groups(state: &AppState) -> Vec<HelpGroup> {
+fn model_check_groups(state: &AppState, common: CommonLabels) -> Vec<HelpGroup> {
     if state.model_check.running {
-        return vec![group("Exit", vec![entry("Esc", "cancel")])];
+        return vec![group(common.group_exit, vec![entry("Esc", common.cancel)])];
     }
     vec![
         group(
-            "Actions",
+            common.group_actions,
             vec![
-                entry("Enter / c", "continue"),
-                entry("r", "retry"),
-                entry("s", "skip"),
+                entry("Enter / c", common.continue_label),
+                entry("r", common.retry),
+                entry("s", common.skip),
             ],
         ),
-        group("Exit", vec![entry("Esc / b", "back to model list")]),
+        group(
+            common.group_exit,
+            vec![entry("Esc / b", common.back_to_model_list)],
+        ),
     ]
 }
 
-fn settings_groups(state: &AppState) -> Vec<HelpGroup> {
+fn settings_groups(state: &AppState, common: CommonLabels) -> Vec<HelpGroup> {
     if state.settings.pending_reset.is_some() {
         return vec![group(
-            "Actions",
+            common.group_actions,
             vec![
-                entry("y", "confirm reset"),
-                entry("any other key", "cancel"),
+                entry("y", format!("{} {}", common.confirm, common.reset)),
+                entry("any other key", common.cancel),
             ],
         )];
     }
     if !state.settings.in_section {
         return vec![
-            group("Navigation", vec![entry("↑/↓", "navigate")]),
-            group("Actions", vec![entry("Enter", "open")]),
-            group("Exit", vec![entry("Esc", "back")]),
+            group(common.group_navigation, vec![entry("↑/↓", common.navigate)]),
+            group(common.group_actions, vec![entry("Enter", common.open)]),
+            group(common.group_exit, vec![entry("Esc", common.back)]),
         ];
     }
     if state.settings.section == Section::Provider {
-        return provider_setup_groups(state);
+        return provider_setup_groups(state, common);
     }
     match state.settings.section {
         Section::Data => vec![
-            group("Navigation", vec![entry("↑/↓", "action")]),
-            group("Actions", vec![entry("Enter", "reset")]),
-            group("Exit", vec![entry("Esc", "back")]),
+            group(common.group_navigation, vec![entry("↑/↓", common.action)]),
+            group(common.group_actions, vec![entry("Enter", common.reset)]),
+            group(common.group_exit, vec![entry("Esc", common.back)]),
         ],
         Section::Session => vec![
-            group("Navigation", vec![entry("↑/↓", "select")]),
-            group("Exit", vec![entry("Esc", "back")]),
+            group(common.group_navigation, vec![entry("↑/↓", common.select)]),
+            group(common.group_exit, vec![entry("Esc", common.back)]),
         ],
         Section::Profile => vec![
-            group("Navigation", vec![entry("←/→", "move caret")]),
             group(
-                "Actions",
-                vec![entry("(type)", "edit"), entry("Enter", "save")],
+                common.group_navigation,
+                vec![entry("←/→", common.move_caret)],
             ),
-            group("Exit", vec![entry("Esc", "back")]),
+            group(
+                common.group_actions,
+                vec![entry("(type)", common.edit), entry("Enter", common.save)],
+            ),
+            group(common.group_exit, vec![entry("Esc", common.back)]),
         ],
         Section::Provider => unreachable!("handled above"),
     }
 }
 
-fn provider_setup_groups(state: &AppState) -> Vec<HelpGroup> {
+fn provider_setup_groups(state: &AppState, common: CommonLabels) -> Vec<HelpGroup> {
     match state.settings.provider_setup_step {
         ProviderSetupStep::SelectProvider => vec![
-            group("Navigation", vec![entry("↑/↓", "navigate")]),
-            group("Actions", vec![entry("Enter", "select")]),
-            group("Exit", vec![entry("Esc", "back")]),
+            group(common.group_navigation, vec![entry("↑/↓", common.navigate)]),
+            group(common.group_actions, vec![entry("Enter", common.select)]),
+            group(common.group_exit, vec![entry("Esc", common.back)]),
         ],
         ProviderSetupStep::BaseUrl | ProviderSetupStep::Endpoint => {
             let editable = state.settings.provider_setup_provider == ProviderId::Custom;
             let actions = if editable {
-                vec![entry("(type)", "edit"), entry("Enter", "save")]
+                vec![entry("(type)", common.edit), entry("Enter", common.save)]
             } else {
-                vec![entry("Enter", "next")]
+                vec![entry("Enter", common.next)]
             };
             vec![
-                group("Actions", actions),
-                group("Exit", vec![entry("Esc", "back")]),
+                group(common.group_actions, actions),
+                group(common.group_exit, vec![entry("Esc", common.back)]),
             ]
         }
         ProviderSetupStep::ApiKey => vec![
             group(
-                "Actions",
-                vec![entry("(type)", "edit"), entry("Enter", "save")],
+                common.group_actions,
+                vec![entry("(type)", common.edit), entry("Enter", common.save)],
             ),
-            group("Exit", vec![entry("Esc", "back")]),
+            group(common.group_exit, vec![entry("Esc", common.back)]),
         ],
         ProviderSetupStep::Model => {
             let picker = &state.settings.model_picker;
             if picker.loading {
-                vec![group("Exit", vec![entry("Esc", "back")])]
+                vec![group(common.group_exit, vec![entry("Esc", common.back)])]
             } else if picker.error.is_some() {
                 vec![
                     group(
-                        "Actions",
-                        vec![entry("Enter", "manual"), entry("r", "retry")],
+                        common.group_actions,
+                        vec![entry("Enter", common.manual), entry("r", common.retry)],
                     ),
-                    group("Exit", vec![entry("Esc", "back")]),
+                    group(common.group_exit, vec![entry("Esc", common.back)]),
                 ]
             } else if picker.manual {
                 vec![
                     group(
-                        "Actions",
-                        vec![entry("(type)", "edit"), entry("Enter", "save")],
+                        common.group_actions,
+                        vec![entry("(type)", common.edit), entry("Enter", common.save)],
                     ),
-                    group("Exit", vec![entry("Esc", "back")]),
+                    group(common.group_exit, vec![entry("Esc", common.back)]),
                 ]
             } else if picker.models.is_empty() {
                 vec![
-                    group("Actions", vec![entry("Enter", "enter manually")]),
-                    group("Exit", vec![entry("Esc", "back")]),
+                    group(
+                        common.group_actions,
+                        vec![entry("Enter", common.enter_manually)],
+                    ),
+                    group(common.group_exit, vec![entry("Esc", common.back)]),
                 ]
             } else {
                 vec![
-                    group("Navigation", vec![entry("↑/↓", "navigate")]),
-                    group("Actions", vec![entry("Enter", "select")]),
-                    group("Exit", vec![entry("Esc", "back")]),
+                    group(common.group_navigation, vec![entry("↑/↓", common.navigate)]),
+                    group(common.group_actions, vec![entry("Enter", common.select)]),
+                    group(common.group_exit, vec![entry("Esc", common.back)]),
                 ]
             }
         }
     }
 }
 
-fn onboarding_groups(state: &AppState) -> Vec<HelpGroup> {
+fn onboarding_groups(state: &AppState, common: CommonLabels) -> Vec<HelpGroup> {
     let step = state.onboarding.steps[state.onboarding.active];
     let picker = &state.onboarding.model_picker;
     let mut groups = match step {
         OnboardingStep::Provider => vec![
-            group("Navigation", vec![entry("↑/↓", "select provider")]),
-            group("Actions", vec![entry("Enter", "next")]),
+            group(
+                common.group_navigation,
+                vec![entry("↑/↓", common.select_provider)],
+            ),
+            group(common.group_actions, vec![entry("Enter", common.next)]),
         ],
         OnboardingStep::Cefr => vec![
-            group("Navigation", vec![entry("↑/↓", "select level")]),
-            group("Actions", vec![entry("Enter", "next")]),
+            group(
+                common.group_navigation,
+                vec![entry("↑/↓", common.select_level)],
+            ),
+            group(common.group_actions, vec![entry("Enter", common.next)]),
         ],
         OnboardingStep::BatchSize => vec![
-            group("Navigation", vec![entry("↑/↓", "select batch size")]),
-            group("Actions", vec![entry("Enter", "next")]),
+            group(
+                common.group_navigation,
+                vec![entry("↑/↓", common.select_batch_size)],
+            ),
+            group(common.group_actions, vec![entry("Enter", common.next)]),
         ],
-        OnboardingStep::Model if picker.loading => vec![group("Actions", Vec::new())],
+        OnboardingStep::Model if picker.loading => vec![group(common.group_actions, Vec::new())],
         OnboardingStep::Model if picker.error.is_some() => vec![group(
-            "Actions",
-            vec![entry("r", "retry"), entry("m", "enter manually")],
+            common.group_actions,
+            vec![entry("r", common.retry), entry("m", common.enter_manually)],
         )],
         OnboardingStep::Model if picker.manual => vec![group(
-            "Actions",
-            vec![entry("(type)", "model ID"), entry("Enter", "next")],
+            common.group_actions,
+            vec![
+                entry("(type)", common.model_id),
+                entry("Enter", common.next),
+            ],
         )],
         OnboardingStep::Model if !picker.models.is_empty() => vec![
-            group("Navigation", vec![entry("↑/↓", "select model")]),
-            group("Actions", vec![entry("Enter", "next")]),
+            group(
+                common.group_navigation,
+                vec![entry("↑/↓", common.select_model)],
+            ),
+            group(common.group_actions, vec![entry("Enter", common.next)]),
         ],
         _ => vec![
-            group("Navigation", vec![entry("Shift+Tab", "previous step")]),
             group(
-                "Actions",
-                vec![entry("(type)", "edit"), entry("Tab / Enter", "next")],
+                common.group_navigation,
+                vec![entry("Shift+Tab", common.previous_step)],
+            ),
+            group(
+                common.group_actions,
+                vec![
+                    entry("(type)", common.edit),
+                    entry("Tab / Enter", common.next),
+                ],
             ),
         ],
     };
-    groups.push(group("Exit", vec![entry("Esc", "quit")]));
+    groups.push(group(common.group_exit, vec![entry("Esc", common.quit)]));
     groups
 }
 
-fn update_groups() -> Vec<HelpGroup> {
+fn update_groups(common: CommonLabels) -> Vec<HelpGroup> {
     vec![
-        group("Actions", vec![entry("y", "install update")]),
         group(
-            "Exit",
-            vec![entry("n / Esc / Enter", "skip, continue to app")],
+            common.group_actions,
+            vec![entry("y", common.install_update)],
+        ),
+        group(
+            common.group_exit,
+            vec![entry("n / Esc / Enter", common.skip_continue)],
         ),
     ]
 }

--- a/src/ui/labels.rs
+++ b/src/ui/labels.rs
@@ -79,6 +79,21 @@ pub struct ReportLabels {
     pub wheel_scroll: &'static str,
     pub select_text: &'static str,
     pub wheel_mode: &'static str,
+    pub also_acceptable: &'static str,
+    pub no_topics_available: &'static str,
+    pub waiting: &'static str,
+    pub generating_plan: &'static str,
+    pub difficulty_beginner: &'static str,
+    pub difficulty_intermediate: &'static str,
+    pub difficulty_advanced: &'static str,
+    pub regenerate_curriculum_title: &'static str,
+    pub regenerate_curriculum_msg: &'static str,
+    pub delete_topic_title: &'static str,
+    pub delete_topic_msg: &'static str,
+    pub toast_info: &'static str,
+    pub help_title: &'static str,
+    pub close_hint: &'static str,
+    pub error_footer_hint: &'static str,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -91,6 +106,7 @@ pub struct DocsLabels {
     pub loading: &'static str,
     pub no_review: &'static str,
     pub sort: &'static str,
+    pub sort_last_practiced: &'static str,
 }
 
 const EN_REPORT: ReportLabels = ReportLabels {
@@ -171,6 +187,21 @@ const EN_REPORT: ReportLabels = ReportLabels {
     wheel_scroll: "scroll",
     select_text: "select text",
     wheel_mode: "wheel scroll",
+    also_acceptable: "Also acceptable: ",
+    no_topics_available: "No topics available.",
+    waiting: "waiting...",
+    generating_plan: "Generating curriculum plan...",
+    difficulty_beginner: "beginner",
+    difficulty_intermediate: "intermediate",
+    difficulty_advanced: "advanced",
+    regenerate_curriculum_title: "Regenerate Curriculum",
+    regenerate_curriculum_msg: "This will delete the current curriculum, all progress scores, and topic reviews.\nAre you sure?",
+    delete_topic_title: "Delete Topic",
+    delete_topic_msg: "Delete \"{}\" and its progress/review?\nThis cannot be undone.",
+    toast_info: "Info",
+    help_title: "Help",
+    close_hint: "Esc / ?: close",
+    error_footer_hint: "r: retry | m: change model | q: quit",
 };
 
 const RU_REPORT: ReportLabels = ReportLabels {
@@ -251,6 +282,21 @@ const RU_REPORT: ReportLabels = ReportLabels {
     wheel_scroll: "скролл",
     select_text: "выделение текста",
     wheel_mode: "скролл колесом",
+    also_acceptable: "Также принимается: ",
+    no_topics_available: "Нет доступных тем.",
+    waiting: "ожидание...",
+    generating_plan: "Генерация плана программы...",
+    difficulty_beginner: "начальный",
+    difficulty_intermediate: "средний",
+    difficulty_advanced: "продвинутый",
+    regenerate_curriculum_title: "Пересоздать программу",
+    regenerate_curriculum_msg: "Текущая программа, все оценки прогресса и повторения тем будут удалены.\nВы уверены?",
+    delete_topic_title: "Удалить тему",
+    delete_topic_msg: "Удалить \"{}\" вместе с прогрессом и повторением?\nДействие необратимо.",
+    toast_info: "Инфо",
+    help_title: "Помощь",
+    close_hint: "Esc / ?: закрыть",
+    error_footer_hint: "r: повторить | m: сменить модель | q: выход",
 };
 
 const EN_DOCS: DocsLabels = DocsLabels {
@@ -262,6 +308,7 @@ const EN_DOCS: DocsLabels = DocsLabels {
     loading: "Loading...",
     no_review: "No review available.",
     sort: "Sort",
+    sort_last_practiced: "last practiced",
 };
 
 const RU_DOCS: DocsLabels = DocsLabels {
@@ -273,6 +320,531 @@ const RU_DOCS: DocsLabels = DocsLabels {
     loading: "Загрузка...",
     no_review: "Повторение недоступно.",
     sort: "Сортировка",
+    sort_last_practiced: "по дате практики",
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CommonLabels {
+    pub help: &'static str,
+    pub back: &'static str,
+    pub scroll: &'static str,
+    pub navigate: &'static str,
+    pub select: &'static str,
+    pub view: &'static str,
+    pub save: &'static str,
+    pub edit: &'static str,
+    pub next: &'static str,
+    pub prev: &'static str,
+    pub open: &'static str,
+    pub quit: &'static str,
+    pub cancel: &'static str,
+    pub confirm: &'static str,
+    pub retry: &'static str,
+    pub skip: &'static str,
+    pub install: &'static str,
+    pub close: &'static str,
+    pub continue_label: &'static str,
+    pub manual: &'static str,
+    pub enter_manually: &'static str,
+    pub model_id: &'static str,
+    pub reset: &'static str,
+    pub delete: &'static str,
+    pub action: &'static str,
+    pub field: &'static str,
+    pub move_caret: &'static str,
+    pub dashboard: &'static str,
+    pub new_topic: &'static str,
+    pub repeat: &'static str,
+    pub back_to_list: &'static str,
+    pub back_to_model_list: &'static str,
+    pub select_model: &'static str,
+    pub select_provider: &'static str,
+    pub select_level: &'static str,
+    pub select_batch_size: &'static str,
+    pub clear_topic_selection: &'static str,
+    pub write_your_answer: &'static str,
+    pub switch_to_text_selection: &'static str,
+    pub switch_to_wheel_scroll: &'static str,
+    pub install_update: &'static str,
+    pub skip_continue: &'static str,
+    pub change_model: &'static str,
+    pub previous_step: &'static str,
+    pub type_hint: &'static str,
+    pub group_navigation: &'static str,
+    pub group_actions: &'static str,
+    pub group_exit: &'static str,
+    pub confirm_keys: &'static str,
+    pub confirm_any_other: &'static str,
+    pub sort: &'static str,
+    pub docs: &'static str,
+}
+
+const EN_COMMON: CommonLabels = CommonLabels {
+    help: "help",
+    back: "back",
+    scroll: "scroll",
+    navigate: "navigate",
+    select: "select",
+    view: "view",
+    save: "save",
+    edit: "edit",
+    next: "next",
+    prev: "prev",
+    open: "open",
+    quit: "quit",
+    cancel: "cancel",
+    confirm: "confirm",
+    retry: "retry",
+    skip: "skip",
+    install: "install",
+    close: "close",
+    continue_label: "continue",
+    manual: "manual",
+    enter_manually: "enter manually",
+    model_id: "model ID",
+    reset: "reset",
+    delete: "delete",
+    action: "action",
+    field: "field",
+    move_caret: "move caret",
+    dashboard: "dashboard",
+    new_topic: "new topic",
+    repeat: "repeat",
+    back_to_list: "back to list",
+    back_to_model_list: "back to model list",
+    select_model: "select model",
+    select_provider: "select provider",
+    select_level: "select level",
+    select_batch_size: "select batch size",
+    clear_topic_selection: "clear topic selection",
+    write_your_answer: "write your answer",
+    switch_to_text_selection: "switch to text selection",
+    switch_to_wheel_scroll: "switch to wheel scroll",
+    install_update: "install update",
+    skip_continue: "skip, continue to app",
+    change_model: "change model",
+    previous_step: "previous step",
+    type_hint: "Type",
+    group_navigation: "Navigation",
+    group_actions: "Actions",
+    group_exit: "Exit",
+    confirm_keys: "y: confirm | n/Esc: cancel",
+    confirm_any_other: "y: confirm | any other key: cancel",
+    sort: "sort",
+    docs: "docs",
+};
+
+const RU_COMMON: CommonLabels = CommonLabels {
+    help: "помощь",
+    back: "назад",
+    scroll: "прокрутка",
+    navigate: "навигация",
+    select: "выбрать",
+    view: "открыть",
+    save: "сохранить",
+    edit: "редактировать",
+    next: "далее",
+    prev: "назад",
+    open: "открыть",
+    quit: "выход",
+    cancel: "отмена",
+    confirm: "подтвердить",
+    retry: "повторить",
+    skip: "пропустить",
+    install: "установить",
+    close: "закрыть",
+    continue_label: "продолжить",
+    manual: "вручную",
+    enter_manually: "ввести вручную",
+    model_id: "ID модели",
+    reset: "сбросить",
+    delete: "удалить",
+    action: "действие",
+    field: "поле",
+    move_caret: "курсор",
+    dashboard: "на главную",
+    new_topic: "новая тема",
+    repeat: "повторить",
+    back_to_list: "к списку",
+    back_to_model_list: "к списку моделей",
+    select_model: "выберите модель",
+    select_provider: "выберите провайдера",
+    select_level: "выберите уровень",
+    select_batch_size: "выберите размер сессии",
+    clear_topic_selection: "сбросить выбор темы",
+    write_your_answer: "введите ответ",
+    switch_to_text_selection: "режим выделения",
+    switch_to_wheel_scroll: "режим прокрутки",
+    install_update: "установить обновление",
+    skip_continue: "пропустить и продолжить",
+    change_model: "сменить модель",
+    previous_step: "предыдущий шаг",
+    type_hint: "Ввод",
+    group_navigation: "Навигация",
+    group_actions: "Действия",
+    group_exit: "Выход",
+    confirm_keys: "y: подтвердить | n/Esc: отмена",
+    confirm_any_other: "y: подтвердить | любая другая клавиша: отмена",
+    sort: "сортировка",
+    docs: "документация",
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OnboardingLabels {
+    pub step_native_language: &'static str,
+    pub step_target_language: &'static str,
+    pub step_age: &'static str,
+    pub step_cefr: &'static str,
+    pub step_batch_size: &'static str,
+    pub step_provider: &'static str,
+    pub step_api_key: &'static str,
+    pub step_base_url: &'static str,
+    pub step_model: &'static str,
+    pub help_native_language: &'static str,
+    pub help_target_language: &'static str,
+    pub help_age: &'static str,
+    pub intro_providers: &'static str,
+    pub intro_cefr: &'static str,
+    pub intro_batch_size: &'static str,
+    pub env_var_set: &'static str,
+    pub env_var_hint: &'static str,
+    pub api_key_required: &'static str,
+    pub api_key_optional: &'static str,
+    pub base_url_prompt: &'static str,
+    pub base_url_not_required: &'static str,
+    pub setup_subtitle: &'static str,
+    pub step_progress: &'static str,
+    pub loading_models: &'static str,
+    pub fetching_models: &'static str,
+    pub failed_load_models: &'static str,
+    pub enter_model_manually: &'static str,
+    pub no_models_found: &'static str,
+    pub model_picker_info: &'static str,
+    pub select_lists: &'static str,
+    pub err_base_url_required: &'static str,
+    pub err_model_required: &'static str,
+    pub err_invalid_language: &'static str,
+    pub err_languages_differ: &'static str,
+    pub err_invalid_age: &'static str,
+    pub err_cefr_required: &'static str,
+    pub err_invalid_cefr: &'static str,
+    pub err_batch_required: &'static str,
+    pub err_batch_range: &'static str,
+}
+
+const EN_ONBOARDING: OnboardingLabels = OnboardingLabels {
+    step_native_language: "Native language (e.g. en)",
+    step_target_language: "Target language (e.g. es)",
+    step_age: "Age (optional)",
+    step_cefr: "CEFR level (required)",
+    step_batch_size: "Batch size (required)",
+    step_provider: "Select provider",
+    step_api_key: "Enter API key",
+    step_base_url: "Enter base URL",
+    step_model: "Select model",
+    help_native_language: "Enter your native language code (ISO 639-1, e.g. en, ru)",
+    help_target_language: "Enter the language you want to learn (ISO 639-1, e.g. es, de)",
+    help_age: "Enter your age (optional, used to pick age-appropriate contexts)",
+    intro_providers: "Available providers:",
+    intro_cefr: "Select your CEFR level (required). Pick the level that best matches your current ability (self-assessment):",
+    intro_batch_size: "Select batch size — number of exercises per session (required):",
+    env_var_set: "{name} is set in your environment and will be used if you leave this blank.",
+    env_var_hint: "You can also set the {name} environment variable instead.",
+    api_key_required: "Enter API key for {}\n(required){}",
+    api_key_optional: "Enter API key for {}\n(optional — press Enter to skip){}",
+    base_url_prompt: "Enter API base URL for {}\n(e.g. {})",
+    base_url_not_required: "Base URL is not required for {}.\nPress Enter to continue.",
+    setup_subtitle: "Set up your language learning profile",
+    step_progress: "Step {} of {}",
+    loading_models: "Loading models... | {}",
+    fetching_models: "Fetching available models from provider...",
+    failed_load_models: "Failed to load models:\n{}\n\nr: retry | m: enter manually",
+    enter_model_manually: "Enter model ID manually\n(e.g. gpt-4o-mini, ...)",
+    no_models_found: "No models found.\nr: retry | m: enter manually",
+    model_picker_info: "Model {} of {} (m: manual, r: retry, Esc: quit)",
+    select_lists: "select lists",
+    err_base_url_required: "Base URL is required for this provider",
+    err_model_required: "Model is required",
+    err_invalid_language: "Invalid language code: {value}",
+    err_languages_differ: "Target language must differ from native language",
+    err_invalid_age: "Age must be a number between 1 and 120: {value}",
+    err_cefr_required: "CEFR level is required",
+    err_invalid_cefr: "Invalid CEFR level: {value}",
+    err_batch_required: "Batch size is required",
+    err_batch_range: "Batch size must be 2-5: {value}",
+};
+
+const RU_ONBOARDING: OnboardingLabels = OnboardingLabels {
+    step_native_language: "Родной язык (например, ru)",
+    step_target_language: "Изучаемый язык (например, es)",
+    step_age: "Возраст (необязательно)",
+    step_cefr: "Уровень CEFR (обязательно)",
+    step_batch_size: "Размер сессии (обязательно)",
+    step_provider: "Выберите провайдера",
+    step_api_key: "Введите API-ключ",
+    step_base_url: "Введите base URL",
+    step_model: "Выберите модель",
+    help_native_language: "Введите код родного языка (ISO 639-1, например en, ru)",
+    help_target_language: "Введите язык, который хотите изучать (ISO 639-1, например es, de)",
+    help_age: "Введите возраст (необязательно, используется для подбора контекстов по возрасту)",
+    intro_providers: "Доступные провайдеры:",
+    intro_cefr: "Выберите ваш уровень CEFR (обязательно). Укажите уровень, который лучше всего соответствует вашим текущим знаниям (самооценка):",
+    intro_batch_size: "Выберите размер сессии — количество упражнений за сессию (обязательно):",
+    env_var_set: "{name} задана в окружении и будет использована, если оставить поле пустым.",
+    env_var_hint: "Также можно задать переменную окружения {name}.",
+    api_key_required: "Введите API-ключ для {}\n(обязательно){}",
+    api_key_optional: "Введите API-ключ для {}\n(необязательно — Enter, чтобы пропустить){}",
+    base_url_prompt: "Введите base URL API для {}\n(например, {})",
+    base_url_not_required: "Base URL не требуется для {}.\nНажмите Enter, чтобы продолжить.",
+    setup_subtitle: "Настройте ваш профиль изучения языка",
+    step_progress: "Шаг {} из {}",
+    loading_models: "Загрузка моделей... | {}",
+    fetching_models: "Получение списка моделей от провайдера...",
+    failed_load_models: "Не удалось загрузить модели:\n{}\n\nr: повторить | m: ввести вручную",
+    enter_model_manually: "Введите ID модели вручную\n(например, gpt-4o-mini, ...)",
+    no_models_found: "Модели не найдены.\nr: повторить | m: ввести вручную",
+    model_picker_info: "Модель {} из {} (m: вручную, r: повторить, Esc: выход)",
+    select_lists: "выбор списком",
+    err_base_url_required: "Base URL обязателен для этого провайдера",
+    err_model_required: "Модель обязательна",
+    err_invalid_language: "Недопустимый код языка: {value}",
+    err_languages_differ: "Изучаемый язык должен отличаться от родного",
+    err_invalid_age: "Возраст должен быть числом от 1 до 120: {value}",
+    err_cefr_required: "Уровень CEFR обязателен",
+    err_invalid_cefr: "Недопустимый уровень CEFR: {value}",
+    err_batch_required: "Размер сессии обязателен",
+    err_batch_range: "Размер сессии должен быть 2-5: {value}",
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SettingsLabels {
+    pub section_provider: &'static str,
+    pub section_profile: &'static str,
+    pub section_session: &'static str,
+    pub section_data: &'static str,
+    pub no_config: &'static str,
+    pub batch_size_title: &'static str,
+    pub recommended_suffix: &'static str,
+    pub age_label: &'static str,
+    pub none_placeholder: &'static str,
+    pub err_invalid_age: &'static str,
+    pub batch_size_label: &'static str,
+    pub err_invalid_batch: &'static str,
+    pub err_batch_range: &'static str,
+    pub reset_progress_action: &'static str,
+    pub reset_history_action: &'static str,
+    pub reset_curriculum_action: &'static str,
+    pub reset_reviews_action: &'static str,
+    pub reset_all_action: &'static str,
+    pub reset_progress_title: &'static str,
+    pub reset_history_title: &'static str,
+    pub reset_curriculum_title: &'static str,
+    pub reset_reviews_title: &'static str,
+    pub reset_all_title: &'static str,
+    pub reset_progress_desc: &'static str,
+    pub reset_history_desc: &'static str,
+    pub reset_curriculum_desc: &'static str,
+    pub reset_reviews_desc: &'static str,
+    pub reset_all_desc: &'static str,
+    pub reset_data_title: &'static str,
+    pub confirm_action: &'static str,
+    pub select_model_title: &'static str,
+    pub select_provider_title: &'static str,
+    pub base_url_label: &'static str,
+    pub base_url_readonly: &'static str,
+    pub endpoint_choose: &'static str,
+    pub endpoint_readonly: &'static str,
+    pub api_key_env: &'static str,
+    pub env_currently_set: &'static str,
+    pub env_not_set: &'static str,
+    pub api_key_label: &'static str,
+    pub loading_models: &'static str,
+    pub error_loading_models: &'static str,
+    pub model_manual_label: &'static str,
+    pub no_models_loaded: &'static str,
+    pub err_base_url_custom: &'static str,
+    pub err_endpoint_values: &'static str,
+    pub err_api_key_required: &'static str,
+    pub env_var_or_set: &'static str,
+    pub err_no_models: &'static str,
+    pub err_model_required: &'static str,
+}
+
+const EN_SETTINGS: SettingsLabels = SettingsLabels {
+    section_provider: "Provider",
+    section_profile: "Profile",
+    section_session: "Session",
+    section_data: "Data",
+    no_config: "No configuration available. Press Esc to return.",
+    batch_size_title: "Batch size:",
+    recommended_suffix: " (recommended)",
+    age_label: "Age",
+    none_placeholder: "(none)",
+    err_invalid_age: "invalid age",
+    batch_size_label: "Batch size",
+    err_invalid_batch: "Invalid batch size: {value}",
+    err_batch_range: "Batch size must be 2-5",
+    reset_progress_action: "reset progress",
+    reset_history_action: "reset history",
+    reset_curriculum_action: "reset curriculum",
+    reset_reviews_action: "reset reviews",
+    reset_all_action: "reset all data",
+    reset_progress_title: "Reset progress",
+    reset_history_title: "Reset history",
+    reset_curriculum_title: "Reset curriculum",
+    reset_reviews_title: "Reset reviews",
+    reset_all_title: "Reset all",
+    reset_progress_desc: "Clear all progress scores",
+    reset_history_desc: "Clear all session history",
+    reset_curriculum_desc: "Clear all curriculum topics",
+    reset_reviews_desc: "Clear all topic reviews",
+    reset_all_desc: "Clear all data",
+    reset_data_title: "Reset data",
+    confirm_action: "Confirm {}",
+    select_model_title: "Select model:",
+    select_provider_title: "Select provider:",
+    base_url_label: "Base URL: {}",
+    base_url_readonly: "Base URL: {} (read-only)",
+    endpoint_choose: "Endpoint: {}\n\nChoose the API endpoint path for your custom provider:\n\n  chat/completions  — OpenAI-compatible endpoints\n                    (OpenCode Go: DeepSeek, GLM, Kimi, MiMo; Ollama; OpenRouter)\n  messages          — Anthropic Messages API\n                    (OpenCode Go: Qwen, MiniMax; Anthropic)",
+    endpoint_readonly: "Endpoint: {} (read-only)\n\nThis provider uses the {} endpoint.",
+    api_key_env: "API key: {}\n\nLeave empty to use the {} environment variable{}",
+    env_currently_set: " (currently set)",
+    env_not_set: " (not currently set)",
+    api_key_label: "API key: {}",
+    loading_models: "Loading models...",
+    error_loading_models: "Error loading models: {}\n\nEnter: enter manually | r: retry | Esc: back",
+    model_manual_label: "Model (manual): {}",
+    no_models_loaded: "No models loaded.\nEnter: enter manually",
+    err_base_url_custom: "Base URL is required for custom provider",
+    err_endpoint_values: "Endpoint must be 'chat/completions' or 'messages'",
+    err_api_key_required: "API key is required for this provider{hint}",
+    env_var_or_set: " or set the {name} environment variable",
+    err_no_models: "No models loaded",
+    err_model_required: "Model is required",
+};
+
+const RU_SETTINGS: SettingsLabels = SettingsLabels {
+    section_provider: "Провайдер",
+    section_profile: "Профиль",
+    section_session: "Сессия",
+    section_data: "Данные",
+    no_config: "Конфигурация недоступна. Нажмите Esc для возврата.",
+    batch_size_title: "Размер сессии:",
+    recommended_suffix: " (рекомендуется)",
+    age_label: "Возраст",
+    none_placeholder: "(не задано)",
+    err_invalid_age: "недопустимый возраст",
+    batch_size_label: "Размер сессии",
+    err_invalid_batch: "Недопустимый размер сессии: {value}",
+    err_batch_range: "Размер сессии должен быть 2-5",
+    reset_progress_action: "сброс прогресса",
+    reset_history_action: "сброс истории",
+    reset_curriculum_action: "сброс программы",
+    reset_reviews_action: "сброс повторений",
+    reset_all_action: "сброс всех данных",
+    reset_progress_title: "Сбросить прогресс",
+    reset_history_title: "Сбросить историю",
+    reset_curriculum_title: "Сбросить программу",
+    reset_reviews_title: "Сбросить повторения",
+    reset_all_title: "Сбросить всё",
+    reset_progress_desc: "Удалить все оценки прогресса",
+    reset_history_desc: "Удалить всю историю сессий",
+    reset_curriculum_desc: "Удалить все темы программы",
+    reset_reviews_desc: "Удалить все повторения тем",
+    reset_all_desc: "Удалить все данные",
+    reset_data_title: "Сброс данных",
+    confirm_action: "Подтвердите: {}",
+    select_model_title: "Выберите модель:",
+    select_provider_title: "Выберите провайдера:",
+    base_url_label: "Base URL: {}",
+    base_url_readonly: "Base URL: {} (только чтение)",
+    endpoint_choose: "Endpoint: {}\n\nВыберите путь API-эндпоинта для вашего провайдера:\n\n  chat/completions  — OpenAI-совместимые эндпоинты\n                    (OpenCode Go: DeepSeek, GLM, Kimi, MiMo; Ollama; OpenRouter)\n  messages          — Anthropic Messages API\n                    (OpenCode Go: Qwen, MiniMax; Anthropic)",
+    endpoint_readonly: "Endpoint: {} (только чтение)\n\nЭтот провайдер использует эндпоинт {}.",
+    api_key_env: "API-ключ: {}\n\nОставьте пустым, чтобы использовать переменную окружения {}{}",
+    env_currently_set: " (задана)",
+    env_not_set: " (не задана)",
+    api_key_label: "API-ключ: {}",
+    loading_models: "Загрузка моделей...",
+    error_loading_models: "Ошибка загрузки моделей: {}\n\nEnter: ввести вручную | r: повторить | Esc: назад",
+    model_manual_label: "Модель (вручную): {}",
+    no_models_loaded: "Модели не загружены.\nEnter: ввести вручную",
+    err_base_url_custom: "Base URL обязателен для пользовательского провайдера",
+    err_endpoint_values: "Endpoint должен быть 'chat/completions' или 'messages'",
+    err_api_key_required: "API-ключ обязателен для этого провайдера{hint}",
+    env_var_or_set: " или задайте переменную окружения {name}",
+    err_no_models: "Модели не загружены",
+    err_model_required: "Модель обязательна",
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct UpdateLabels {
+    pub title: &'static str,
+    pub unknown_version: &'static str,
+    pub message: &'static str,
+    pub installing: &'static str,
+    pub installer_failed: &'static str,
+    pub latest_placeholder: &'static str,
+}
+
+const EN_UPDATE: UpdateLabels = UpdateLabels {
+    title: "Update available",
+    unknown_version: "unknown",
+    message: "A new version of opencourse is available.\n\nCurrent: v{}\nLatest: v{}\n\nInstall now?",
+    installing: "Installing opencourse {latest}...",
+    installer_failed: "Installer failed. Press any key to continue.",
+    latest_placeholder: "latest",
+};
+
+const RU_UPDATE: UpdateLabels = UpdateLabels {
+    title: "Доступно обновление",
+    unknown_version: "неизвестно",
+    message: "Доступна новая версия opencourse.\n\nТекущая: v{}\nПоследняя: v{}\n\nУстановить сейчас?",
+    installing: "Установка opencourse {latest}...",
+    installer_failed: "Установка не удалась. Нажмите любую клавишу, чтобы продолжить.",
+    latest_placeholder: "latest",
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ModelCheckLabels {
+    pub check_connectivity: &'static str,
+    pub check_streaming: &'static str,
+    pub check_exercise_generation: &'static str,
+    pub check_answer_analysis: &'static str,
+    pub check_topic_review: &'static str,
+    pub running_checks: &'static str,
+    pub verdict_failed: &'static str,
+    pub verdict_warnings: &'static str,
+    pub verdict_ready: &'static str,
+    pub running_diagnostics: &'static str,
+    pub reasoning_suffix: &'static str,
+}
+
+const EN_MODEL_CHECK: ModelCheckLabels = ModelCheckLabels {
+    check_connectivity: "Connectivity",
+    check_streaming: "Streaming",
+    check_exercise_generation: "Exercise generation",
+    check_answer_analysis: "Answer analysis",
+    check_topic_review: "Topic review",
+    running_checks: "Running checks... | {}",
+    verdict_failed: "Some checks failed. You can change the model or continue anyway.",
+    verdict_warnings: "Model works, but shows warnings.",
+    verdict_ready: "Model is ready.",
+    running_diagnostics: "Running diagnostics...",
+    reasoning_suffix: ", {:.0}% reasoning",
+};
+
+const RU_MODEL_CHECK: ModelCheckLabels = ModelCheckLabels {
+    check_connectivity: "Соединение",
+    check_streaming: "Стриминг",
+    check_exercise_generation: "Генерация упражнений",
+    check_answer_analysis: "Анализ ответов",
+    check_topic_review: "Повторение темы",
+    running_checks: "Выполнение проверок... | {}",
+    verdict_failed: "Некоторые проверки не прошли. Можно сменить модель или продолжить.",
+    verdict_warnings: "Модель работает, но есть предупреждения.",
+    verdict_ready: "Модель готова.",
+    running_diagnostics: "Выполнение диагностики...",
+    reasoning_suffix: ", {:.0}% рассуждений",
 };
 
 static SUPPORTED_REPORT: [(&str, ReportLabels); 17] = [
@@ -342,6 +914,41 @@ pub fn get_docs_labels(lang: &str) -> DocsLabels {
     lookup(&SUPPORTED_DOCS, lang)
 }
 
+pub fn get_common_labels(lang: &str) -> CommonLabels {
+    match normalize_language_code(lang).as_str() {
+        "ru" => RU_COMMON,
+        _ => EN_COMMON,
+    }
+}
+
+pub fn get_onboarding_labels(lang: &str) -> OnboardingLabels {
+    match normalize_language_code(lang).as_str() {
+        "ru" => RU_ONBOARDING,
+        _ => EN_ONBOARDING,
+    }
+}
+
+pub fn get_settings_labels(lang: &str) -> SettingsLabels {
+    match normalize_language_code(lang).as_str() {
+        "ru" => RU_SETTINGS,
+        _ => EN_SETTINGS,
+    }
+}
+
+pub fn get_update_labels(lang: &str) -> UpdateLabels {
+    match normalize_language_code(lang).as_str() {
+        "ru" => RU_UPDATE,
+        _ => EN_UPDATE,
+    }
+}
+
+pub fn get_model_check_labels(lang: &str) -> ModelCheckLabels {
+    match normalize_language_code(lang).as_str() {
+        "ru" => RU_MODEL_CHECK,
+        _ => EN_MODEL_CHECK,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -369,5 +976,49 @@ mod tests {
         for (code, _) in SUPPORTED_REPORT {
             assert!(!get_report_labels(code).session_report.is_empty());
         }
+    }
+
+    #[test]
+    fn common_labels_localized() {
+        assert_eq!(get_common_labels("ru").help, "помощь");
+        assert_eq!(get_common_labels("en").help, "help");
+        assert_eq!(get_common_labels("unknown").help, "help");
+    }
+
+    #[test]
+    fn onboarding_labels_localized() {
+        assert_eq!(
+            get_onboarding_labels("ru").step_age,
+            "Возраст (необязательно)"
+        );
+        assert_eq!(get_onboarding_labels("en").step_age, "Age (optional)");
+        assert_eq!(get_onboarding_labels("unknown").step_age, "Age (optional)");
+    }
+
+    #[test]
+    fn settings_labels_localized() {
+        assert_eq!(get_settings_labels("ru").section_data, "Данные");
+        assert_eq!(get_settings_labels("en").section_data, "Data");
+        assert_eq!(get_settings_labels("unknown").section_data, "Data");
+    }
+
+    #[test]
+    fn update_labels_localized() {
+        assert_eq!(get_update_labels("ru").title, "Доступно обновление");
+        assert_eq!(get_update_labels("en").title, "Update available");
+        assert_eq!(get_update_labels("unknown").title, "Update available");
+    }
+
+    #[test]
+    fn model_check_labels_localized() {
+        assert_eq!(get_model_check_labels("ru").verdict_ready, "Модель готова.");
+        assert_eq!(
+            get_model_check_labels("en").verdict_ready,
+            "Model is ready."
+        );
+        assert_eq!(
+            get_model_check_labels("unknown").verdict_ready,
+            "Model is ready."
+        );
     }
 }

--- a/src/ui/views/curriculum.rs
+++ b/src/ui/views/curriculum.rs
@@ -13,7 +13,7 @@ use crate::llm::factory::create_llm_model;
 use crate::llm::pipeline::generate_curriculum as generate_curriculum_llm;
 use crate::llm::prompts::build_curriculum_extension_prompt;
 use crate::ui::colors;
-use crate::ui::labels::{get_report_labels, native_language_code};
+use crate::ui::labels::{get_common_labels, get_report_labels, native_language_code};
 use crate::ui::views::docs;
 use crate::ui::views::utils::{select_next_wrapping, select_previous_wrapping};
 use crate::ui::widgets::{build_footer, draw_confirmation, mouse_footer_entries};
@@ -102,6 +102,7 @@ impl CurriculumState {
 pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut AppState) {
     if state.curriculum.loading {
         let labels = get_report_labels(native_language_code(state.config.as_ref()));
+        let common = get_common_labels(native_language_code(state.config.as_ref()));
         let accent = colors::BLUE;
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -142,7 +143,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                 .curriculum_progress
                 .get(&level)
                 .cloned()
-                .unwrap_or_else(|| "waiting...".to_string());
+                .unwrap_or_else(|| labels.waiting.to_string());
             lines.push(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(level, Style::default().fg(accent)),
@@ -157,7 +158,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         );
 
         frame.render_widget(
-            Paragraph::new(build_footer(&[("Esc", labels.cancel), ("?", "help")]))
+            Paragraph::new(build_footer(&[("Esc", labels.cancel), ("?", common.help)]))
                 .style(Style::default().fg(Color::DarkGray)),
             chunks[2],
         );
@@ -165,26 +166,27 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     }
 
     if state.curriculum.pending_reset {
+        let labels = get_report_labels(native_language_code(state.config.as_ref()));
+        let common = get_common_labels(native_language_code(state.config.as_ref()));
         draw_confirmation(
             frame,
             area,
-            "Regenerate Curriculum",
-            "This will delete the current curriculum, all progress scores, and topic reviews.\nAre you sure?",
-            "y: confirm | n/Esc: cancel",
+            labels.regenerate_curriculum_title,
+            labels.regenerate_curriculum_msg,
+            common.confirm_keys,
         );
         return;
     }
 
     if let Some(topic) = &state.curriculum.pending_delete {
+        let labels = get_report_labels(native_language_code(state.config.as_ref()));
+        let common = get_common_labels(native_language_code(state.config.as_ref()));
         draw_confirmation(
             frame,
             area,
-            "Delete Topic",
-            &format!(
-                "Delete \"{}\" and its progress/review?\nThis cannot be undone.",
-                topic.name
-            ),
-            "y: confirm | n/Esc: cancel",
+            labels.delete_topic_title,
+            &labels.delete_topic_msg.replacen("{}", &topic.name, 1),
+            common.confirm_keys,
         );
         return;
     }
@@ -264,6 +266,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     frame.render_stateful_widget(list, chunks[1], &mut state.curriculum.list_state);
 
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
+    let common = get_common_labels(native_language_code(state.config.as_ref()));
     let sort_label = match state.curriculum.sort_by {
         CurriculumSortBy::Progression => labels.sort_progression,
         CurriculumSortBy::Score => labels.sort_score,
@@ -272,7 +275,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         build_footer(&[
             ("g", labels.generate_label),
             ("Esc", labels.back),
-            ("?", "help"),
+            ("?", common.help),
         ])
     } else {
         let sort_entry = format!("{} ({})", labels.sort, sort_label);
@@ -286,7 +289,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         entries.push(("x", labels.delete_label));
         entries.push(("r", labels.reset_label));
         entries.push(("Esc", labels.back));
-        entries.push(("?", "help"));
+        entries.push(("?", common.help));
         build_footer(&entries)
     };
     frame.render_widget(
@@ -415,7 +418,8 @@ pub async fn generate_curriculum(state: &mut AppState) -> Result<()> {
 
     state.curriculum.loading = true;
     state.curriculum.pending_reset = false;
-    state.stream_status = Some("Generating curriculum plan...".to_string());
+    let labels = get_report_labels(native_language_code(state.config.as_ref()));
+    state.stream_status = Some(labels.generating_plan.to_string());
     state.curriculum_progress.clear();
 
     let tx = state.llm_tx.clone();

--- a/src/ui/views/dashboard.rs
+++ b/src/ui/views/dashboard.rs
@@ -17,7 +17,7 @@ use crate::core::session::{get_due_review_topics, get_weak_review_topics};
 use crate::db::curriculum::Topic;
 use crate::error::Result;
 use crate::ui::colors;
-use crate::ui::labels::{ReportLabels, get_report_labels, native_language_code};
+use crate::ui::labels::{ReportLabels, get_common_labels, get_report_labels, native_language_code};
 use crate::ui::views::{docs, session};
 use crate::ui::widgets::activity_calendar;
 use crate::ui::widgets::{HintBar, Logo, StackedProgressBar, mouse_footer_entries};
@@ -689,6 +689,7 @@ fn draw_weak_topics(buf: &mut Buffer, area: Rect, state: &AppState, labels: Repo
 }
 
 fn draw_hint_bar(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportLabels) {
+    let common = get_common_labels(native_language_code(state.config.as_ref()));
     let mut hints: Vec<(&str, &str)> = Vec::new();
     if state.dashboard.max_scroll > 0 {
         hints.extend(mouse_footer_entries(state.mouse_capture, &labels));
@@ -700,7 +701,7 @@ fn draw_hint_bar(buf: &mut Buffer, area: Rect, state: &AppState, labels: ReportL
         ("p", labels.pairs),
         ("s", labels.settings),
         ("q", labels.quit),
-        ("?", "help"),
+        ("?", common.help),
     ]);
     if state.dashboard.weak_visible_len() > 0 {
         hints.insert(0, ("Enter", labels.start_label));

--- a/src/ui/views/docs.rs
+++ b/src/ui/views/docs.rs
@@ -22,7 +22,10 @@ use crate::llm::factory::create_llm_model;
 use crate::llm::pipeline::generate_topic_review;
 use crate::llm::prompts::build_topic_review_prompt;
 use crate::ui::colors;
-use crate::ui::labels::{get_docs_labels, get_report_labels, native_language_code};
+use crate::ui::labels::{
+    DocsLabels, ReportLabels, get_common_labels, get_docs_labels, get_report_labels,
+    native_language_code,
+};
 use crate::ui::views::utils::{select_next_wrapping, select_previous_wrapping};
 use crate::ui::widgets::{OpenCourseStyleSheet, build_footer, mouse_footer_entries};
 
@@ -41,10 +44,10 @@ impl SortBy {
         }
     }
 
-    pub fn label(self) -> &'static str {
+    pub fn label(self, docs_labels: &DocsLabels, report_labels: &ReportLabels) -> &'static str {
         match self {
-            SortBy::Score => "score",
-            SortBy::LastPracticed => "last practiced",
+            SortBy::Score => report_labels.sort_score,
+            SortBy::LastPracticed => docs_labels.sort_last_practiced,
         }
     }
 }
@@ -153,6 +156,8 @@ fn sort_topics(state: &mut AppState, progress: &HashMap<String, ProgressTopic>) 
 
 pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut AppState) {
     let labels = get_docs_labels(native_language_code(state.config.as_ref()));
+    let report_labels = get_report_labels(native_language_code(state.config.as_ref()));
+    let common = get_common_labels(native_language_code(state.config.as_ref()));
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -178,7 +183,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                     "{} ({}: {})",
                     topic.name,
                     labels.sort,
-                    state.docs.sort_by.label()
+                    state.docs.sort_by.label(&labels, &report_labels)
                 ),
                 Style::default().fg(Color::DarkGray),
             )),
@@ -204,23 +209,22 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
 
         frame.render_widget(body, chunks[1]);
 
-        let report_labels = get_report_labels(native_language_code(state.config.as_ref()));
         let help = if state.docs.content.is_empty() {
             build_footer(&[
-                ("Esc", "back to list"),
+                ("Esc", common.back_to_list),
                 ("e", labels.regenerate),
                 ("p", labels.practice),
-                ("?", "help"),
+                ("?", common.help),
             ])
         } else {
             let mut entries = vec![("↑/↓", report_labels.wheel_scroll)];
             if state.docs.max_scroll_offset > 0 {
                 entries.extend(mouse_footer_entries(state.mouse_capture, &report_labels));
             }
-            entries.push(("Esc", "back to list"));
+            entries.push(("Esc", common.back_to_list));
             entries.push(("e", labels.regenerate));
             entries.push(("p", labels.practice));
-            entries.push(("?", "help"));
+            entries.push(("?", common.help));
             build_footer(&entries)
         };
         frame.render_widget(
@@ -241,7 +245,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                     "{} ({}: {})",
                     labels.select_topic,
                     labels.sort,
-                    state.docs.sort_by.label()
+                    state.docs.sort_by.label(&labels, &report_labels)
                 ),
                 Style::default().fg(Color::DarkGray),
             )),
@@ -252,7 +256,8 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         let body = if state.docs.loading {
             Paragraph::new(loading_message).style(Style::default().fg(colors::YELLOW))
         } else if state.docs.topics.is_empty() {
-            Paragraph::new("No topics available.").style(Style::default().fg(Color::DarkGray))
+            Paragraph::new(report_labels.no_topics_available)
+                .style(Style::default().fg(Color::DarkGray))
         } else {
             Paragraph::new("")
         };
@@ -277,16 +282,15 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
             state.docs.list_overflows = false;
         }
 
-        let report_labels = get_report_labels(native_language_code(state.config.as_ref()));
-        let mut entries: Vec<(&str, &str)> = vec![("↑/↓", "navigate")];
+        let mut entries: Vec<(&str, &str)> = vec![("↑/↓", common.navigate)];
         if state.docs.list_overflows {
             entries.extend(mouse_footer_entries(state.mouse_capture, &report_labels));
         }
-        entries.push(("s", "sort"));
-        entries.push(("Enter", "view"));
+        entries.push(("s", common.sort));
+        entries.push(("Enter", common.view));
         entries.push(("p", labels.practice));
-        entries.push(("Esc", "back"));
-        entries.push(("?", "help"));
+        entries.push(("Esc", common.back));
+        entries.push(("?", common.help));
         frame.render_widget(
             Paragraph::new(build_footer(&entries)).style(Style::default().fg(Color::DarkGray)),
             chunks[2],

--- a/src/ui/views/model_check.rs
+++ b/src/ui/views/model_check.rs
@@ -12,7 +12,10 @@ use crate::llm::diagnostics::{
 };
 use crate::llm::factory::create_llm_model;
 use crate::ui::colors;
-use crate::ui::labels::{get_report_labels, native_language_code};
+use crate::ui::labels::{
+    ModelCheckLabels, get_common_labels, get_model_check_labels, get_report_labels,
+    native_language_code,
+};
 use crate::ui::widgets::build_footer;
 
 #[derive(Debug, Clone, Default)]
@@ -37,39 +40,40 @@ impl ModelCheckState {
 }
 
 pub fn start(state: &mut AppState, config: OpenCourseConfig, return_to: View) {
+    let mc = get_model_check_labels(native_language_code(state.config.as_ref()));
     state.model_check = ModelCheckState {
         checks: vec![
             CheckResult {
                 id: "connectivity",
-                label: "Connectivity".to_string(),
+                label: mc.check_connectivity.to_string(),
                 status: CheckStatus::Pending,
                 duration_ms: 0,
                 reasoning_ratio: None,
             },
             CheckResult {
                 id: "streaming",
-                label: "Streaming".to_string(),
+                label: mc.check_streaming.to_string(),
                 status: CheckStatus::Pending,
                 duration_ms: 0,
                 reasoning_ratio: None,
             },
             CheckResult {
                 id: "exercises",
-                label: "Exercise generation".to_string(),
+                label: mc.check_exercise_generation.to_string(),
                 status: CheckStatus::Pending,
                 duration_ms: 0,
                 reasoning_ratio: None,
             },
             CheckResult {
                 id: "analysis",
-                label: "Answer analysis".to_string(),
+                label: mc.check_answer_analysis.to_string(),
                 status: CheckStatus::Pending,
                 duration_ms: 0,
                 reasoning_ratio: None,
             },
             CheckResult {
                 id: "topic_review",
-                label: "Topic review".to_string(),
+                label: mc.check_topic_review.to_string(),
                 status: CheckStatus::Pending,
                 duration_ms: 0,
                 reasoning_ratio: None,
@@ -87,7 +91,7 @@ pub fn start(state: &mut AppState, config: OpenCourseConfig, return_to: View) {
             Err(e) => {
                 let _ = tx.try_send(LlmResult::DiagnosticUpdate(CheckResult {
                     id: "connectivity",
-                    label: "Connectivity".to_string(),
+                    label: mc.check_connectivity.to_string(),
                     status: CheckStatus::Failed(e.to_string()),
                     duration_ms: 0,
                     reasoning_ratio: None,
@@ -106,26 +110,31 @@ pub fn start(state: &mut AppState, config: OpenCourseConfig, return_to: View) {
 }
 
 pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut AppState) {
+    let lang = native_language_code(state.config.as_ref());
+    let mc = get_model_check_labels(lang);
+    let common = get_common_labels(lang);
+
     let footer = if state.model_check.running {
-        format!("Running checks... | {}", build_footer(&[("?", "help")]))
+        mc.running_checks
+            .replacen("{}", &build_footer(&[("?", common.help)]), 1)
     } else {
         let (has_failed, has_warning) = model_check_verdict(&state.model_check.checks);
         let verdict = if has_failed {
-            "Some checks failed. You can change the model or continue anyway."
+            mc.verdict_failed
         } else if has_warning {
-            "Model works, but shows warnings."
+            mc.verdict_warnings
         } else {
-            "Model is ready."
+            mc.verdict_ready
         };
         format!(
             "{} | {}",
             verdict,
             build_footer(&[
-                ("Enter/c", "continue"),
-                ("Esc/b", "back to model list"),
-                ("r", "retry"),
-                ("s", "skip"),
-                ("?", "help"),
+                ("Enter/c", common.continue_label),
+                ("Esc/b", common.back_to_model_list),
+                ("r", common.retry),
+                ("s", common.skip),
+                ("?", common.help),
             ])
         )
     };
@@ -150,11 +159,11 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
 
     let mut lines: Vec<Line> = Vec::new();
     if state.model_check.checks.is_empty() {
-        lines.push(Line::from("Running diagnostics...").style(Style::default().fg(colors::YELLOW)));
+        lines.push(Line::from(mc.running_diagnostics).style(Style::default().fg(colors::YELLOW)));
     } else {
         let spinner_symbol = state.spinner.symbol();
         for check in &state.model_check.checks {
-            lines.push(render_check_line(check, spinner_symbol));
+            lines.push(render_check_line(check, spinner_symbol, &mc));
         }
     }
     frame.render_widget(Paragraph::new(Text::from(lines)), chunks[1]);
@@ -165,7 +174,11 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     );
 }
 
-fn render_check_line<'a>(check: &'a CheckResult, spinner_symbol: &'a str) -> Line<'a> {
+fn render_check_line<'a>(
+    check: &'a CheckResult,
+    spinner_symbol: &'a str,
+    mc: &ModelCheckLabels,
+) -> Line<'a> {
     let verdict = check.verdict(Some(spinner_symbol));
     let mut spans = vec![
         Span::styled(verdict, status_style(&check.status)),
@@ -179,7 +192,10 @@ fn render_check_line<'a>(check: &'a CheckResult, spinner_symbol: &'a str) -> Lin
         )));
     }
     if let Some(ratio) = check.reasoning_ratio {
-        spans.push(Span::raw(format!(", {:.0}% reasoning", ratio * 100.0)));
+        spans.push(Span::raw(
+            mc.reasoning_suffix
+                .replace("{:.0}", &format!("{:.0}", ratio * 100.0)),
+        ));
     }
     if let Some(msg) = check.status.message() {
         spans.push(Span::raw("\n  "));

--- a/src/ui/views/onboarding/mod.rs
+++ b/src/ui/views/onboarding/mod.rs
@@ -15,6 +15,7 @@ use crate::config::{OpenCourseConfig, write_config};
 use crate::error::{AppError, Result};
 use crate::llm::provider::ProviderMeta;
 use crate::ui::colors;
+use crate::ui::labels::{get_common_labels, get_onboarding_labels, native_language_code};
 use crate::ui::views::model_check;
 use crate::ui::widgets::Logo;
 use crate::ui::widgets::build_footer;
@@ -33,52 +34,57 @@ fn display_input(input: &str, step: Step) -> String {
 }
 
 pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut AppState) {
+    let lang = native_language_code(state.config.as_ref());
+    let labels = get_onboarding_labels(lang);
+    let common = get_common_labels(lang);
     let step = state.onboarding.current_step();
     let footer_text = match step {
         Step::Provider => build_footer(&[
-            ("↑/↓", "select provider"),
-            ("Enter", "next"),
-            ("Esc", "quit"),
-            ("?", "help"),
+            ("↑/↓", common.select_provider),
+            ("Enter", common.next),
+            ("Esc", common.quit),
+            ("?", common.help),
         ]),
         Step::Cefr => build_footer(&[
-            ("↑/↓", "select level"),
-            ("Enter", "next"),
-            ("Esc", "quit"),
-            ("?", "help"),
+            ("↑/↓", common.select_level),
+            ("Enter", common.next),
+            ("Esc", common.quit),
+            ("?", common.help),
         ]),
         Step::BatchSize => build_footer(&[
-            ("↑/↓", "select batch size"),
-            ("Enter", "next"),
-            ("Esc", "quit"),
-            ("?", "help"),
+            ("↑/↓", common.select_batch_size),
+            ("Enter", common.next),
+            ("Esc", common.quit),
+            ("?", common.help),
         ]),
-        Step::Model if state.onboarding.model_picker.loading => format!(
-            "Loading models... | {}",
-            build_footer(&[("Esc", "quit"), ("?", "help")])
+        Step::Model if state.onboarding.model_picker.loading => labels.loading_models.replace(
+            "{}",
+            &build_footer(&[("Esc", common.quit), ("?", common.help)]),
         ),
         Step::Model if state.onboarding.model_picker.error.is_some() => build_footer(&[
-            ("r", "retry"),
-            ("m", "manual"),
-            ("Esc", "quit"),
-            ("?", "help"),
+            ("r", common.retry),
+            ("m", common.manual),
+            ("Esc", common.quit),
+            ("?", common.help),
         ]),
-        Step::Model if state.onboarding.model_picker.manual => {
-            build_footer(&[("Type", "model ID"), ("Enter", "next"), ("Esc", "quit")])
-        }
+        Step::Model if state.onboarding.model_picker.manual => build_footer(&[
+            (common.type_hint, common.model_id),
+            ("Enter", common.next),
+            ("Esc", common.quit),
+        ]),
         Step::Model if !state.onboarding.model_picker.models.is_empty() => build_footer(&[
-            ("↑/↓", "select model"),
-            ("Enter", "next"),
-            ("Esc", "quit"),
-            ("?", "help"),
+            ("↑/↓", common.select_model),
+            ("Enter", common.next),
+            ("Esc", common.quit),
+            ("?", common.help),
         ]),
         Step::BaseUrl if !steps::shows_base_url_step(state.onboarding.provider) => {
-            build_footer(&[("Enter", "next"), ("Esc", "quit")])
+            build_footer(&[("Enter", common.next), ("Esc", common.quit)])
         }
         _ => build_footer(&[
-            ("Tab/Enter", "next"),
-            ("Shift+Tab", "prev"),
-            ("Esc", "quit"),
+            ("Tab/Enter", common.next),
+            ("Shift+Tab", common.prev),
+            ("Esc", common.quit),
         ]),
     };
     let mut footer_lines = vec![Line::from(footer_text)];
@@ -118,17 +124,17 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
 
     let subtitle = Text::from(vec![
         Line::from(Span::styled(
-            "Set up your language learning profile",
+            labels.setup_subtitle,
             Style::default()
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(Span::styled(
             build_footer(&[
-                ("Tab/Enter", "continue"),
-                ("Shift+Tab", "prev"),
-                ("Esc", "quit"),
-                ("↑/↓", "select lists"),
+                ("Tab/Enter", common.continue_label),
+                ("Shift+Tab", common.prev),
+                ("Esc", common.quit),
+                ("↑/↓", labels.select_lists),
             ]),
             Style::default().fg(Color::DarkGray),
         )),
@@ -148,8 +154,11 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         .position(|s| *s == step)
         .map(|i| i + 1)
         .unwrap_or(1);
-    let progress = format!("Step {} of {}", current_position, visible_steps.len());
-    let title = format!("{} — {}", step.label(), progress);
+    let progress = labels
+        .step_progress
+        .replacen("{}", &current_position.to_string(), 1)
+        .replacen("{}", &visible_steps.len().to_string(), 1);
+    let title = format!("{} — {}", step.label(lang), progress);
     let card_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(accent))
@@ -217,10 +226,10 @@ fn render_model_step(
     area: ratatui::layout::Rect,
     state: &mut AppState,
 ) {
+    let labels = get_onboarding_labels(native_language_code(state.config.as_ref()));
     if state.onboarding.model_picker.loading {
         frame.render_widget(
-            Paragraph::new("Fetching available models from provider...")
-                .style(Style::default().fg(colors::YELLOW)),
+            Paragraph::new(labels.fetching_models).style(Style::default().fg(colors::YELLOW)),
             area,
         );
         return;
@@ -228,11 +237,8 @@ fn render_model_step(
 
     if let Some(err) = &state.onboarding.model_picker.error {
         frame.render_widget(
-            Paragraph::new(format!(
-                "Failed to load models:\n{}\n\nr: retry | m: enter manually",
-                err
-            ))
-            .style(Style::default().fg(Color::Red)),
+            Paragraph::new(labels.failed_load_models.replace("{}", err))
+                .style(Style::default().fg(Color::Red)),
             area,
         );
         return;
@@ -240,10 +246,7 @@ fn render_model_step(
 
     if state.onboarding.model_picker.manual {
         frame.render_widget(
-            Paragraph::new(
-                "Enter model ID manually\n(e.g. gpt-4o-mini, claude-3-5-sonnet-20241022)",
-            )
-            .style(Style::default().fg(Color::White)),
+            Paragraph::new(labels.enter_model_manually).style(Style::default().fg(Color::White)),
             area,
         );
         return;
@@ -251,8 +254,7 @@ fn render_model_step(
 
     if state.onboarding.model_picker.models.is_empty() {
         frame.render_widget(
-            Paragraph::new("No models found.\nr: retry | m: enter manually")
-                .style(Style::default().fg(Color::White)),
+            Paragraph::new(labels.no_models_found).style(Style::default().fg(Color::White)),
             area,
         );
         return;
@@ -260,16 +262,16 @@ fn render_model_step(
 
     let selected = state.onboarding.model_picker.selected;
     let total = state.onboarding.model_picker.models.len();
-    let info = format!(
-        "Model {} of {} (m: manual, r: retry, Esc: quit)",
-        selected + 1,
-        total
-    );
+    let info = labels
+        .model_picker_info
+        .replacen("{}", &(selected + 1).to_string(), 1)
+        .replacen("{}", &total.to_string(), 1);
     model_picker::draw_model_list(frame, area, &state.onboarding.model_picker, Some(&info));
 }
 
 async fn advance_onboarding(state: &mut AppState) -> Result<()> {
-    if let Err(e) = state.onboarding.apply_input() {
+    let lang = native_language_code(state.config.as_ref());
+    if let Err(e) = state.onboarding.apply_input(lang) {
         state.onboarding.error = e.to_string();
         return Ok(());
     }

--- a/src/ui/views/onboarding/state.rs
+++ b/src/ui/views/onboarding/state.rs
@@ -2,6 +2,7 @@ use crate::config::provider::ProviderId;
 use crate::core::language::{is_valid_language_code, normalize_language_code};
 use crate::db::curriculum::CEFR_LEVELS;
 use crate::error::{AppError, Result};
+use crate::ui::labels::get_onboarding_labels;
 use crate::ui::widgets::model_picker::ModelPickerState;
 
 use super::steps::{Step, base_url_default, shows_base_url_step};
@@ -149,7 +150,8 @@ impl OnboardingState {
         self.error.clear();
     }
 
-    pub(super) fn apply_input(&mut self) -> Result<()> {
+    pub(super) fn apply_input(&mut self, lang: &str) -> Result<()> {
+        let labels = get_onboarding_labels(lang);
         let value = self.input.trim().to_string();
         match self.current_step() {
             Step::Provider => {
@@ -161,34 +163,34 @@ impl OnboardingState {
             Step::ApiKey => self.api_key = value,
             Step::BaseUrl => {
                 if shows_base_url_step(self.provider) && value.is_empty() {
-                    return Err(AppError::Config(
-                        "Base URL is required for this provider".to_string(),
-                    ));
+                    return Err(AppError::Config(labels.err_base_url_required.to_string()));
                 }
                 self.base_url = value;
             }
             Step::Model => {
                 if value.is_empty() {
-                    return Err(AppError::Config("Model is required".to_string()));
+                    return Err(AppError::Config(labels.err_model_required.to_string()));
                 }
                 self.model = value;
             }
             Step::NativeLanguage => {
                 let norm = normalize_language_code(&value);
                 if !is_valid_language_code(&norm) {
-                    return Err(AppError::Config(format!("Invalid language code: {value}")));
+                    return Err(AppError::Config(
+                        labels.err_invalid_language.replace("{value}", &value),
+                    ));
                 }
                 self.native_language = norm;
             }
             Step::TargetLanguage => {
                 let norm = normalize_language_code(&value);
                 if !is_valid_language_code(&norm) {
-                    return Err(AppError::Config(format!("Invalid language code: {value}")));
+                    return Err(AppError::Config(
+                        labels.err_invalid_language.replace("{value}", &value),
+                    ));
                 }
                 if norm == self.native_language {
-                    return Err(AppError::Config(
-                        "Target language must differ from native language".to_string(),
-                    ));
+                    return Err(AppError::Config(labels.err_languages_differ.to_string()));
                 }
                 self.target_language = norm;
             }
@@ -199,29 +201,35 @@ impl OnboardingState {
                     match value.parse::<u32>() {
                         Ok(age) if (1..=120).contains(&age) => self.age = age.to_string(),
                         _ => {
-                            return Err(AppError::Config(format!(
-                                "Age must be a number between 1 and 120: {value}"
-                            )));
+                            return Err(AppError::Config(
+                                labels.err_invalid_age.replace("{value}", &value),
+                            ));
                         }
                     }
                 }
             }
             Step::Cefr => {
                 if value.is_empty() {
-                    return Err(AppError::Config("CEFR level is required".to_string()));
+                    return Err(AppError::Config(labels.err_cefr_required.to_string()));
                 }
                 if !CEFR_LEVELS.contains(&value.to_uppercase().as_str()) {
-                    return Err(AppError::Config(format!("Invalid CEFR level: {value}")));
+                    return Err(AppError::Config(
+                        labels.err_invalid_cefr.replace("{value}", &value),
+                    ));
                 }
                 self.cefr = value.to_uppercase();
             }
             Step::BatchSize => {
                 if value.is_empty() {
-                    return Err(AppError::Config("Batch size is required".to_string()));
+                    return Err(AppError::Config(labels.err_batch_required.to_string()));
                 }
                 match value.parse::<u32>() {
                     Ok(n) if (2..=5).contains(&n) => self.batch_size = n,
-                    _ => return Err(AppError::Config(format!("Batch size must be 2-5: {value}"))),
+                    _ => {
+                        return Err(AppError::Config(
+                            labels.err_batch_range.replace("{value}", &value),
+                        ));
+                    }
                 }
             }
         }

--- a/src/ui/views/onboarding/steps.rs
+++ b/src/ui/views/onboarding/steps.rs
@@ -6,6 +6,7 @@ use crate::config::provider::ProviderId;
 use crate::db::curriculum::CEFR_LEVELS;
 use crate::llm::provider::ProviderMeta;
 use crate::ui::colors;
+use crate::ui::labels::{OnboardingLabels, get_onboarding_labels, native_language_code};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Step {
@@ -21,17 +22,18 @@ pub enum Step {
 }
 
 impl Step {
-    pub(super) fn label(&self) -> &'static str {
+    pub(super) fn label(&self, lang: &str) -> &'static str {
+        let labels = get_onboarding_labels(lang);
         match self {
-            Step::NativeLanguage => "Native language (e.g. en)",
-            Step::TargetLanguage => "Target language (e.g. es)",
-            Step::Age => "Age (optional)",
-            Step::Cefr => "CEFR level (required)",
-            Step::BatchSize => "Batch size (required)",
-            Step::Provider => "Select provider",
-            Step::ApiKey => "Enter API key",
-            Step::BaseUrl => "Enter base URL",
-            Step::Model => "Select model",
+            Step::NativeLanguage => labels.step_native_language,
+            Step::TargetLanguage => labels.step_target_language,
+            Step::Age => labels.step_age,
+            Step::Cefr => labels.step_cefr,
+            Step::BatchSize => labels.step_batch_size,
+            Step::Provider => labels.step_provider,
+            Step::ApiKey => labels.step_api_key,
+            Step::BaseUrl => labels.step_base_url,
+            Step::Model => labels.step_model,
         }
     }
 
@@ -72,16 +74,13 @@ pub(super) fn is_text_step(step: Step) -> bool {
 }
 
 pub(super) fn step_help_text(step: Step, state: &AppState) -> String {
+    let labels = get_onboarding_labels(native_language_code(state.config.as_ref()));
     match step {
-        Step::ApiKey => api_key_help(state),
-        Step::BaseUrl => base_url_help(state),
-        Step::NativeLanguage => {
-            "Enter your native language code (ISO 639-1, e.g. en, ru)".to_string()
-        }
-        Step::TargetLanguage => {
-            "Enter the language you want to learn (ISO 639-1, e.g. es, de)".to_string()
-        }
-        Step::Age => "Enter your age (optional, used to pick age-appropriate contexts)".to_string(),
+        Step::ApiKey => api_key_help(state, labels),
+        Step::BaseUrl => base_url_help(state, labels),
+        Step::NativeLanguage => labels.help_native_language.to_string(),
+        Step::TargetLanguage => labels.help_target_language.to_string(),
+        Step::Age => labels.help_age.to_string(),
         _ => String::new(),
     }
 }
@@ -89,12 +88,11 @@ pub(super) fn step_help_text(step: Step, state: &AppState) -> String {
 /// Options list for selector steps (provider, CEFR, batch size) with the
 /// currently selected option highlighted in the design-system green.
 pub(super) fn step_selector_text(step: Step, state: &AppState) -> Text<'static> {
+    let labels = get_onboarding_labels(native_language_code(state.config.as_ref()));
     let intro = match step {
-        Step::Provider => "Available providers:",
-        Step::Cefr => {
-            "Select your CEFR level (required). Pick the level that best matches your current ability (self-assessment):"
-        }
-        Step::BatchSize => "Select batch size — number of exercises per session (required):",
+        Step::Provider => labels.intro_providers,
+        Step::Cefr => labels.intro_cefr,
+        Step::BatchSize => labels.intro_batch_size,
         _ => "",
     };
     let options: Vec<(String, bool)> = match step {
@@ -138,41 +136,34 @@ pub(super) fn step_selector_text(step: Step, state: &AppState) -> Text<'static> 
     Text::from(lines)
 }
 
-fn api_key_help(state: &AppState) -> String {
+fn api_key_help(state: &AppState, labels: OnboardingLabels) -> String {
     let meta = ProviderMeta::for_provider(state.onboarding.provider);
     let env_note = match meta.env_key {
         Some(name) if std::env::var(name).is_ok() => {
-            format!("\n{name} is set in your environment and will be used if you leave this blank.")
+            format!("\n{}", labels.env_var_set.replace("{name}", name))
         }
-        Some(name) => format!("\nYou can also set the {name} environment variable instead."),
+        Some(name) => format!("\n{}", labels.env_var_hint.replace("{name}", name)),
         None => String::new(),
     };
-    if meta.requires_api_key && !meta.api_key_optional {
-        format!(
-            "Enter API key for {}\n(required){}",
-            state.onboarding.provider.label(),
-            env_note
-        )
+    let template = if meta.requires_api_key && !meta.api_key_optional {
+        labels.api_key_required
     } else {
-        format!(
-            "Enter API key for {}\n(optional — press Enter to skip){}",
-            state.onboarding.provider.label(),
-            env_note
-        )
-    }
+        labels.api_key_optional
+    };
+    template
+        .replacen("{}", state.onboarding.provider.label(), 1)
+        .replacen("{}", &env_note, 1)
 }
 
-fn base_url_help(state: &AppState) -> String {
+fn base_url_help(state: &AppState, labels: OnboardingLabels) -> String {
     if shows_base_url_step(state.onboarding.provider) {
-        format!(
-            "Enter API base URL for {}\n(e.g. {})",
-            state.onboarding.provider.label(),
-            base_url_default(state.onboarding.provider)
-        )
+        labels
+            .base_url_prompt
+            .replacen("{}", state.onboarding.provider.label(), 1)
+            .replacen("{}", base_url_default(state.onboarding.provider), 1)
     } else {
-        format!(
-            "Base URL is not required for {}.\nPress Enter to continue.",
-            state.onboarding.provider.label()
-        )
+        labels
+            .base_url_not_required
+            .replacen("{}", state.onboarding.provider.label(), 1)
     }
 }

--- a/src/ui/views/pairs.rs
+++ b/src/ui/views/pairs.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{List, ListItem, Paragraph};
 use crate::app::{AppState, View};
 use crate::error::Result;
 use crate::ui::colors;
-use crate::ui::labels::{get_report_labels, native_language_code};
+use crate::ui::labels::{get_common_labels, get_report_labels, native_language_code};
 use crate::ui::views::onboarding;
 use crate::ui::widgets::build_footer;
 
@@ -34,6 +34,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         .split(area);
 
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
+    let common = get_common_labels(native_language_code(state.config.as_ref()));
 
     frame.render_widget(
         Paragraph::new(Text::from(vec![
@@ -93,7 +94,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         ("Enter", labels.switch),
         ("a", labels.add_pair),
         ("Esc", labels.back),
-        ("?", "help"),
+        ("?", common.help),
     ]);
     frame.render_widget(
         Paragraph::new(hint).style(Style::default().fg(Color::DarkGray)),

--- a/src/ui/views/report.rs
+++ b/src/ui/views/report.rs
@@ -10,7 +10,7 @@ use crate::core::session::{AnalysisResult, MentorSession, SemanticVerdict};
 use crate::db::curriculum::Topic;
 use crate::error::Result;
 use crate::ui::colors;
-use crate::ui::labels::{ReportLabels, get_report_labels, native_language_code};
+use crate::ui::labels::{ReportLabels, get_common_labels, get_report_labels, native_language_code};
 use crate::ui::views::{docs, session};
 use crate::ui::widgets::{build_footer, mouse_footer_entries};
 
@@ -81,6 +81,7 @@ impl ReportState {
 
 pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut AppState) {
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
+    let common = get_common_labels(native_language_code(state.config.as_ref()));
 
     let chunks: [Rect; 2] =
         Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(area);
@@ -102,11 +103,11 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     if state.report.max_scroll_offset > 0 {
         entries.extend(mouse_footer_entries(state.mouse_capture, &labels));
     }
-    entries.push(("n", "new topic"));
-    entries.push(("r", "repeat"));
-    entries.push(("d", "docs"));
-    entries.push(("Esc", "dashboard"));
-    entries.push(("?", "help"));
+    entries.push(("n", common.new_topic));
+    entries.push(("r", common.repeat));
+    entries.push(("d", labels.docs));
+    entries.push(("Esc", common.dashboard));
+    entries.push(("?", common.help));
 
     frame.render_widget(
         Paragraph::new(Line::from(build_footer(&entries)))
@@ -230,7 +231,7 @@ fn build_report_lines(report: &ReportState, labels: ReportLabels) -> Vec<Line<'s
             let alts = sentence.acceptable_translations.join("; ");
             lines.push(Line::from(vec![
                 Span::raw("   "),
-                Span::styled("Also acceptable: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(labels.also_acceptable, Style::default().fg(Color::DarkGray)),
                 Span::raw(alts),
             ]));
         }

--- a/src/ui/views/session.rs
+++ b/src/ui/views/session.rs
@@ -18,7 +18,7 @@ use crate::llm::pipeline::{
 };
 use crate::llm::prompts::{build_batch_analysis_prompt, build_exercise_prompt};
 use crate::ui::colors;
-use crate::ui::labels::{get_report_labels, native_language_code};
+use crate::ui::labels::{get_common_labels, get_report_labels, native_language_code};
 use crate::ui::views::curriculum;
 use crate::ui::views::utils::{
     screen_chunks, select_next_wrapping, select_previous_wrapping, wrapped_input_text,
@@ -65,6 +65,7 @@ impl SessionState {
 
 pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut AppState) {
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
+    let common = get_common_labels(native_language_code(state.config.as_ref()));
 
     if state.session.loading {
         let loading_chunks = Layout::default()
@@ -91,7 +92,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         );
 
         frame.render_widget(
-            Paragraph::new(build_footer(&[("Esc", labels.cancel), ("?", "help")]))
+            Paragraph::new(build_footer(&[("Esc", labels.cancel), ("?", common.help)]))
                 .style(Style::default().fg(Color::DarkGray)),
             loading_chunks[1],
         );
@@ -118,7 +119,15 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                     .session
                     .topics
                     .iter()
-                    .map(|topic| ListItem::new(format!("{} [{}]", topic.name, topic.difficulty)))
+                    .map(|topic| {
+                        let difficulty = match topic.difficulty.as_str() {
+                            "beginner" => labels.difficulty_beginner,
+                            "intermediate" => labels.difficulty_intermediate,
+                            "advanced" => labels.difficulty_advanced,
+                            _ => topic.difficulty.as_str(),
+                        };
+                        ListItem::new(format!("{} [{}]", topic.name, difficulty))
+                    })
                     .collect()
             };
 
@@ -135,7 +144,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                     ("↑↓", labels.navigate),
                     ("Enter", labels.start_session),
                     ("Esc", labels.back),
-                    ("?", "help"),
+                    ("?", common.help),
                 ]))
                 .style(Style::default().fg(Color::DarkGray)),
                 chunks[2],

--- a/src/ui/views/settings/data.rs
+++ b/src/ui/views/settings/data.rs
@@ -1,5 +1,6 @@
 use crate::app::AppState;
 use crate::error::Result;
+use crate::ui::labels::SettingsLabels;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResetAction {
@@ -11,35 +12,35 @@ pub enum ResetAction {
 }
 
 impl ResetAction {
-    pub fn label(&self) -> &'static str {
+    pub fn label(&self, labels: &SettingsLabels) -> &'static str {
         match self {
-            ResetAction::Progress => "reset progress",
-            ResetAction::History => "reset history",
-            ResetAction::Curriculum => "reset curriculum",
-            ResetAction::Reviews => "reset reviews",
-            ResetAction::All => "reset all data",
+            ResetAction::Progress => labels.reset_progress_action,
+            ResetAction::History => labels.reset_history_action,
+            ResetAction::Curriculum => labels.reset_curriculum_action,
+            ResetAction::Reviews => labels.reset_reviews_action,
+            ResetAction::All => labels.reset_all_action,
         }
     }
 
     /// Title of the field row in the Data section.
-    pub fn field_label(&self) -> &'static str {
+    pub fn field_label(&self, labels: &SettingsLabels) -> &'static str {
         match self {
-            ResetAction::Progress => "Reset progress",
-            ResetAction::History => "Reset history",
-            ResetAction::Curriculum => "Reset curriculum",
-            ResetAction::Reviews => "Reset reviews",
-            ResetAction::All => "Reset all",
+            ResetAction::Progress => labels.reset_progress_title,
+            ResetAction::History => labels.reset_history_title,
+            ResetAction::Curriculum => labels.reset_curriculum_title,
+            ResetAction::Reviews => labels.reset_reviews_title,
+            ResetAction::All => labels.reset_all_title,
         }
     }
 
     /// Description shown as the field value in the Data section.
-    pub fn description(&self) -> &'static str {
+    pub fn description(&self, labels: &SettingsLabels) -> &'static str {
         match self {
-            ResetAction::Progress => "Clear all progress scores",
-            ResetAction::History => "Clear all session history",
-            ResetAction::Curriculum => "Clear all curriculum topics",
-            ResetAction::Reviews => "Clear all topic reviews",
-            ResetAction::All => "Clear all data",
+            ResetAction::Progress => labels.reset_progress_desc,
+            ResetAction::History => labels.reset_history_desc,
+            ResetAction::Curriculum => labels.reset_curriculum_desc,
+            ResetAction::Reviews => labels.reset_reviews_desc,
+            ResetAction::All => labels.reset_all_desc,
         }
     }
 

--- a/src/ui/views/settings/fields.rs
+++ b/src/ui/views/settings/fields.rs
@@ -1,6 +1,7 @@
 use crate::config::OpenCourseConfig;
 use crate::config::write_config;
 use crate::error::{AppError, Result};
+use crate::ui::labels::{SettingsLabels, get_settings_labels, native_language_code};
 
 use super::data::ResetAction;
 use super::{Section, SettingsState};
@@ -11,29 +12,29 @@ use super::{Section, SettingsState};
 struct FieldDef {
     section: Section,
     index: usize,
-    label: &'static str,
+    label: fn(&SettingsLabels) -> &'static str,
     /// Whether typing goes into the input box (hint mode toggles instead).
     text_input: bool,
     /// Current value for display, with "(none)" placeholders.
-    display: fn(&OpenCourseConfig) -> String,
+    display: fn(&OpenCourseConfig, &SettingsLabels) -> String,
     /// Current value for the input box.
     load: fn(&OpenCourseConfig) -> String,
     /// Validates and stores the trimmed input value.
-    apply: fn(&mut OpenCourseConfig, &str) -> Result<()>,
+    apply: fn(&mut OpenCourseConfig, &str, &SettingsLabels) -> Result<()>,
 }
 
 static FIELDS: &[FieldDef] = &[
     FieldDef {
         section: Section::Profile,
         index: 0,
-        label: "Age",
+        label: |labels| labels.age_label,
         text_input: true,
-        display: |config: &OpenCourseConfig| {
+        display: |config: &OpenCourseConfig, labels: &SettingsLabels| {
             config
                 .active_profile()
                 .age
                 .map(|a| a.to_string())
-                .unwrap_or_else(|| "(none)".to_string())
+                .unwrap_or_else(|| labels.none_placeholder.to_string())
         },
         load: |config: &OpenCourseConfig| {
             config
@@ -42,14 +43,17 @@ static FIELDS: &[FieldDef] = &[
                 .map(|a| a.to_string())
                 .unwrap_or_default()
         },
-        apply: |config: &mut OpenCourseConfig, value: &str| -> Result<()> {
+        apply: |config: &mut OpenCourseConfig,
+                value: &str,
+                labels: &SettingsLabels|
+         -> Result<()> {
             config.active_profile_mut().age = if value.is_empty() {
                 None
             } else {
                 match value.parse::<u32>() {
                     Ok(age) if (14..=100).contains(&age) => Some(age),
                     _ => {
-                        return Err(AppError::Config("invalid age".to_string()));
+                        return Err(AppError::Config(labels.err_invalid_age.to_string()));
                     }
                 }
             };
@@ -59,20 +63,27 @@ static FIELDS: &[FieldDef] = &[
     FieldDef {
         section: Section::Session,
         index: 0,
-        label: "Batch size",
+        label: |labels| labels.batch_size_label,
         text_input: false,
-        display: |config: &OpenCourseConfig| {
+        display: |config: &OpenCourseConfig, labels: &SettingsLabels| {
             let size = config.preferences.batch_size;
-            let suffix = if size == 3 { " (recommended)" } else { "" };
+            let suffix = if size == 3 {
+                labels.recommended_suffix
+            } else {
+                ""
+            };
             format!("{}{}", size, suffix)
         },
         load: |config: &OpenCourseConfig| config.preferences.batch_size.to_string(),
-        apply: |config: &mut OpenCourseConfig, value: &str| -> Result<()> {
-            let size = value
-                .parse::<u32>()
-                .map_err(|_| AppError::Config(format!("Invalid batch size: {value}")))?;
+        apply: |config: &mut OpenCourseConfig,
+                value: &str,
+                labels: &SettingsLabels|
+         -> Result<()> {
+            let size = value.parse::<u32>().map_err(|_| {
+                AppError::Config(labels.err_invalid_batch.replace("{value}", value))
+            })?;
             if !(2..=5).contains(&size) {
-                return Err(AppError::Config("Batch size must be 2-5".to_string()));
+                return Err(AppError::Config(labels.err_batch_range.to_string()));
             }
             config.preferences.batch_size = size;
             Ok(())
@@ -94,24 +105,31 @@ pub(super) fn field_count(section: Section) -> usize {
     }
 }
 
-pub(super) fn field_label(section: Section, field: usize) -> &'static str {
+pub(super) fn field_label(section: Section, field: usize, labels: &SettingsLabels) -> &'static str {
     match section {
         Section::Provider => "",
         Section::Data => ResetAction::from_field(field)
-            .map(|a| a.field_label())
+            .map(|a| a.field_label(labels))
             .unwrap_or(""),
-        _ => find_field(section, field).map(|f| f.label).unwrap_or(""),
+        _ => find_field(section, field)
+            .map(|f| (f.label)(labels))
+            .unwrap_or(""),
     }
 }
 
-pub(super) fn field_value(config: &OpenCourseConfig, section: Section, field: usize) -> String {
+pub(super) fn field_value(
+    config: &OpenCourseConfig,
+    section: Section,
+    field: usize,
+    labels: &SettingsLabels,
+) -> String {
     match section {
         Section::Provider => String::new(),
         Section::Data => ResetAction::from_field(field)
-            .map(|a| a.description().to_string())
+            .map(|a| a.description(labels).to_string())
             .unwrap_or_default(),
         _ => find_field(section, field)
-            .map(|f| (f.display)(config))
+            .map(|f| (f.display)(config, labels))
             .unwrap_or_default(),
     }
 }
@@ -155,12 +173,16 @@ impl SettingsState {
         }
     }
 
-    pub(super) fn apply_input(&mut self, config: &mut OpenCourseConfig) -> Result<()> {
+    pub(super) fn apply_input(
+        &mut self,
+        config: &mut OpenCourseConfig,
+        labels: &SettingsLabels,
+    ) -> Result<()> {
         let value = self.input.trim().to_string();
         match self.section {
             Section::Provider | Section::Data => Ok(()),
             _ => match find_field(self.section, self.active_field) {
-                Some(f) => (f.apply)(config, &value),
+                Some(f) => (f.apply)(config, &value, labels),
                 None => Ok(()),
             },
         }
@@ -171,7 +193,8 @@ impl SettingsState {
         config: &mut OpenCourseConfig,
         data_dir: &std::path::Path,
     ) -> Result<()> {
-        self.apply_input(config)?;
+        let labels = get_settings_labels(native_language_code(Some(config)));
+        self.apply_input(config, &labels)?;
         write_config(config, data_dir)?;
         Ok(())
     }

--- a/src/ui/views/settings/mod.rs
+++ b/src/ui/views/settings/mod.rs
@@ -14,7 +14,10 @@ use crate::config::provider::ProviderId;
 use crate::config::write_config;
 use crate::error::Result;
 use crate::ui::colors;
-use crate::ui::labels::{ReportLabels, get_report_labels, native_language_code};
+use crate::ui::labels::{
+    ReportLabels, SettingsLabels, get_common_labels, get_report_labels, get_settings_labels,
+    native_language_code,
+};
 use crate::ui::views::utils::{select_next_wrapping, select_previous_wrapping};
 use crate::ui::widgets::{build_footer, draw_confirmation, model_picker};
 
@@ -34,12 +37,12 @@ pub enum Section {
 }
 
 impl Section {
-    fn label(&self) -> &'static str {
+    fn label(&self, labels: &SettingsLabels) -> &'static str {
         match self {
-            Section::Provider => "Provider",
-            Section::Profile => "Profile",
-            Section::Session => "Session",
-            Section::Data => "Data",
+            Section::Provider => labels.section_provider,
+            Section::Profile => labels.section_profile,
+            Section::Session => labels.section_session,
+            Section::Data => labels.section_data,
         }
     }
 
@@ -138,14 +141,16 @@ impl SettingsState {
     }
 }
 
-fn build_body(state: &AppState, labels: ReportLabels) -> Text<'static> {
+fn build_body(state: &AppState, labels: ReportLabels, settings: &SettingsLabels) -> Text<'static> {
     let config = match state.config.as_ref() {
         Some(c) => c,
-        None => return Text::from("No configuration available. Press Esc to return."),
+        None => return Text::from(settings.no_config),
     };
 
     if state.settings.section == Section::Provider && state.settings.in_section {
-        return Text::from(provider_setup::build_provider_setup_body(state, config));
+        return Text::from(provider_setup::build_provider_setup_body(
+            state, config, settings,
+        ));
     }
 
     let mut lines = vec![];
@@ -154,14 +159,18 @@ fn build_body(state: &AppState, labels: ReportLabels) -> Text<'static> {
         let sizes = [2u32, 3, 4, 5];
         let saved_size = config.preferences.batch_size;
         let saved_idx = sizes.iter().position(|&s| s == saved_size).unwrap_or(0);
-        lines.push(Line::from("Batch size:"));
+        lines.push(Line::from(settings.batch_size_title));
         for (idx, size) in sizes.iter().enumerate() {
             let marker = if idx == state.settings.session_batch_idx {
                 "> "
             } else {
                 "  "
             };
-            let suffix = if *size == 3 { " (recommended)" } else { "" };
+            let suffix = if *size == 3 {
+                settings.recommended_suffix
+            } else {
+                ""
+            };
             let content = format!("{}{}{}", marker, size, suffix);
             let is_saved = idx == saved_idx;
             let is_cursor = idx == state.settings.session_batch_idx;
@@ -188,7 +197,7 @@ fn build_body(state: &AppState, labels: ReportLabels) -> Text<'static> {
     for i in 0..count {
         let is_active = i == state.settings.active_field;
         let marker = if is_active { "> " } else { "  " };
-        let label = fields::field_label(state.settings.section, i);
+        let label = fields::field_label(state.settings.section, i, settings);
 
         if is_active && state.settings.section != Section::Data && state.settings.is_text_field() {
             let value = &state.settings.input;
@@ -215,7 +224,7 @@ fn build_body(state: &AppState, labels: ReportLabels) -> Text<'static> {
             }
             lines.push(Line::from(spans));
         } else {
-            let value = fields::field_value(config, state.settings.section, i);
+            let value = fields::field_value(config, state.settings.section, i, settings);
             lines.push(Line::from(format!("{}{}: {}", marker, label, value)));
         }
     }
@@ -224,28 +233,34 @@ fn build_body(state: &AppState, labels: ReportLabels) -> Text<'static> {
 }
 
 fn footer_text(state: &AppState) -> String {
+    let common = get_common_labels(native_language_code(state.config.as_ref()));
+
     if state.settings.section == Section::Provider && state.settings.in_section {
-        return provider_setup::build_provider_setup_footer(state);
+        return provider_setup::build_provider_setup_footer(state, &common);
     }
 
     match state.settings.section {
         Section::Data => build_footer(&[
-            ("↑/↓", "action"),
-            ("Enter", "reset"),
-            ("Esc", "back"),
-            ("?", "help"),
+            ("↑/↓", common.action),
+            ("Enter", common.reset),
+            ("Esc", common.back),
+            ("?", common.help),
         ]),
-        Section::Session => build_footer(&[("↑/↓", "select"), ("Esc", "back"), ("?", "help")]),
+        Section::Session => build_footer(&[
+            ("↑/↓", common.select),
+            ("Esc", common.back),
+            ("?", common.help),
+        ]),
         Section::Profile => build_footer(&[
-            ("←/→", "move caret"),
-            ("Type", "edit"),
-            ("Enter", "save"),
-            ("Esc", "back"),
+            ("←/→", common.move_caret),
+            ("Type", common.edit),
+            ("Enter", common.save),
+            ("Esc", common.back),
         ]),
         Section::Provider => build_footer(&[
-            ("Tab/Shift+Tab", "field"),
-            ("Enter", "save"),
-            ("Esc", "back"),
+            ("Tab/Shift+Tab", common.field),
+            ("Enter", common.save),
+            ("Esc", common.back),
         ]),
     }
 }
@@ -256,12 +271,17 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     }
 
     if let Some(action) = state.settings.pending_reset {
+        let lang = native_language_code(state.config.as_ref());
+        let settings = get_settings_labels(lang);
+        let common = get_common_labels(lang);
         draw_confirmation(
             frame,
             area,
-            "Reset data",
-            &format!("Confirm {}", action.label()),
-            "y: confirm | any other key: cancel",
+            settings.reset_data_title,
+            &settings
+                .confirm_action
+                .replace("{}", action.label(&settings)),
+            common.confirm_any_other,
         );
         return;
     }
@@ -279,6 +299,8 @@ fn draw_section_picker(
     state: &mut AppState,
 ) {
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
+    let settings = get_settings_labels(native_language_code(state.config.as_ref()));
+    let common = get_common_labels(native_language_code(state.config.as_ref()));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -303,7 +325,7 @@ fn draw_section_picker(
 
     let items: Vec<ListItem> = Section::all()
         .iter()
-        .map(|s| ListItem::new(s.label()))
+        .map(|s| ListItem::new(s.label(&settings)))
         .collect();
 
     let list = List::new(items).highlight_symbol("> ").highlight_style(
@@ -316,10 +338,10 @@ fn draw_section_picker(
 
     frame.render_widget(
         Paragraph::new(build_footer(&[
-            ("↑/↓", "navigate"),
-            ("Enter", "open"),
-            ("Esc", "back"),
-            ("?", "help"),
+            ("↑/↓", common.navigate),
+            ("Enter", common.open),
+            ("Esc", common.back),
+            ("?", common.help),
         ]))
         .style(Style::default().fg(Color::DarkGray)),
         chunks[2],
@@ -332,6 +354,7 @@ fn draw_section_page(
     state: &mut AppState,
 ) {
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
+    let settings = get_settings_labels(native_language_code(state.config.as_ref()));
     let footer_text = self::footer_text(state);
     let footer_height = footer_text.lines().count() as u16;
     let chunks = Layout::default()
@@ -352,7 +375,7 @@ fn draw_section_page(
         ),
         Span::raw(" / "),
         Span::styled(
-            state.settings.section.label(),
+            state.settings.section.label(&settings),
             Style::default().fg(Color::DarkGray),
         ),
     ]));
@@ -370,13 +393,14 @@ fn draw_section_page(
             .constraints([Constraint::Length(1), Constraint::Min(0)])
             .split(chunks[1]);
         frame.render_widget(
-            Paragraph::new("Select model:").style(Style::default().fg(Color::White)),
+            Paragraph::new(settings.select_model_title).style(Style::default().fg(Color::White)),
             body_chunks[0],
         );
         model_picker::draw_model_list(frame, body_chunks[1], &state.settings.model_picker, None);
     } else {
         frame.render_widget(
-            Paragraph::new(build_body(state, labels)).style(Style::default().fg(Color::White)),
+            Paragraph::new(build_body(state, labels, &settings))
+                .style(Style::default().fg(Color::White)),
             chunks[1],
         );
     }

--- a/src/ui/views/settings/provider_setup.rs
+++ b/src/ui/views/settings/provider_setup.rs
@@ -6,6 +6,7 @@ use crate::config::provider::{ProviderConfig, ProviderId};
 use crate::config::write_config;
 use crate::error::{AppError, Result};
 use crate::llm::provider::ProviderMeta;
+use crate::ui::labels::{CommonLabels, SettingsLabels, get_settings_labels, native_language_code};
 use crate::ui::views::model_check;
 use crate::ui::widgets::build_footer;
 use crate::ui::widgets::model_picker::{self, ModelPickerAction, ModelPickerOptions};
@@ -58,14 +59,18 @@ impl SettingsState {
     }
 }
 
-pub(super) fn build_provider_setup_body(state: &AppState, config: &OpenCourseConfig) -> String {
+pub(super) fn build_provider_setup_body(
+    state: &AppState,
+    config: &OpenCourseConfig,
+    labels: &SettingsLabels,
+) -> String {
     let provider = state.settings.provider_setup_provider;
     let _provider_config = config.providers.get(&provider);
     let meta = ProviderMeta::for_provider(provider);
 
     match state.settings.provider_setup_step {
         ProviderSetupStep::SelectProvider => {
-            let mut lines = vec!["Select provider:".to_string()];
+            let mut lines = vec![labels.select_provider_title.to_string()];
             for p in ProviderId::all() {
                 let marker = if *p == provider { "> " } else { "  " };
                 lines.push(format!("{}{} - {}", marker, p.as_str(), p.label()));
@@ -74,96 +79,101 @@ pub(super) fn build_provider_setup_body(state: &AppState, config: &OpenCourseCon
         }
         ProviderSetupStep::BaseUrl => {
             if provider == ProviderId::Custom {
-                format!("Base URL: {}", state.settings.input)
+                labels.base_url_label.replace("{}", &state.settings.input)
             } else {
-                format!(
-                    "Base URL: {} (read-only)",
-                    meta.default_base_url.unwrap_or("(none)")
+                labels.base_url_readonly.replace(
+                    "{}",
+                    meta.default_base_url.unwrap_or(labels.none_placeholder),
                 )
             }
         }
         ProviderSetupStep::Endpoint => {
             if provider == ProviderId::Custom {
-                format!(
-                    "Endpoint: {}\n\nChoose the API endpoint path for your custom provider:\n\n  chat/completions  — OpenAI-compatible endpoints\n                    (OpenCode Go: DeepSeek, GLM, Kimi, MiMo; Ollama; OpenRouter)\n  messages          — Anthropic Messages API\n                    (OpenCode Go: Qwen, MiniMax; Anthropic)",
-                    state.settings.input
-                )
+                labels.endpoint_choose.replace("{}", &state.settings.input)
             } else {
-                format!(
-                    "Endpoint: {} (read-only)\n\nThis provider uses the {} endpoint.",
-                    state.settings.input, state.settings.input
-                )
+                labels
+                    .endpoint_readonly
+                    .replace("{}", &state.settings.input)
             }
         }
         ProviderSetupStep::ApiKey => {
             let masked = "*".repeat(state.settings.input.chars().count());
             match meta.env_key {
-                Some(name) if state.settings.input.is_empty() => format!(
-                    "API key: {}\n\nLeave empty to use the {} environment variable{}",
-                    masked,
-                    name,
-                    if std::env::var(name).is_ok() {
-                        " (currently set)"
+                Some(name) if state.settings.input.is_empty() => {
+                    let suffix = if std::env::var(name).is_ok() {
+                        labels.env_currently_set
                     } else {
-                        " (not currently set)"
-                    }
-                ),
-                _ => format!("API key: {}", masked),
+                        labels.env_not_set
+                    };
+                    labels
+                        .api_key_env
+                        .replacen("{}", &masked, 1)
+                        .replacen("{}", name, 1)
+                        .replacen("{}", suffix, 1)
+                }
+                _ => labels.api_key_label.replace("{}", &masked),
             }
         }
         ProviderSetupStep::Model => {
             if state.settings.model_picker.loading {
-                "Loading models...".to_string()
+                labels.loading_models.to_string()
             } else if let Some(err) = &state.settings.model_picker.error {
-                format!(
-                    "Error loading models: {}\n\nEnter: enter manually | r: retry | Esc: back",
-                    err
-                )
+                labels.error_loading_models.replace("{}", err)
             } else if state.settings.model_picker.manual {
-                format!("Model (manual): {}", state.settings.input)
+                labels
+                    .model_manual_label
+                    .replace("{}", &state.settings.input)
             } else {
-                "No models loaded.\nEnter: enter manually".to_string()
+                labels.no_models_loaded.to_string()
             }
         }
     }
 }
 
-pub(super) fn build_provider_setup_footer(state: &AppState) -> String {
+pub(super) fn build_provider_setup_footer(state: &AppState, common: &CommonLabels) -> String {
     match state.settings.provider_setup_step {
         ProviderSetupStep::SelectProvider => build_footer(&[
-            ("↑/↓", "navigate"),
-            ("Enter", "select"),
-            ("Esc", "back"),
-            ("?", "help"),
+            ("↑/↓", common.navigate),
+            ("Enter", common.select),
+            ("Esc", common.back),
+            ("?", common.help),
         ]),
         ProviderSetupStep::BaseUrl | ProviderSetupStep::Endpoint => {
             if state.settings.provider_setup_provider == ProviderId::Custom {
-                build_footer(&[("Enter", "save"), ("Esc", "back")])
+                build_footer(&[("Enter", common.save), ("Esc", common.back)])
             } else {
-                build_footer(&[("Enter", "next"), ("Esc", "back"), ("?", "help")])
+                build_footer(&[
+                    ("Enter", common.next),
+                    ("Esc", common.back),
+                    ("?", common.help),
+                ])
             }
         }
-        ProviderSetupStep::ApiKey => build_footer(&[("Enter", "save"), ("Esc", "back")]),
+        ProviderSetupStep::ApiKey => build_footer(&[("Enter", common.save), ("Esc", common.back)]),
         ProviderSetupStep::Model => {
             if state.settings.model_picker.loading {
-                build_footer(&[("Esc", "back"), ("?", "help")])
+                build_footer(&[("Esc", common.back), ("?", common.help)])
             } else if state.settings.model_picker.error.is_some() {
                 build_footer(&[
-                    ("Enter", "manual"),
-                    ("r", "retry"),
-                    ("Esc", "back"),
-                    ("?", "help"),
+                    ("Enter", common.manual),
+                    ("r", common.retry),
+                    ("Esc", common.back),
+                    ("?", common.help),
                 ])
             } else if state.settings.model_picker.manual {
-                build_footer(&[("Enter", "save"), ("Esc", "back")])
+                build_footer(&[("Enter", common.save), ("Esc", common.back)])
             } else if state.settings.model_picker.models.is_empty() {
-                build_footer(&[("Enter", "enter manually"), ("Esc", "back"), ("?", "help")])
+                build_footer(&[
+                    ("Enter", common.enter_manually),
+                    ("Esc", common.back),
+                    ("?", common.help),
+                ])
             } else {
                 build_footer(&[
-                    ("↑/↓", "navigate"),
-                    ("Enter", "select"),
-                    ("Esc", "back"),
-                    ("?", "help"),
+                    ("↑/↓", common.navigate),
+                    ("Enter", common.select),
+                    ("Esc", common.back),
+                    ("?", common.help),
                 ])
             }
         }
@@ -397,8 +407,8 @@ async fn handle_base_url_step(state: &mut AppState, code: KeyCode) -> Result<()>
                 if provider == ProviderId::Custom {
                     let value = state.settings.input.trim().to_string();
                     if value.is_empty() {
-                        state.settings.error =
-                            Some("Base URL is required for custom provider".to_string());
+                        let labels = get_settings_labels(native_language_code(Some(config)));
+                        state.settings.error = Some(labels.err_base_url_custom.to_string());
                         return Ok(());
                     }
                     if let Some(provider_config) = config.providers.get(&provider) {
@@ -436,8 +446,8 @@ async fn handle_endpoint_step(state: &mut AppState, code: KeyCode) -> Result<()>
                 if provider == ProviderId::Custom {
                     let value = state.settings.input.trim().to_string();
                     if !value.eq("chat/completions") && !value.eq("messages") {
-                        state.settings.error =
-                            Some("Endpoint must be 'chat/completions' or 'messages'".to_string());
+                        let labels = get_settings_labels(native_language_code(Some(config)));
+                        state.settings.error = Some(labels.err_endpoint_values.to_string());
                         return Ok(());
                     }
                     if let Some(provider_config) = config.providers.get(&provider) {
@@ -479,12 +489,13 @@ async fn handle_api_key_step(state: &mut AppState, code: KeyCode) -> Result<()> 
                     && value.is_empty()
                     && meta.resolve_api_key(None).is_none()
                 {
+                    let labels = get_settings_labels(native_language_code(Some(config)));
                     let hint = meta
                         .env_key
-                        .map(|name| format!(" or set the {name} environment variable"))
+                        .map(|name| labels.env_var_or_set.replace("{name}", name))
                         .unwrap_or_default();
                     state.settings.error =
-                        Some(format!("API key is required for this provider{hint}"));
+                        Some(labels.err_api_key_required.replace("{hint}", &hint));
                     return Ok(());
                 }
                 if let Some(provider_config) = config.providers.get(&provider) {
@@ -534,9 +545,10 @@ async fn handle_model_step(state: &mut AppState, code: KeyCode) -> Result<()> {
             }
         }
         ModelPickerAction::ExitManual => {
+            let labels = get_settings_labels(native_language_code(state.config.as_ref()));
             state.settings.model_picker.error = None;
             if state.settings.model_picker.models.is_empty() {
-                state.settings.model_picker.error = Some("No models loaded".to_string());
+                state.settings.model_picker.error = Some(labels.err_no_models.to_string());
             }
         }
         ModelPickerAction::EmptyEnter => {
@@ -562,7 +574,8 @@ async fn handle_model_step(state: &mut AppState, code: KeyCode) -> Result<()> {
 
 fn save_model_and_run_diagnostics(state: &mut AppState, model_id: String) -> Result<()> {
     if model_id.is_empty() {
-        return Err(AppError::Config("Model is required".to_string()));
+        let labels = get_settings_labels(native_language_code(state.config.as_ref()));
+        return Err(AppError::Config(labels.err_model_required.to_string()));
     }
     let provider = state.settings.provider_setup_provider;
     let config_clone = {

--- a/src/ui/views/update.rs
+++ b/src/ui/views/update.rs
@@ -4,6 +4,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use crate::app::AppState;
 use crate::ui::colors;
+use crate::ui::labels::{get_common_labels, get_update_labels, native_language_code};
 use crate::ui::widgets::build_footer;
 use crate::update::CURRENT_VERSION;
 
@@ -19,11 +20,15 @@ impl UpdateState {
 }
 
 pub fn draw(frame: &mut ratatui::Frame, area: Rect, state: &AppState) {
+    let lang = native_language_code(state.config.as_ref());
+    let labels = get_update_labels(lang);
+    let common = get_common_labels(lang);
+
     let popup_area = centered_rect(60, 30, area);
     frame.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title("Update available")
+        .title(labels.title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(colors::BLUE))
         .title_style(
@@ -35,12 +40,16 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, state: &AppState) {
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
 
-    let latest = state.update.latest_version.as_deref().unwrap_or("unknown");
+    let latest = state
+        .update
+        .latest_version
+        .as_deref()
+        .unwrap_or(labels.unknown_version);
 
-    let message = format!(
-        "A new version of opencourse is available.\n\nCurrent: v{}\nLatest: v{}\n\nInstall now?",
-        CURRENT_VERSION, latest
-    );
+    let message = labels
+        .message
+        .replacen("{}", CURRENT_VERSION, 1)
+        .replacen("{}", latest, 1);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -55,7 +64,11 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, state: &AppState) {
         chunks[0],
     );
 
-    let footer_text = build_footer(&[("y", "install"), ("n", "skip"), ("?", "help")]);
+    let footer_text = build_footer(&[
+        ("y", common.install),
+        ("n", common.skip),
+        ("?", common.help),
+    ]);
     frame.render_widget(
         Paragraph::new(footer_text).alignment(Alignment::Center),
         chunks[1],

--- a/src/ui/widgets/error_box.rs
+++ b/src/ui/widgets/error_box.rs
@@ -5,12 +5,16 @@ use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 
 pub struct ErrorBox {
     message: String,
+    title: &'static str,
+    footer_hint: &'static str,
 }
 
 impl ErrorBox {
-    pub fn new(message: impl Into<String>) -> Self {
+    pub fn new(message: impl Into<String>, title: &'static str, footer_hint: &'static str) -> Self {
         Self {
             message: message.into(),
+            title,
+            footer_hint,
         }
     }
 }
@@ -18,13 +22,13 @@ impl ErrorBox {
 impl Widget for ErrorBox {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let block = Block::default()
-            .title("Error")
+            .title(self.title)
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Red));
         let inner = block.inner(area);
         block.render(area, buf);
 
-        let text = format!("{}\n\nr: retry | m: change model | q: quit", self.message);
+        let text = format!("{}\n\n{}", self.message, self.footer_hint);
         Paragraph::new(text)
             .style(Style::default().fg(Color::Red))
             .wrap(Wrap { trim: true })

--- a/src/ui/widgets/help_overlay.rs
+++ b/src/ui/widgets/help_overlay.rs
@@ -8,11 +8,17 @@ use crate::ui::help::HelpGroup;
 
 pub struct HelpOverlay<'a> {
     groups: &'a [HelpGroup],
+    title: &'a str,
+    close_hint: &'a str,
 }
 
 impl<'a> HelpOverlay<'a> {
-    pub fn new(groups: &'a [HelpGroup]) -> Self {
-        Self { groups }
+    pub fn new(groups: &'a [HelpGroup], title: &'a str, close_hint: &'a str) -> Self {
+        Self {
+            groups,
+            title,
+            close_hint,
+        }
     }
 }
 
@@ -40,7 +46,7 @@ impl Widget for HelpOverlay<'_> {
         Clear.render(popup, buf);
 
         let block = Block::default()
-            .title("Help")
+            .title(self.title)
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Blue));
         let inner = block.inner(popup);
@@ -68,7 +74,7 @@ impl Widget for HelpOverlay<'_> {
             lines.push(Line::from(""));
         }
         lines.push(Line::from(Span::styled(
-            "Esc / ?: close",
+            self.close_hint,
             Style::default().fg(Color::DarkGray),
         )));
 

--- a/src/ui/widgets/toast.rs
+++ b/src/ui/widgets/toast.rs
@@ -5,6 +5,8 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
 
+use crate::ui::labels::ReportLabels;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToastLevel {
     Info,
@@ -42,11 +44,12 @@ impl Toast {
 
 pub struct ToastWidget<'a> {
     toast: &'a Toast,
+    labels: ReportLabels,
 }
 
 impl<'a> ToastWidget<'a> {
-    pub fn new(toast: &'a Toast) -> Self {
-        Self { toast }
+    pub fn new(toast: &'a Toast, labels: ReportLabels) -> Self {
+        Self { toast, labels }
     }
 }
 
@@ -57,8 +60,8 @@ impl Widget for ToastWidget<'_> {
             ToastLevel::Info => Color::Green,
         };
         let title = match self.toast.level {
-            ToastLevel::Error => "Error",
-            ToastLevel::Info => "Info",
+            ToastLevel::Error => self.labels.error,
+            ToastLevel::Info => self.labels.toast_info,
         };
 
         let max_width = area.width.saturating_sub(2).max(10);

--- a/tests/settings_layout_test.rs
+++ b/tests/settings_layout_test.rs
@@ -124,7 +124,7 @@ async fn settings_profile_shows_age_without_cefr() {
         .unwrap();
 
     let text = buffer_text(&terminal);
-    assert!(text.contains("Age"), "Profile should show Age");
+    assert!(text.contains("Возраст"), "Profile should show Age");
     assert!(
         !text.contains("CEFR"),
         "Profile should not show CEFR in settings"
@@ -148,11 +148,11 @@ async fn settings_session_shows_batch_size_selector() {
 
     let text = buffer_text(&terminal);
     assert!(
-        text.contains("Batch size"),
+        text.contains("Размер сессии"),
         "Session should show Batch size"
     );
     assert!(
-        text.contains("recommended"),
+        text.contains("рекомендуется"),
         "Batch size 3 should be marked recommended"
     );
     assert!(
@@ -182,10 +182,10 @@ async fn settings_data_lists_reset_actions() {
 
     let text = buffer_text(&terminal);
     assert!(
-        text.contains("Reset progress"),
+        text.contains("Сбросить прогресс"),
         "Data should show reset actions"
     );
-    assert!(text.contains("Reset all"), "Data should show Reset all");
+    assert!(text.contains("Сбросить всё"), "Data should show Reset all");
 }
 
 #[tokio::test]
@@ -273,14 +273,17 @@ async fn update_available_prompt_renders() {
 
     let text = buffer_text(&terminal);
     assert!(
-        text.contains("Update available"),
+        text.contains("Доступно обновление"),
         "Prompt should show update title"
     );
     assert!(
-        text.contains("Latest: v9.9.9"),
+        text.contains("Последняя: v9.9.9"),
         "Prompt should show latest version"
     );
-    assert!(text.contains("n: skip"), "Prompt should offer skip action");
+    assert!(
+        text.contains("n: пропустить"),
+        "Prompt should offer skip action"
+    );
 }
 
 #[tokio::test]
@@ -332,7 +335,7 @@ async fn settings_session_highlights_current_green() {
     // The current option (index 1 = 3) should have green bold marker
     // Check that the selected option has green style
     assert!(
-        text.contains("3 (recommended)"),
+        text.contains("3 (рекомендуется)"),
         "Should show batch size options"
     );
 }


### PR DESCRIPTION
## Goal

Every user-facing UI string now goes through the labels system (`src/ui/labels.rs`) with English and Russian variants, selected by the profile's native language. A full-project audit found hardcoded English strings across nearly every view; this PR routes all of them through labels.

## New label structs (labels.rs)

- **`CommonLabels`** (+ `get_common_labels`) — shared action/hint words used across footers and the help screen: help, back, scroll, navigate, select, save, edit, next/prev, cancel, confirm, retry, skip, install, close, continue, manual, enter_manually, model_id, reset, delete, dashboard, new_topic, repeat, back_to_list, back_to_model_list, group titles (Navigation/Actions/Exit), confirmation key hints, and more.
- **`OnboardingLabels`** — step titles, help texts, selector intros, env-var hints, model-picker strings, and all validation error messages.
- **`SettingsLabels`** — section names, reset-action titles/descriptions, field labels, provider-setup wizard texts and validation errors.
- **`UpdateLabels`** — update popup title/message/installer strings.
- **`ModelCheckLabels`** — check names, verdicts, running statuses, reasoning suffix.
- Extended `ReportLabels` (also_acceptable, waiting, generating_plan, difficulty_*, curriculum confirmation dialogs, toast/help/error-box titles) and `DocsLabels` (sort_last_practiced).

## Wired views

- **report.rs** — "Also acceptable", full footer.
- **dashboard.rs / pairs.rs / session.rs / docs.rs / curriculum.rs** — footers, "help" hints, sort labels, "waiting...", "No topics available", curriculum confirmation dialogs, difficulty names in the topic list.
- **onboarding/** — the whole flow: step titles, help texts, footers, model picker, validation errors.
- **settings/** — sections, reset actions, provider wizard, footers, confirmation dialog, validation errors.
- **update.rs / model_check.rs** — fully localized.
- **help.rs** — group titles and all action strings via `CommonLabels`.
- **widgets** — help overlay title/close hint, error box title/footer hint, toast titles (`Error`/`Info`); `Toast::error`/`Toast::info` signatures unchanged.
- **app/mod.rs** — installer messages.
- **main.rs** — startup cleanup messages and `opencourse update` CLI output localized inline (en/ru) after config load.

## Deliberately not localized

Key names (Enter, Esc, ?), separators/markers, CEFR codes, API paths, brand logo, clap `--help` text (compile-time), and technical `AppError`/LLM diagnostics shown in toasts.

English label values match the previous hardcoded strings byte-for-byte, so the English UI is unchanged; one settings layout test and the update-prompt test now assert Russian strings (test config uses native_language "ru").

## Checks

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean; full `cargo test` suite green (including 5 new label tests).