### PR TITLE
feat(cli): trigger release 0.10.0 for the core LLM move

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,3 +1,9 @@
+//! Binary crate plus re-exports used by the integration tests.
+//!
+//! The LLM prompt builders and response parsers live in
+//! `open_course_core::llm` (moved there so the sync server can reuse them
+//! via a git dependency); `open_course_llm` re-exports them.
+
 pub mod app;
 pub mod ui;
 pub mod update;


### PR DESCRIPTION
Release-please tracks only the `crates/cli` path, so PR #37 (core/config/llm only) did not produce a release PR.

This commit touches `crates/cli` (doc comment only) and carries `Release-As: 0.10.0`, so merging it makes release-please open the 0.10.0 release PR. The resulting git tag is needed by open-course-server (git dependency on open-course-core with the new llm module and utoipa feature).