### PR TITLE
feat(core): move LLM prompts/parsing and UserProfile into core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4600,11 +4600,13 @@ name = "open-course-core"
 version = "0.8.0"
 dependencies = [
  "chrono",
+ "regex",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "unicode-normalization",
+ "utoipa",
  "uuid",
 ]
 
@@ -7080,6 +7082,29 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ arrow-schema = "58"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "1"
+utoipa = "5"
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/config/src/profile.rs
+++ b/crates/config/src/profile.rs
@@ -1,21 +1,15 @@
 use serde::{Deserialize, Serialize};
 
+// Re-exported from core so the profile type is shared with the LLM
+// prompt/parsing code and external consumers; the config file format is
+// unchanged.
+pub use open_course_core::profile::UserProfile;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LanguagePair {
     pub id: String,
     pub profile: UserProfile,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct UserProfile {
-    pub native_language: String,
-    pub target_language: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub age: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub self_assessed_cefr: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.8.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = []
+# Optional OpenAPI schema derives for consumers that build an HTTP API
+# (e.g. the sync server) on top of these wire types.
+utoipa = ["dep:utoipa"]
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -13,3 +19,4 @@ thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 uuid = { workspace = true }
 regex = { workspace = true }
+utoipa = { workspace = true, optional = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,3 +12,4 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 uuid = { workspace = true }
+regex = { workspace = true }

--- a/crates/core/src/curriculum.rs
+++ b/crates/core/src/curriculum.rs
@@ -149,6 +149,7 @@ pub fn dedupe(topics: Vec<Topic>) -> (Vec<Topic>, Vec<Topic>) {
     (kept, removed)
 }
 #[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Topic {
     pub id: String,
@@ -229,6 +230,7 @@ impl Difficulty {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Curriculum {
     #[serde(default = "default_version")]

--- a/crates/core/src/history.rs
+++ b/crates/core/src/history.rs
@@ -1,6 +1,7 @@
 pub const MAX_HISTORY_ENTRIES: usize = 500;
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct SessionSummary {
     pub id: String,
     pub date: String,

--- a/crates/core/src/learning_items.rs
+++ b/crates/core/src/learning_items.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::curriculum::is_abstract_topic_name;
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct LearningItem {
     pub id: String,
     pub name: String,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,8 @@ pub mod error;
 pub mod history;
 pub mod language;
 pub mod learning_items;
+pub mod llm;
+pub mod profile;
 pub mod progress;
 pub mod reviews;
 pub mod session;

--- a/crates/core/src/llm/mod.rs
+++ b/crates/core/src/llm/mod.rs
@@ -1,0 +1,6 @@
+//! LLM prompt builders and response parsing, shared with external consumers
+//! (e.g. the server crate) that drive the same model contract.
+
+pub mod parse;
+pub mod prompts;
+pub mod response;

--- a/crates/core/src/llm/parse.rs
+++ b/crates/core/src/llm/parse.rs
@@ -1,24 +1,24 @@
 use serde::{Deserialize, Serialize};
 use serde_json::from_str;
 
-use crate::transport::LlmResponse;
-use open_course_core::curriculum::Topic;
-use open_course_core::error::{AppError, Result};
-use open_course_core::session::{AnalysisResult, Exercise, SentenceAnalysis};
+use crate::curriculum::Topic;
+use crate::error::{AppError, Result};
+use crate::llm::response::LlmResponse;
+use crate::session::{AnalysisResult, Exercise, SentenceAnalysis};
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct Exercises {
+pub struct Exercises {
     pub exercises: Vec<Exercise>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct LevelCurriculum {
+pub struct LevelCurriculum {
     pub topics: Vec<Topic>,
 }
 
-pub(crate) fn parse_exercises(
+pub fn parse_exercises(
     cleaned: &str,
     content_chars: usize,
     reasoning_chars: usize,
@@ -49,7 +49,7 @@ pub(crate) fn parse_exercises(
     ))
 }
 
-pub(crate) fn exercise_parse_errors(cleaned: &str) -> String {
+pub fn exercise_parse_errors(cleaned: &str) -> String {
     let wrapper_err = from_str::<Exercises>(cleaned)
         .err()
         .map(|e| format!("as {{exercises}}: {e}"))
@@ -61,7 +61,7 @@ pub(crate) fn exercise_parse_errors(cleaned: &str) -> String {
     format!("{wrapper_err}; {vec_err}")
 }
 
-pub(crate) fn parse_analysis(
+pub fn parse_analysis(
     cleaned: &str,
     expected_sentence_count: usize,
     content_chars: usize,
@@ -109,7 +109,7 @@ pub(crate) fn parse_analysis(
     )
 }
 
-pub(crate) fn validate_analysis_sentences(
+pub fn validate_analysis_sentences(
     mut analysis: AnalysisResult,
     expected_sentence_count: usize,
     content_chars: usize,
@@ -135,7 +135,7 @@ pub(crate) fn validate_analysis_sentences(
     Ok(analysis)
 }
 
-pub(crate) fn analysis_parse_errors(cleaned: &str, expected_sentence_count: usize) -> String {
+pub fn analysis_parse_errors(cleaned: &str, expected_sentence_count: usize) -> String {
     let top_err = from_str::<AnalysisResult>(cleaned)
         .err()
         .map(|e| format!("top-level: {e}"))
@@ -147,7 +147,7 @@ pub(crate) fn analysis_parse_errors(cleaned: &str, expected_sentence_count: usiz
     format!("expected {expected_sentence_count} sentences; top-level: {top_err}; array: {arr_err}")
 }
 
-pub(crate) fn parse_curriculum_level(
+pub fn parse_curriculum_level(
     cleaned: &str,
     level: &str,
     content_chars: usize,
@@ -180,14 +180,14 @@ pub(crate) fn parse_curriculum_level(
     Ok(level_curriculum.topics)
 }
 
-pub(crate) fn curriculum_parse_errors(cleaned: &str, level: &str) -> String {
+pub fn curriculum_parse_errors(cleaned: &str, level: &str) -> String {
     from_str::<LevelCurriculum>(cleaned)
         .err()
         .map(|e| format!("{level} curriculum parse: {e}"))
         .unwrap_or_default()
 }
 
-pub(crate) fn build_parse_error(
+pub fn build_parse_error(
     kind: &str,
     response: &LlmResponse,
     cleaned: &str,
@@ -223,7 +223,7 @@ pub(crate) fn build_parse_error(
     ))
 }
 
-pub(crate) fn clean_json_response(raw: &str) -> String {
+pub fn clean_json_response(raw: &str) -> String {
     // Replace raw newlines with spaces so models that emit multi-line strings
     // without escaping do not break JSON parsing.
     let trimmed = raw.trim().replace('\r', "").replace('\n', " ");
@@ -272,7 +272,7 @@ static CURRICULUM_ID_RE: std::sync::LazyLock<regex::Regex> =
 /// Some models return ids containing brackets, semicolons, etc., which break
 /// JSON parsing. This replaces every id value with a kebab-case string
 /// containing only lowercase letters, digits, and hyphens.
-pub(crate) fn sanitize_curriculum_ids(raw: &str) -> String {
+pub fn sanitize_curriculum_ids(raw: &str) -> String {
     CURRICULUM_ID_RE
         .replace_all(raw, |caps: &regex::Captures| {
             let value = &caps[1];
@@ -295,7 +295,7 @@ pub(crate) fn sanitize_curriculum_ids(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use open_course_core::session::SemanticVerdict;
+    use crate::session::SemanticVerdict;
 
     // --- clean_json_response ---
 

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -1,8 +1,8 @@
-use open_course_config::profile::UserProfile;
-use open_course_core::curriculum::{CURRICULUM_DOMAIN_DESCRIPTIONS, Topic, cefr_to_difficulty};
-use open_course_core::learning_items::LearningItem;
-use open_course_core::progress::ProgressTopic;
-use open_course_core::session::{Exercise, NewTopicRef};
+use crate::curriculum::{CURRICULUM_DOMAIN_DESCRIPTIONS, Topic, cefr_to_difficulty};
+use crate::learning_items::LearningItem;
+use crate::profile::UserProfile;
+use crate::progress::ProgressTopic;
+use crate::session::{Exercise, NewTopicRef};
 
 pub fn build_exercise_prompt(
     profile: &UserProfile,

--- a/crates/core/src/llm/response.rs
+++ b/crates/core/src/llm/response.rs
@@ -1,0 +1,27 @@
+/// Raw text of an LLM response together with its content/reasoning sizes,
+/// used by the parsing code to build informative errors.
+#[derive(Debug, Clone)]
+pub struct LlmResponse {
+    pub raw: String,
+    pub content_chars: usize,
+    pub reasoning_chars: usize,
+}
+
+impl LlmResponse {
+    pub fn empty() -> Self {
+        Self {
+            raw: String::new(),
+            content_chars: 0,
+            reasoning_chars: 0,
+        }
+    }
+
+    pub fn from_text(text: String) -> Self {
+        let chars = text.chars().count();
+        Self {
+            raw: text,
+            content_chars: chars,
+            reasoning_chars: 0,
+        }
+    }
+}

--- a/crates/core/src/profile.rs
+++ b/crates/core/src/profile.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 /// Field names and serde attributes are part of the config file and wire
 /// format — change them only with a migration.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct UserProfile {
     pub native_language: String,

--- a/crates/core/src/profile.rs
+++ b/crates/core/src/profile.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+/// Language-learner profile shared with the prompts and the server.
+/// Field names and serde attributes are part of the config file and wire
+/// format — change them only with a migration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UserProfile {
+    pub native_language: String,
+    pub target_language: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub age: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_assessed_cefr: Option<String>,
+}

--- a/crates/core/src/progress.rs
+++ b/crates/core/src/progress.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ProgressTopic {
     pub topic_id: String,
     pub score: f64,

--- a/crates/core/src/session/models.rs
+++ b/crates/core/src/session/models.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::curriculum::Topic;
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Exercise {
     pub id: String,
@@ -53,6 +54,7 @@ where
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct AnalysisResult {
     pub session_score: Option<f64>,
@@ -71,6 +73,7 @@ pub struct AnalysisResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SentenceAnalysis {
     pub sentence_number: i32,
@@ -89,6 +92,7 @@ pub struct SentenceAnalysis {
 #[derive(
     Debug, Clone, Copy, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq, Default,
 )]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum SemanticVerdict {
     #[default]
@@ -98,12 +102,14 @@ pub enum SemanticVerdict {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FeedbackComment {
     pub comment: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GrammarError {
     #[serde(rename = "type", default)]
@@ -119,6 +125,7 @@ pub struct GrammarError {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct NewTopicRef {
     #[serde(default)]
@@ -132,6 +139,7 @@ pub struct NewTopicRef {
 #[derive(
     Debug, Clone, Copy, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq, Default,
 )]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum GrammarErrorType {
     Critical,
@@ -142,6 +150,7 @@ pub enum GrammarErrorType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluatedTopic {
     pub topic_id: String,

--- a/crates/core/src/sync_protocol.rs
+++ b/crates/core/src/sync_protocol.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 /// `POST {base}/auth/device` response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceCodeResponse {
     pub device_code: String,
@@ -23,6 +24,7 @@ pub struct DeviceCodeResponse {
 
 /// `POST {base}/auth/device/poll` success body (HTTP 200).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct TokenSet {
     pub access_token: String,
@@ -35,6 +37,7 @@ pub struct TokenSet {
 
 /// Error body used by device poll (and accepted elsewhere).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ErrorBody {
     pub error: String,
 }
@@ -43,6 +46,7 @@ pub struct ErrorBody {
 /// "tombstoneReset"; `entity` is one of "topic" | "progress" | "session" |
 /// "learningItem" | "metadata".
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Change {
     pub seq: i64,
@@ -57,6 +61,7 @@ pub struct Change {
 
 /// `POST {base}/v1/sync/push` request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PushRequest {
     pub pair_id: String,
@@ -71,6 +76,7 @@ pub struct PushRequest {
 
 /// `POST {base}/v1/sync/push` success body (HTTP 2xx).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PushResponse {
     pub revision: i64,
@@ -79,6 +85,7 @@ pub struct PushResponse {
 /// The server's canonical curriculum, returned on a push conflict (409) or
 /// requested when binding a device to a pair that already has one.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CurriculumPayload {
     pub revision: i64,
@@ -92,6 +99,7 @@ pub struct CurriculumPayload {
 
 /// Push conflict body (HTTP 409): `{ "canonical": CurriculumPayload }`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ConflictBody {
     pub canonical: CurriculumPayload,
 }
@@ -100,6 +108,7 @@ pub struct ConflictBody {
 /// present when the server wiped the pair's data (all clients must reset
 /// before applying `changes`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PullResponse {
     pub revision: i64,
@@ -111,6 +120,7 @@ pub struct PullResponse {
 
 /// `GET {base}/v1/me` response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct MeResponse {
     pub email: String,

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -5,15 +5,20 @@ pub mod debug_log;
 pub mod diagnostics;
 pub mod factory;
 pub mod model_listing;
-pub mod parse;
 pub mod pipeline;
-pub mod prompts;
 pub mod provider;
 pub mod result;
 pub mod retry;
 pub mod streaming;
 pub mod topic_review;
 pub mod transport;
+
+// Prompt builders and response parsing live in `open-course-core` so external
+// consumers (e.g. the server) can reuse them without the LLM client stack.
+// Re-exported here to keep the existing `open_course_llm::{prompts, parse}`
+// paths working.
+pub use open_course_core::llm::parse;
+pub use open_course_core::llm::prompts;
 
 pub use result::LlmResult;
 

--- a/crates/llm/src/transport.rs
+++ b/crates/llm/src/transport.rs
@@ -9,35 +9,10 @@ use crate::client::LlmClient;
 use crate::debug_log::log_debug_event;
 use crate::streaming::StreamChunk;
 use open_course_core::error::{AppError, Result};
+pub(crate) use open_course_core::llm::response::LlmResponse;
 
 pub(crate) const LLM_TIMEOUT_SECONDS: u64 = 60;
 pub(crate) const LLM_CURRICULUM_TIMEOUT_SECONDS: u64 = 300;
-
-#[derive(Debug, Clone)]
-pub(crate) struct LlmResponse {
-    pub raw: String,
-    pub content_chars: usize,
-    pub reasoning_chars: usize,
-}
-
-impl LlmResponse {
-    pub fn empty() -> Self {
-        Self {
-            raw: String::new(),
-            content_chars: 0,
-            reasoning_chars: 0,
-        }
-    }
-
-    pub fn from_text(text: String) -> Self {
-        let chars = text.chars().count();
-        Self {
-            raw: text,
-            content_chars: chars,
-            reasoning_chars: 0,
-        }
-    }
-}
 
 pub(crate) fn send_status(label: &str, stream_tx: Option<&mpsc::Sender<LlmResult>>) {
     if let Some(tx) = stream_tx {


### PR DESCRIPTION
## Summary

Moves the LLM prompt builders and response parsing into `open-course-core` so the upcoming server crate (separate repo) can consume them via a git dependency without pulling in the LLM client stack (rig-core, reqwest, tokio).

- `UserProfile` moved from `open-course-config` to `open_course_core::profile`, re-exported from config (`open_course_config::profile::UserProfile` still works; `config.json` format unchanged, serde attributes verbatim).
- `crates/llm/src/prompts.rs` and `crates/llm/src/parse.rs` moved to `open_course_core::llm::{prompts, parse}`; items made `pub`. `LlmResponse` moved to `open_course_core::llm::response`.
- `open-course-llm` re-exports both modules (`pub use open_course_core::llm::{parse, prompts}`), so all existing call sites in service/cli and the `open_course_llm::{prompts, parse}` paths are unchanged.
- New optional `utoipa` feature on `open-course-core` (default off): `cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))` on the wire types — sync protocol (`PushRequest`, `Change`, `PullResponse`, `TokenSet`, etc.), `Topic`/`Curriculum`, `LearningItem`, `ProgressTopic`, `SessionSummary`, session DTOs (`Exercise`, `AnalysisResult`, `SentenceAnalysis`, `GrammarError`, `EvaluatedTopic`, …) and `UserProfile` — so the server can generate OpenAPI schemas from the same types.

CLI behavior is unchanged: changes are moves/re-exports plus additive feature-gated derives only.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo check -p open-course-core --features utoipa`
