### PR TITLE
fix(ui): print the analysis report to the main screen for native scroll and selection

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -177,6 +177,17 @@ pub async fn run_app(
     let mut mouse_captured = false;
 
     loop {
+        // The analysis report lives on the main screen (not in the alternate
+        // screen): it is printed once, so the terminal's native scrollback
+        // and text selection work. The TUI resumes on any navigation key.
+        if state.view == View::Report {
+            run_report_screen(terminal, &mut state, &mut events, &mut llm_rx).await?;
+            // Mouse capture was released while on the main screen; let the
+            // desired-capture check below re-apply it if the new view needs it.
+            mouse_captured = false;
+            continue;
+        }
+
         terminal.draw(|frame| draw(frame, &mut state))?;
 
         if state.view == View::Session
@@ -234,6 +245,72 @@ pub async fn run_app(
         }
     }
 
+    Ok(())
+}
+
+/// Shows the analysis report on the main screen: leaves the alternate screen,
+/// prints the report once (native scrollback + native text selection), then
+/// waits for a navigation key. Re-enters the alternate screen before
+/// returning. There is no custom scrolling and no mouse capture here.
+async fn run_report_screen(
+    terminal: &mut DefaultTerminal,
+    state: &mut AppState,
+    events: &mut EventStream,
+    llm_rx: &mut mpsc::Receiver<LlmResult>,
+) -> Result<()> {
+    use ratatui::crossterm::event::DisableMouseCapture;
+    use ratatui::crossterm::execute;
+    use ratatui::crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+
+    execute!(
+        terminal.backend_mut(),
+        DisableMouseCapture,
+        LeaveAlternateScreen
+    )?;
+    report::print(state)?;
+
+    while state.view == View::Report {
+        tokio::select! {
+            Some(event) = events.next() => {
+                match event {
+                    Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => {
+                        if key.modifiers.contains(KeyModifiers::CONTROL)
+                            && key.code == KeyCode::Char('c')
+                        {
+                            state.view = View::Quitting;
+                            break;
+                        }
+                        let previous_view = state.view;
+                        if let Err(e) = report::handle_key(state, key.code).await {
+                            state.error = Some(e.to_string());
+                        }
+                        // Errors are rendered by the TUI error box; leave the
+                        // main screen so the user actually sees them.
+                        if state.error.is_some() {
+                            state.view = View::Dashboard;
+                        }
+                        if state.view == View::Dashboard && previous_view != View::Dashboard {
+                            let config = state.config.as_ref();
+                            if let Err(e) = state.dashboard.refresh(&state.db, config).await {
+                                state.error = Some(e.to_string());
+                            }
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => state.error = Some(e.to_string()),
+                }
+            }
+            Some(result) = llm_rx.recv() => {
+                apply_llm_result(state, result).await;
+            }
+        }
+        if state.quit_requested.load(Ordering::Relaxed) {
+            state.view = View::Quitting;
+        }
+    }
+
+    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+    terminal.clear()?;
     Ok(())
 }
 
@@ -317,7 +394,6 @@ async fn handle_mouse(state: &mut AppState, mouse: MouseEvent) -> Result<()> {
     let delta: i32 = if down { 3 } else { -3 };
     match state.view {
         View::Dashboard => state.dashboard.scroll_by(delta),
-        View::Report => state.report.scroll_by(delta),
         View::Docs if state.docs.viewing_topic.is_some() => state.docs.scroll_by(delta),
         View::Docs => {
             let len = state.docs.topics.len();
@@ -350,12 +426,11 @@ fn is_text_input_active(state: &AppState) -> bool {
 }
 
 /// Views where the mouse wheel is useful and there is no text input, so mouse
-/// capture can be enabled without breaking typing.
+/// capture can be enabled without breaking typing. The report view is
+/// excluded on purpose: it is printed to the main screen, where scrolling and
+/// text selection are handled natively by the terminal.
 fn view_supports_mouse(view: View) -> bool {
-    matches!(
-        view,
-        View::Dashboard | View::Report | View::Docs | View::Curriculum
-    )
+    matches!(view, View::Dashboard | View::Docs | View::Curriculum)
 }
 
 /// Whether the current view's content is taller than its viewport. Mouse
@@ -366,7 +441,6 @@ fn view_supports_mouse(view: View) -> bool {
 fn view_content_overflows(state: &AppState) -> bool {
     match state.view {
         View::Dashboard => state.dashboard.max_scroll > 0,
-        View::Report => state.report.max_scroll_offset > 0,
         View::Docs if state.docs.viewing_topic.is_some() => state.docs.max_scroll_offset > 0,
         View::Docs => state.docs.list_overflows,
         View::Curriculum => state.curriculum.list_overflows,
@@ -556,7 +630,9 @@ fn draw(frame: &mut ratatui::Frame, state: &mut AppState) {
         View::Dashboard => dashboard::draw(frame, area, state),
         View::Session => session::draw(frame, area, state),
         View::Docs => docs::draw(frame, area, state),
-        View::Report => report::draw(frame, area, state),
+        // The report is printed to the main screen by `run_report_screen`;
+        // the TUI never draws it.
+        View::Report => {}
         View::Curriculum => curriculum::draw(frame, area, state),
         View::Settings => settings::draw(frame, area, state),
         View::ModelCheck => model_check::draw(frame, area, state),
@@ -609,9 +685,10 @@ mod tests {
         assert!(view_content_overflows(&state));
 
         state.view = View::Report;
+        // The report is printed to the main screen; it never captures the
+        // mouse, no matter how long the content is.
         assert!(!view_content_overflows(&state));
-        state.report.max_scroll_offset = 5;
-        assert!(view_content_overflows(&state));
+        assert!(!view_supports_mouse(state.view));
 
         state.view = View::Docs;
         assert!(!view_content_overflows(&state));

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -55,7 +55,7 @@ pub fn groups_for(state: &AppState) -> Vec<HelpGroup> {
         View::Docs => docs_groups(state, labels, common),
         View::Session => session_groups(state, labels, common),
         View::Pairs => pairs_groups(labels, common),
-        View::Report => report_groups(state, labels, common),
+        View::Report => report_groups(common),
         View::ModelCheck => model_check_groups(state, common),
         View::Settings => settings_groups(state, common),
         View::Onboarding => onboarding_groups(state, common),
@@ -221,13 +221,10 @@ fn pairs_groups(labels: ReportLabels, common: CommonLabels) -> Vec<HelpGroup> {
     ]
 }
 
-fn report_groups(state: &AppState, labels: ReportLabels, common: CommonLabels) -> Vec<HelpGroup> {
-    let mut nav = vec![entry("↑/↓", labels.wheel_scroll)];
-    if state.report.max_scroll_offset > 0 {
-        nav.extend(mouse_entries(state, labels));
-    }
+fn report_groups(common: CommonLabels) -> Vec<HelpGroup> {
+    // The report is printed to the main screen: it has no scrolling and no
+    // mouse modes, only the navigation keys below.
     vec![
-        group(common.group_navigation, nav),
         group(
             common.group_actions,
             vec![

--- a/src/ui/views/report.rs
+++ b/src/ui/views/report.rs
@@ -1,8 +1,13 @@
+use std::io::Write;
+
 use ratatui::crossterm::event::KeyCode;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::crossterm::style::{
+    Attribute, Color as CrosstermColor, ContentStyle, Print, PrintStyledContent, ResetColor,
+    StyledContent,
+};
+use ratatui::crossterm::{ExecutableCommand, QueueableCommand};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Paragraph, Wrap};
+use ratatui::text::{Line, Span};
 use unicode_normalization::UnicodeNormalization;
 
 use crate::app::{AppState, View};
@@ -12,15 +17,13 @@ use crate::error::Result;
 use crate::ui::colors;
 use crate::ui::labels::{ReportLabels, get_common_labels, get_report_labels, native_language_code};
 use crate::ui::views::{docs, session};
-use crate::ui::widgets::{build_footer, mouse_footer_entries};
+use crate::ui::widgets::build_footer;
 
 #[derive(Debug, Clone)]
 pub struct ReportState {
     pub analysis: AnalysisResult,
     pub session: MentorSession,
     pub weak_topics: Vec<Topic>,
-    pub scroll_offset: u16,
-    pub max_scroll_offset: u16,
     pub target_topic_id: Option<String>,
     pub target_topic_name: Option<String>,
 }
@@ -42,8 +45,6 @@ impl Default for ReportState {
                 current_exercise_index: 0,
             },
             weak_topics: Vec::new(),
-            scroll_offset: 0,
-            max_scroll_offset: 0,
             target_topic_id: None,
             target_topic_name: None,
         }
@@ -55,7 +56,7 @@ impl ReportState {
         Self::default()
     }
 
-    /// Builds the report shown after a session analysis, scrolled to top.
+    /// Builds the report shown after a session analysis.
     pub fn from_analysis(
         analysis: AnalysisResult,
         session: MentorSession,
@@ -69,51 +70,84 @@ impl ReportState {
             weak_topics,
             target_topic_id,
             target_topic_name,
-            ..Default::default()
         }
-    }
-
-    pub fn scroll_by(&mut self, delta: i32) {
-        let max = self.max_scroll_offset as i32;
-        self.scroll_offset = (self.scroll_offset as i32 + delta).clamp(0, max) as u16;
     }
 }
 
-pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut AppState) {
+/// Prints the full report onto the main screen (the app leaves the alternate
+/// screen while the report is shown) so the terminal's native scrollback and
+/// native text selection just work. There is intentionally no custom
+/// scrolling and no pinned footer on this page: the command line is printed
+/// last and scrolls away with the content.
+pub fn print(state: &AppState) -> Result<()> {
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
     let common = get_common_labels(native_language_code(state.config.as_ref()));
-
-    let chunks: [Rect; 2] =
-        Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(area);
-
-    let (paragraph, max_offset) = {
-        let lines = build_report_lines(&state.report, labels);
-        let paragraph = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: true });
-        let line_count = paragraph.line_count(chunks[0].width);
-        let max_offset = line_count.saturating_sub(chunks[0].height as usize) as u16;
-        (paragraph, max_offset)
-    };
-
-    state.report.scroll_offset = state.report.scroll_offset.min(max_offset);
-    state.report.max_scroll_offset = max_offset;
-
-    frame.render_widget(paragraph.scroll((state.report.scroll_offset, 0)), chunks[0]);
-
-    let mut entries = vec![("↑/↓", labels.wheel_scroll)];
-    if state.report.max_scroll_offset > 0 {
-        entries.extend(mouse_footer_entries(state.mouse_capture, &labels));
+    let mut stdout = std::io::stdout();
+    stdout.queue(Print("\r\n"))?;
+    for line in build_report_lines(&state.report, labels) {
+        print_line(&mut stdout, &line, None)?;
     }
-    entries.push(("n", common.new_topic));
-    entries.push(("r", common.repeat));
-    entries.push(("d", labels.docs));
-    entries.push(("Esc", common.dashboard));
-    entries.push(("?", common.help));
+    let footer = Line::from(build_footer(&[
+        ("n", common.new_topic),
+        ("r", common.repeat),
+        ("d", labels.docs),
+        ("Esc", common.dashboard),
+    ]));
+    print_line(&mut stdout, &footer, Some(Color::DarkGray))?;
+    stdout.execute(ResetColor)?;
+    stdout.flush()?;
+    Ok(())
+}
 
-    frame.render_widget(
-        Paragraph::new(Line::from(build_footer(&entries)))
-            .style(Style::default().fg(Color::DarkGray)),
-        chunks[1],
-    );
+fn print_line(stdout: &mut impl Write, line: &Line, fallback_fg: Option<Color>) -> Result<()> {
+    for span in &line.spans {
+        let mut style = span.style;
+        if style.fg.is_none() {
+            style.fg = fallback_fg;
+        }
+        stdout.queue(PrintStyledContent(StyledContent::new(
+            to_content_style(style),
+            span.content.as_ref(),
+        )))?;
+    }
+    stdout.queue(Print("\r\n"))?;
+    Ok(())
+}
+
+fn to_content_style(style: Style) -> ContentStyle {
+    let mut converted = ContentStyle::new();
+    converted.foreground_color = style.fg.map(to_crossterm_color);
+    if style.add_modifier.contains(Modifier::BOLD) {
+        converted.attributes.set(Attribute::Bold);
+    }
+    if style.add_modifier.contains(Modifier::ITALIC) {
+        converted.attributes.set(Attribute::Italic);
+    }
+    converted
+}
+
+fn to_crossterm_color(color: Color) -> CrosstermColor {
+    match color {
+        Color::Reset => CrosstermColor::Reset,
+        Color::Black => CrosstermColor::Black,
+        Color::Red => CrosstermColor::DarkRed,
+        Color::Green => CrosstermColor::DarkGreen,
+        Color::Yellow => CrosstermColor::DarkYellow,
+        Color::Blue => CrosstermColor::DarkBlue,
+        Color::Magenta => CrosstermColor::DarkMagenta,
+        Color::Cyan => CrosstermColor::DarkCyan,
+        Color::Gray => CrosstermColor::Grey,
+        Color::DarkGray => CrosstermColor::DarkGrey,
+        Color::LightRed => CrosstermColor::Red,
+        Color::LightGreen => CrosstermColor::Green,
+        Color::LightYellow => CrosstermColor::Yellow,
+        Color::LightBlue => CrosstermColor::Blue,
+        Color::LightMagenta => CrosstermColor::Magenta,
+        Color::LightCyan => CrosstermColor::Cyan,
+        Color::White => CrosstermColor::White,
+        Color::Rgb(r, g, b) => CrosstermColor::Rgb { r, g, b },
+        Color::Indexed(i) => CrosstermColor::AnsiValue(i),
+    }
 }
 
 pub async fn handle_key(state: &mut AppState, code: KeyCode) -> Result<()> {
@@ -143,12 +177,6 @@ pub async fn handle_key(state: &mut AppState, code: KeyCode) -> Result<()> {
                     state.view = View::Docs;
                 }
             }
-        }
-        KeyCode::Char('j') | KeyCode::Down => {
-            state.report.scroll_by(1);
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            state.report.scroll_by(-1);
         }
         _ => {}
     }
@@ -440,23 +468,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn scroll_by_clamps_to_bounds() {
-        let mut state = ReportState {
-            max_scroll_offset: 10,
-            ..Default::default()
-        };
-
-        state.scroll_by(3);
-        assert_eq!(state.scroll_offset, 3);
-
-        state.scroll_by(-5);
-        assert_eq!(state.scroll_offset, 0);
-
-        state.scroll_by(100);
-        assert_eq!(state.scroll_offset, 10);
-    }
-
-    #[test]
     fn report_header_shows_topic_name() {
         let report = ReportState {
             target_topic_name: Some("Preterito".to_string()),
@@ -465,5 +476,34 @@ mod tests {
         let lines = build_report_lines(&report, get_report_labels("ru"));
         let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(header, "Тема: Preterito");
+    }
+
+    #[test]
+    fn ratatui_colors_convert_to_crossterm() {
+        assert_eq!(
+            to_crossterm_color(Color::Rgb(0x34, 0xda, 0xb7)),
+            CrosstermColor::Rgb {
+                r: 0x34,
+                g: 0xda,
+                b: 0xb7
+            }
+        );
+        assert_eq!(
+            to_crossterm_color(Color::DarkGray),
+            CrosstermColor::DarkGrey
+        );
+        assert_eq!(to_crossterm_color(Color::Red), CrosstermColor::DarkRed);
+    }
+
+    #[test]
+    fn bold_and_italic_modifiers_convert_to_attributes() {
+        let style = Style::default()
+            .fg(colors::GREEN)
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::ITALIC);
+        let converted = to_content_style(style);
+        assert!(converted.foreground_color.is_some());
+        assert!(converted.attributes.has(Attribute::Bold));
+        assert!(converted.attributes.has(Attribute::Italic));
     }
 }


### PR DESCRIPTION
## Problem

On the analysis (Report) page, text selection was impossible whenever the content overflowed: the app captured the mouse to provide wheel scrolling, and a terminal cannot do native drag-selection while an application owns the mouse. The page also had custom scrolling (`j/k`, wheel) with a pinned footer — all of which fought the terminal instead of using it. (Note: the app runs in the alternate screen, which has no native scrollback at all, so simply unpinning the footer would not have helped.)

## Fix

The Report page no longer lives in the TUI. When the view becomes `Report`, the app:

1. Leaves the alternate screen and releases the mouse.
2. Prints the full report once onto the main screen — styled spans are converted to ANSI colors/bold/italic, so it looks the same as before.
3. Prints the command line (`n` / `r` / `d` / `Esc`) as the last line — it scrolls away with the content, no pinned footer.
4. Waits for a navigation key, then re-enters the alternate screen and resumes the TUI.

Result: native terminal scrollback scrolling and native text selection, with zero custom scroll code and zero new commands.

## Removed

- Report's custom scrolling (`j/k`, wheel, scroll offsets) and the pinned footer.
- Report from the mouse-capture machinery (`view_supports_mouse`, `view_content_overflows`, wheel handling) — no more `m` mode on this page.
- Scroll/mouse entries from the report help group (help is a TUI overlay and no longer applies to this page).

Wheel scrolling on Dashboard/Docs/Curriculum is unchanged.

## Tests

- New: ratatui→crossterm color conversion and bold/italic attribute conversion.
- Updated: the report no longer participates in overflow/mouse-capture tests (asserts the opposite now); removed the obsolete `scroll_by` test.
- Full suite green; fmt/clippy clean.