### PR TITLE
fix: release binaries never built, false "Updated" on failed download

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      # release-please-action v4 with a manifest config namespaces outputs per
+      # package path: `<path>--release_created`, `<path>--tag_name`. The plain
+      # `release_created`/`tag_name` outputs only exist for single-package
+      # mode — without the namespace the build-release job never starts.
+      release_created: ${{ steps.release.outputs['crates/cli--release_created'] }}
+      tag_name: ${{ steps.release.outputs['crates/cli--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -7,7 +7,10 @@ const GITHUB_LATEST_API: &str =
 
 const GITHUB_LATEST_PAGE: &str = "https://github.com/scriptology/open-course-cli/releases/latest";
 
-const INSTALL_COMMAND: &str = "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/scriptology/open-course-cli/releases/latest/download/opencourse-installer.sh | sh";
+/// Downloads the installer to a temp file first and only then runs it: with a
+/// plain `curl | sh` pipe a failed download (e.g. a release without assets)
+/// pipes nothing into `sh`, which exits 0 and fakes a successful update.
+const INSTALL_COMMAND: &str = "tmp=\"$(mktemp)\" && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/scriptology/open-course-cli/releases/latest/download/opencourse-installer.sh -o \"$tmp\" && sh \"$tmp\"; rc=$?; rm -f \"$tmp\"; exit $rc";
 
 /// Query GitHub for the latest release tag and return it without the leading
 /// `v`. Any network or parse error is treated as "no update available" so the


### PR DESCRIPTION
## Why

After merging the cloud-sync PR, the v0.9.0 release was created **without binaries**: the `build-release` job never started, and `opencourse update` printed `Updated to v0.9.0` while the download had actually failed with 404 — leaving users on the old binary, which then fails to open a database already migrated by v0.9.0 (`Schema Error: Provided schema does not match existing table schema`).

## Fixes

1. **release-please.yml** — with release-please-action v4 + manifest config, step outputs are namespaced per package path: `steps.release.outputs['crates/cli--release_created']` / `['crates/cli--tag_name']`. The un-namespaced outputs only exist in single-package mode, so the `if` on `build-release` was always false.
2. **update.rs** — `INSTALL_COMMAND` now downloads `opencourse-installer.sh` to a temp file first and only then executes it. With `curl | sh`, a failed download pipes nothing into `sh`, which exits 0 and fakes success.
3. **Cargo.lock** — sync `open-course-cli` version with the 0.9.0 release.

## After merge

Backfill the missing v0.9.0 assets: Actions → Release → Run workflow with `version: v0.9.0` (attaches tarballs + installer to the existing release). Then `opencourse update` works for real.