### PR TITLE
fix: one error style across the CLI, action before error in Account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/src/ui/views/onboarding/mod.rs
+++ b/crates/cli/src/ui/views/onboarding/mod.rs
@@ -15,6 +15,7 @@ use crate::ui::views::model_check;
 use crate::ui::widgets::Logo;
 use crate::ui::widgets::build_footer;
 use crate::ui::widgets::build_footer_wrapped;
+use crate::ui::widgets::error_lines;
 use crate::ui::widgets::model_picker;
 use open_course_config::profile::UserProfile;
 use open_course_config::provider::ProviderConfig;
@@ -112,9 +113,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     };
     let mut footer_lines: Vec<Line> = footer_text.lines().map(Line::from).collect();
     if !state.onboarding.error.is_empty() {
-        footer_lines.push(
-            Line::from(state.onboarding.error.clone()).style(Style::default().fg(Color::Red)),
-        );
+        footer_lines.extend(error_lines(&state.onboarding.error));
     }
     let footer_height = footer_lines.len() as u16;
 
@@ -245,11 +244,8 @@ fn render_model_step(
     }
 
     if let Some(err) = &state.onboarding.model_picker.error {
-        frame.render_widget(
-            Paragraph::new(labels.failed_load_models.replace("{}", err))
-                .style(Style::default().fg(Color::Red)),
-            area,
-        );
+        let message = labels.failed_load_models.replace("{}", err);
+        frame.render_widget(Paragraph::new(Text::from(error_lines(&message))), area);
         return;
     }
 

--- a/crates/cli/src/ui/views/settings/account.rs
+++ b/crates/cli/src/ui/views/settings/account.rs
@@ -17,7 +17,7 @@ use open_course_sync::{
 
 use crate::app::AppState;
 use crate::ui::labels::SettingsLabels;
-use crate::ui::widgets::Toast;
+use crate::ui::widgets::{Toast, error_lines};
 
 /// Messages from background sync tasks to the event loop.
 #[derive(Debug)]
@@ -155,8 +155,10 @@ pub struct AccountState {
     pub outbox_len: Option<usize>,
     pub subscription: Option<String>,
     pub relogin_required: bool,
-    /// Transient status/error line (sync result, network error).
+    /// Transient status line (sync result, info).
     pub notice: Option<String>,
+    /// Error line, shown as-is in the shared error style.
+    pub error: Option<String>,
     pub syncing: bool,
     /// Active action row.
     pub field: usize,
@@ -179,6 +181,7 @@ pub async fn on_enter(state: &mut AppState) {
     let account = &mut state.settings.account;
     account.field = 0;
     account.notice = None;
+    account.error = None;
     if let Some(config) = state.config.as_ref() {
         account.email = config.sync.as_ref().and_then(|s| s.account_email.clone());
         account.device_id = config.sync.as_ref().and_then(|s| s.device_id.clone());
@@ -229,6 +232,7 @@ pub async fn activate(state: &mut AppState) -> Result<()> {
 fn start_sign_in(state: &mut AppState) {
     state.settings.account.status = LoginStatus::Starting;
     state.settings.account.notice = None;
+    state.settings.account.error = None;
     let base_url = resolve_sync_server_url(state.config.as_ref());
     let tx = state.sync_tx.clone();
     tokio::spawn(async move {
@@ -320,6 +324,7 @@ async fn finish_login(
 fn start_manual_sync(state: &mut AppState) {
     state.settings.account.syncing = true;
     state.settings.account.notice = None;
+    state.settings.account.error = None;
     spawn_sync(state, SyncKind::Manual);
 }
 
@@ -332,6 +337,7 @@ async fn toggle_sync(state: &mut AppState) -> Result<()> {
     // Enabling: probe the cloud first — the pair may already have a
     // canonical curriculum pushed by another device.
     let lang = crate::ui::labels::native_language_code(state.config.as_ref());
+    state.settings.account.error = None;
     state.settings.account.notice = Some(
         crate::ui::labels::get_settings_labels(lang)
             .account_bind_checking
@@ -559,7 +565,7 @@ pub async fn apply_sync_message(state: &mut AppState, message: SyncMessage) {
         }
         SyncMessage::DeviceFlowStarted(Err(e)) => {
             state.settings.account.status = LoginStatus::LoggedOut;
-            state.settings.account.notice = Some(e);
+            state.settings.account.error = Some(e);
         }
         SyncMessage::DeviceFlowExpired => {
             if state.settings.account.status == LoginStatus::WaitingConfirmation {
@@ -576,7 +582,7 @@ pub async fn apply_sync_message(state: &mut AppState, message: SyncMessage) {
                     sync.server_url = Some(server_url);
                 }
                 if let Err(e) = write_config(config, &state.data_dir) {
-                    state.settings.account.notice = Some(e.to_string());
+                    state.settings.account.error = Some(e.to_string());
                 }
             }
             let account = &mut state.settings.account;
@@ -590,10 +596,11 @@ pub async fn apply_sync_message(state: &mut AppState, message: SyncMessage) {
         }
         SyncMessage::LoginFinished(Err(e)) => {
             state.settings.account.status = LoginStatus::LoggedOut;
-            state.settings.account.notice = Some(e);
+            state.settings.account.error = Some(e);
         }
         SyncMessage::BindScenarioLoaded(Ok(scenario)) => {
             state.settings.account.notice = None;
+            state.settings.account.error = None;
             match scenario {
                 BindScenario::FreshLocal => {
                     enable_and_run(state, SyncKind::AfterSession).await;
@@ -607,7 +614,7 @@ pub async fn apply_sync_message(state: &mut AppState, message: SyncMessage) {
             }
         }
         SyncMessage::BindScenarioLoaded(Err(e)) => {
-            state.settings.account.notice = Some(e);
+            state.settings.account.error = Some(e);
         }
         SyncMessage::CurriculumConflict(payload) => {
             open_bind_dialog(state, payload).await;
@@ -664,7 +671,7 @@ fn apply_sync_failure(state: &mut AppState, labels: &SettingsLabels, failure: Sy
         account.notice = Some(labels.account_sync_conflict.to_string());
         state.toast = Some(Toast::info(labels.account_sync_conflict_toast));
     } else {
-        account.notice = Some(format!(
+        account.error = Some(format!(
             "{}: {}",
             labels.account_sync_failed, failure.message
         ));
@@ -773,6 +780,7 @@ fn confirm_bind_dialog(state: &mut AppState, dialog: BindDialog) {
 fn execute_adopt(state: &mut AppState, payload: CurriculumPayload, merge: ProgressMerge) {
     state.settings.account.syncing = true;
     state.settings.account.notice = None;
+    state.settings.account.error = None;
     let data_dir = state.data_dir.clone();
     let base_url = resolve_sync_server_url(state.config.as_ref());
     let pair_id = state
@@ -817,6 +825,7 @@ fn execute_adopt(state: &mut AppState, payload: CurriculumPayload, merge: Progre
 fn execute_replace(state: &mut AppState, _payload: CurriculumPayload) {
     state.settings.account.syncing = true;
     state.settings.account.notice = None;
+    state.settings.account.error = None;
     let data_dir = state.data_dir.clone();
     let base_url = resolve_sync_server_url(state.config.as_ref());
     let pair_id = state
@@ -890,9 +899,11 @@ pub fn build_body(state: &AppState, labels: &SettingsLabels) -> Text<'static> {
 
     match account.status {
         LoginStatus::LoggedOut => {
-            lines.push(Line::from(labels.account_not_logged_in));
-            lines.push(Line::from(""));
             lines.push(action_line(marker(0), labels.account_sign_in));
+            if account.error.is_none() {
+                lines.push(Line::from(""));
+                lines.push(Line::from(labels.account_not_logged_in));
+            }
         }
         LoginStatus::Starting => {
             lines.push(Line::from(labels.account_starting));
@@ -913,9 +924,11 @@ pub fn build_body(state: &AppState, labels: &SettingsLabels) -> Text<'static> {
             lines.push(Line::from(labels.account_waiting));
         }
         LoginStatus::Expired => {
-            lines.push(Line::from(labels.account_expired));
-            lines.push(Line::from(""));
             lines.push(action_line(marker(0), labels.account_sign_in_retry));
+            if account.error.is_none() {
+                lines.push(Line::from(""));
+                lines.push(Line::from(labels.account_expired));
+            }
         }
         LoginStatus::LoggingIn => {
             lines.push(Line::from(labels.account_logging_in));
@@ -1007,6 +1020,10 @@ pub fn build_body(state: &AppState, labels: &SettingsLabels) -> Text<'static> {
 
     if account.syncing && account.status != LoginStatus::LoggedIn {
         lines.push(Line::from(labels.account_syncing));
+    }
+    if let Some(error) = &account.error {
+        lines.push(Line::from(""));
+        lines.extend(error_lines(error));
     }
     if let Some(notice) = &account.notice {
         lines.push(Line::from(""));

--- a/crates/cli/src/ui/views/settings/mod.rs
+++ b/crates/cli/src/ui/views/settings/mod.rs
@@ -16,7 +16,7 @@ use crate::ui::labels::{
     native_language_code,
 };
 use crate::ui::views::utils::{select_next_wrapping, select_previous_wrapping};
-use crate::ui::widgets::{build_footer_wrapped, draw_confirmation, model_picker};
+use crate::ui::widgets::{ERROR_COLOR, build_footer_wrapped, draw_confirmation, model_picker};
 use open_course_config::OpenCourseConfig;
 use open_course_config::provider::ProviderId;
 use open_course_config::write_config;
@@ -230,7 +230,7 @@ fn build_body(state: &AppState, labels: ReportLabels, settings: &SettingsLabels)
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled(
                     labels.invalid_value.to_string(),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(ERROR_COLOR),
                 ));
             }
             lines.push(Line::from(spans));

--- a/crates/cli/src/ui/widgets/error_box.rs
+++ b/crates/cli/src/ui/widgets/error_box.rs
@@ -1,7 +1,25 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
+
+/// Single source of the error style across the CLI.
+pub const ERROR_COLOR: Color = Color::Red;
+
+/// Inline error rendering: the message as-is, styled with the shared error
+/// color. This is the one way errors are shown inside views.
+pub fn error_lines(message: &str) -> Vec<Line<'static>> {
+    message
+        .lines()
+        .map(|line| {
+            Line::from(Span::styled(
+                line.to_string(),
+                Style::default().fg(ERROR_COLOR),
+            ))
+        })
+        .collect()
+}
 
 pub struct ErrorBox {
     message: String,
@@ -24,14 +42,30 @@ impl Widget for ErrorBox {
         let block = Block::default()
             .title(self.title)
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Red));
+            .border_style(Style::default().fg(ERROR_COLOR));
         let inner = block.inner(area);
         block.render(area, buf);
 
         let text = format!("{}\n\n{}", self.message, self.footer_hint);
         Paragraph::new(text)
-            .style(Style::default().fg(Color::Red))
+            .style(Style::default().fg(ERROR_COLOR))
             .wrap(Wrap { trim: true })
             .render(inner, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_lines_styles_every_line_as_error_without_changes() {
+        let lines = error_lines("boom\nsecond line");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].spans[0].content, "boom");
+        assert_eq!(lines[1].spans[0].content, "second line");
+        for line in &lines {
+            assert_eq!(line.spans[0].style.fg, Some(ERROR_COLOR));
+        }
     }
 }

--- a/crates/cli/src/ui/widgets/mod.rs
+++ b/crates/cli/src/ui/widgets/mod.rs
@@ -18,7 +18,7 @@ pub mod logo;
 
 pub use cards::Card;
 pub use confirmation::draw_confirmation;
-pub use error_box::ErrorBox;
+pub use error_box::{ERROR_COLOR, ErrorBox, error_lines};
 pub use footer::{build_footer, build_footer_wrapped};
 pub use help_overlay::HelpOverlay;
 pub use hint_bar::HintBar;

--- a/crates/cli/tests/settings_layout_test.rs
+++ b/crates/cli/tests/settings_layout_test.rs
@@ -591,6 +591,33 @@ async fn settings_account_logged_out_renders_sign_in() {
 }
 
 #[tokio::test]
+async fn settings_account_error_renders_below_sign_in_action() {
+    let mut state = setup_state().await;
+    state.view = View::Settings;
+    state.settings.in_section = true;
+    state.settings.section = Section::Account;
+    state.settings.account.error = Some("network error: error sending request".to_string());
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| settings::draw(f, f.area(), &mut state))
+        .unwrap();
+
+    let text = buffer_text(&terminal);
+    let action_pos = text.find("Войти").expect("sign-in action shown");
+    let error_pos = text.find("network error").expect("error text shown as-is");
+    assert!(
+        action_pos < error_pos,
+        "action row must come before the error text, got:\n{text}"
+    );
+    assert!(
+        !text.contains("Вход не выполнен"),
+        "neutral status is replaced by the error block, got:\n{text}"
+    );
+}
+
+#[tokio::test]
 async fn settings_account_logged_in_renders_status_and_actions() {
     use open_course_cli::ui::views::settings::account;
     use open_course_sync::TokenBackend;


### PR DESCRIPTION
Inline errors render through a single shared primitive (`error_lines` + `ERROR_COLOR` in the error_box widget); Account shows the sign-in action first with the raw error below it instead of a yellow notice at the bottom; onboarding and settings use the same style source. No message rewriting — errors are shown as-is.