### PR TITLE
fix(ui): show a toast when toggling mouse mode with m

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -273,12 +273,21 @@ async fn handle_event(state: &mut AppState, event: Event) -> Result<()> {
             }
 
             // On mouse-enabled views `m` toggles between wheel-scroll mode and
-            // native text-selection mode (capture off).
+            // native text-selection mode (capture off). A toast makes the
+            // switch explicit — otherwise users can't tell why selection or
+            // scrolling stopped working.
             if matches!(key.code, KeyCode::Char('m') | KeyCode::Char('M'))
                 && view_supports_mouse(state.view)
             {
                 let enabled = !state.mouse_capture;
                 state.set_mouse_capture(enabled)?;
+                let labels = get_report_labels(native_language_code(state.config.as_ref()));
+                let message = if enabled {
+                    labels.mouse_wheel_mode
+                } else {
+                    labels.mouse_select_mode
+                };
+                state.toast = Some(Toast::info(message));
                 return Ok(());
             }
 
@@ -625,5 +634,49 @@ mod tests {
 
         state.view = View::Session;
         assert!(!view_content_overflows(&state));
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(ratatui::crossterm::event::KeyEvent::new(
+            code,
+            KeyModifiers::NONE,
+        ))
+    }
+
+    #[tokio::test]
+    async fn m_toggles_mouse_mode_and_shows_toast() {
+        let mut state = test_state().await;
+        state.view = View::Report;
+        assert!(state.mouse_capture);
+        assert!(state.toast.is_none());
+
+        handle_event(&mut state, key(KeyCode::Char('m')))
+            .await
+            .unwrap();
+        assert!(!state.mouse_capture);
+        assert_eq!(
+            state.toast.as_ref().unwrap().message,
+            get_report_labels("en").mouse_select_mode
+        );
+
+        handle_event(&mut state, key(KeyCode::Char('m')))
+            .await
+            .unwrap();
+        assert!(state.mouse_capture);
+        assert_eq!(
+            state.toast.as_ref().unwrap().message,
+            get_report_labels("en").mouse_wheel_mode
+        );
+    }
+
+    #[tokio::test]
+    async fn m_ignored_on_views_without_mouse_support() {
+        let mut state = test_state().await;
+        state.view = View::Session;
+        handle_event(&mut state, key(KeyCode::Char('m')))
+            .await
+            .unwrap();
+        assert!(state.mouse_capture);
+        assert!(state.toast.is_none());
     }
 }

--- a/src/ui/labels.rs
+++ b/src/ui/labels.rs
@@ -94,6 +94,8 @@ pub struct ReportLabels {
     pub help_title: &'static str,
     pub close_hint: &'static str,
     pub error_footer_hint: &'static str,
+    pub mouse_select_mode: &'static str,
+    pub mouse_wheel_mode: &'static str,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -202,6 +204,8 @@ const EN_REPORT: ReportLabels = ReportLabels {
     help_title: "Help",
     close_hint: "Esc / ?: close",
     error_footer_hint: "r: retry | m: change model | q: quit",
+    mouse_select_mode: "Text selection enabled — mouse scroll off. Press m to switch back.",
+    mouse_wheel_mode: "Mouse scroll enabled — text selection off. Press m to switch back.",
 };
 
 const RU_REPORT: ReportLabels = ReportLabels {
@@ -297,6 +301,8 @@ const RU_REPORT: ReportLabels = ReportLabels {
     help_title: "Помощь",
     close_hint: "Esc / ?: закрыть",
     error_footer_hint: "r: повторить | m: сменить модель | q: выход",
+    mouse_select_mode: "Выделение текста включено — скролл мышью выключен. Нажмите m для возврата.",
+    mouse_wheel_mode: "Скролл мышью включён — выделение текста выключено. Нажмите m для возврата.",
 };
 
 const EN_DOCS: DocsLabels = DocsLabels {


### PR DESCRIPTION
## Problem

On the analysis (Report) page — and any other scrollable view — text selection is impossible while the content overflows: the app captures the mouse to provide wheel scrolling, and a terminal cannot do native drag-selection while an application owns the mouse. The escape hatch already exists (press `m` to toggle between wheel-scroll mode and native text-selection mode), but users can't discover it and experience it as "selection is broken".

## Fix

Pressing `m` on a mouse-enabled view now shows a toast that names the active mode, so the trade-off and the way back are explicit:

- capture off: "Text selection enabled — mouse scroll off. Press m to switch back."
- capture on: "Mouse scroll enabled — text selection off. Press m to switch back."

Both messages are localized (en/ru) via new `ReportLabels.mouse_select_mode` / `mouse_wheel_mode` fields. The footer hints (`wheel: scroll | m: select text`) were already in place.

## Tests

- `m_toggles_mouse_mode_and_shows_toast`: `m` on the Report view flips `mouse_capture` and sets the matching toast message.
- `m_ignored_on_views_without_mouse_support`: `m` on views without mouse support does nothing.
- Full suite green; fmt/clippy clean.