### PR TITLE
fix(ui): wrap long lines in topic documentation view

### DIFF
--- a/src/ui/views/docs.rs
+++ b/src/ui/views/docs.rs
@@ -6,7 +6,7 @@ use ratatui::crossterm::event::KeyCode;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph, Wrap};
 use tokio::sync::mpsc;
 use tui_markdown::{Options, from_str_with_options};
 use unicode_normalization::UnicodeNormalization;
@@ -194,7 +194,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         } else {
             let options = Options::new(OpenCourseStyleSheet);
             let text = from_str_with_options(&content, &options);
-            let paragraph = Paragraph::new(text);
+            let paragraph = wrapped_content_paragraph(text);
             let line_count = paragraph.line_count(chunks[1].width);
             let max_offset = line_count.saturating_sub(chunks[1].height as usize) as u16;
             state.docs.scroll_offset = state.docs.scroll_offset.min(max_offset);
@@ -393,6 +393,13 @@ async fn start_practice_from_docs(state: &mut AppState) -> Result<()> {
     Ok(())
 }
 
+/// Builds the documentation body paragraph: wraps long lines instead of
+/// clipping them at the right edge. `trim: false` keeps markdown
+/// indentation (nested lists) intact.
+fn wrapped_content_paragraph(text: Text<'_>) -> Paragraph<'_> {
+    Paragraph::new(text).wrap(Wrap { trim: false })
+}
+
 pub fn start_viewing(state: &mut AppState, topic: Topic) {
     state.docs.viewing_topic = Some(topic);
     state.docs.content.clear();
@@ -490,5 +497,16 @@ mod tests {
 
         state.scroll_by(100);
         assert_eq!(state.scroll_offset, 10);
+    }
+
+    #[test]
+    fn content_paragraph_wraps_long_lines() {
+        let long_line = "a".repeat(100);
+        let paragraph = wrapped_content_paragraph(Text::from(long_line));
+        // Without wrapping this would be a single (clipped) line; with
+        // wrapping a 100-char line needs multiple rows at width 40.
+        assert!(paragraph.line_count(40) >= 3);
+        // Full width fits the line on one row.
+        assert_eq!(paragraph.line_count(120), 1);
     }
 }


### PR DESCRIPTION
## Problem

In the topic documentation view (Docs -> topic), long lines were clipped at the right edge instead of wrapping, so generated reviews were unreadable past the viewport width.

## Fix

The content paragraph now uses `.wrap(Wrap { trim: false })` (extracted into a small `wrapped_content_paragraph` helper in `src/ui/views/docs.rs`). `trim: false` preserves markdown indentation (nested lists). Scroll math is unaffected — `line_count(width)` accounts for wrapping, so `max_scroll_offset` now reflects the true wrapped height.

## Tests

New regression test `content_paragraph_wraps_long_lines`: a 100-char line wraps into multiple rows at width 40 and stays a single row at width 120. Full suite green; fmt/clippy clean.

Note: the English "last practiced" in the header of this screen is already fixed by the localization PR (#23).