### PR TITLE
fix(cli): upload pre-sync data on first bind (backfill)

### DIFF
--- a/crates/cli/src/app/sync.rs
+++ b/crates/cli/src/app/sync.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 
 use open_course_config::{pair_db_path, resolve_sync_server_url};
 use open_course_db::Database;
-use open_course_sync::{BindScenario, PushError, SyncClient, SyncError, TokenStore};
+use open_course_sync::{
+    BindScenario, PushError, SyncClient, SyncError, TokenStore, backfill_outbox,
+};
 
 use crate::app::AppState;
 use crate::ui::views::settings::account::{PairSyncStatus, SyncFailure, SyncMessage, SyncReport};
@@ -167,8 +169,34 @@ async fn run_sync(
             if let Err(e) = client.pull(&db, &pair_id).await {
                 Err(map_sync_err(e))
             } else {
+                // Heal pairs whose pre-sync data never reached the cloud
+                // (the outbox only carries post-sync mutations): upload
+                // everything once, marked by `cloud_curriculum_version`.
+                let needs_backfill = db
+                    .metadata()
+                    .cloud_curriculum_version()
+                    .await
+                    .unwrap_or(None)
+                    .is_none()
+                    && !db
+                        .curriculum()
+                        .read_all()
+                        .await
+                        .map(|c| c.topics.is_empty())
+                        .unwrap_or(true);
+                if needs_backfill && let Err(e) = backfill_outbox(&db, true).await {
+                    return Some(SyncOutcome::Done(Err(map_sync_err(e))));
+                }
                 match client.push(&db, &pair_id).await {
-                    Ok(revision) => Ok(SyncReport::sync(revision)),
+                    Ok(revision) => {
+                        if needs_backfill && let Ok(curriculum) = db.curriculum().read_all().await {
+                            let _ = db
+                                .metadata()
+                                .set_cloud_curriculum_version(curriculum.version)
+                                .await;
+                        }
+                        Ok(SyncReport::sync(revision))
+                    }
                     Err(PushError::CurriculumConflict(payload)) => {
                         return Some(SyncOutcome::Conflict(payload));
                     }
@@ -378,11 +406,27 @@ async fn bind_and_sync(client: &SyncClient, db: &Database, pair_id: &str) -> Pai
         Err(e) => return PairSyncStatus::Failed(e.to_string()),
     };
     let result = match scenario {
-        BindScenario::FreshLocal => client
-            .push(db, pair_id)
-            .await
-            .map(|_| PairSyncStatus::Done)
-            .map_err(push_err_status),
+        BindScenario::FreshLocal => {
+            // Pre-sync data never entered the outbox: enqueue it first,
+            // otherwise the "fresh local" push is a no-op.
+            let version = db.curriculum().read_all().await.ok().map(|c| c.version);
+            match backfill_outbox(db, true).await.map_err(sync_err_status) {
+                Err(status) => Err(status),
+                Ok(()) => {
+                    let pushed = client
+                        .push(db, pair_id)
+                        .await
+                        .map(|_| PairSyncStatus::Done)
+                        .map_err(push_err_status);
+                    if pushed.is_ok()
+                        && let Some(version) = version
+                    {
+                        let _ = db.metadata().set_cloud_curriculum_version(version).await;
+                    }
+                    pushed
+                }
+            }
+        }
         BindScenario::FreshCloud => client
             .pull(db, pair_id)
             .await

--- a/crates/sync/src/bind.rs
+++ b/crates/sync/src/bind.rs
@@ -8,7 +8,43 @@
 use std::collections::HashSet;
 
 use open_course_db::Database;
-use open_course_db::outbox::{ENTITY_TOPIC, OP_UPSERT};
+use open_course_db::outbox::{
+    ENTITY_LEARNING_ITEM, ENTITY_PROGRESS, ENTITY_SESSION, ENTITY_TOPIC, OP_UPSERT,
+};
+
+/// Enqueues every local row as an upsert: the first upload of a pair whose
+/// data predates sync. The outbox only carries mutations made after sync
+/// was introduced, so without this backfill a "fresh local" bind pushes
+/// nothing. Re-pushing is safe: the server applies rows last-writer-wins.
+pub async fn backfill_outbox(db: &Database, include_topics: bool) -> Result<(), SyncError> {
+    if include_topics {
+        for topic in &db.curriculum().read_all().await?.topics {
+            let payload = serde_json::to_string(topic)?;
+            db.outbox()
+                .append(OP_UPSERT, ENTITY_TOPIC, &topic.id, &payload)
+                .await?;
+        }
+    }
+    for progress in &db.progress().read_all().await?.topics {
+        let payload = serde_json::to_string(progress)?;
+        db.outbox()
+            .append(OP_UPSERT, ENTITY_PROGRESS, &progress.topic_id, &payload)
+            .await?;
+    }
+    for session in &db.history().read_all().await? {
+        let payload = serde_json::to_string(session)?;
+        db.outbox()
+            .append(OP_UPSERT, ENTITY_SESSION, &session.id, &payload)
+            .await?;
+    }
+    for item in &db.learning_items().read_all().await? {
+        let payload = serde_json::to_string(item)?;
+        db.outbox()
+            .append(OP_UPSERT, ENTITY_LEARNING_ITEM, &item.id, &payload)
+            .await?;
+    }
+    Ok(())
+}
 
 use crate::client::{SyncClient, check_status};
 use crate::error::{PushError, SyncError};
@@ -129,6 +165,21 @@ impl SyncClient {
         // reconciles by last-writer-wins.
         db.metadata().set_last_pulled_seq(0).await?;
         self.pull(db, pair_id).await?;
+        if merge == ProgressMerge::Merge {
+            // Rows the cloud lacks were kept locally; upload them so the
+            // other devices see them (the outbox only had post-sync
+            // mutations until now).
+            backfill_outbox(db, false).await?;
+            self.push(db, pair_id).await.map_err(|e| match e {
+                PushError::Sync(e) => e,
+                // We just adopted this canon; a conflict here would be a
+                // race with another device replacing it mid-bind.
+                PushError::CurriculumConflict(payload) => SyncError::Protocol(format!(
+                    "curriculum conflict right after adopt (revision {})",
+                    payload.revision
+                )),
+            })?;
+        }
         Ok(())
     }
 
@@ -165,6 +216,10 @@ impl SyncClient {
                 .await
                 .map_err(SyncError::from)?;
         }
+
+        // Replace means "my local state becomes the cloud's": progress,
+        // sessions and learning items go along with the curriculum.
+        backfill_outbox(db, false).await?;
 
         let revision = self.push_inner(db, pair_id, true).await?;
         db.metadata()
@@ -243,6 +298,10 @@ impl SyncClient {
         }
         // Local topics that lost the merge (not possible by construction —
         // the merged set is a superset of both sides) need no tombstoning.
+
+        // Upload the rest of the local state (progress, sessions, learning
+        // items): pre-sync rows were never in the outbox.
+        backfill_outbox(db, false).await?;
 
         let revision = self.push_inner(db, pair_id, true).await?;
         db.metadata()

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -12,7 +12,7 @@ pub mod error;
 pub mod protocol;
 mod tokens;
 
-pub use bind::{BindScenario, MergeReport, ProgressMerge};
+pub use bind::{BindScenario, MergeReport, ProgressMerge, backfill_outbox};
 pub use client::{PollResult, SyncClient};
 pub use error::{PushError, SyncError};
 pub use protocol::{

--- a/crates/sync/tests/contract.rs
+++ b/crates/sync/tests/contract.rs
@@ -1203,3 +1203,151 @@ async fn merge_bind_is_idempotent() {
     assert_eq!(canon_first.topics.len(), canon_second.topics.len());
     assert_eq!(db.curriculum().read_all().await.unwrap().topics.len(), 2);
 }
+
+// ---------------------------------------------------------------------------
+// backfill: first upload of pre-sync data (empty outbox, full tables)
+// ---------------------------------------------------------------------------
+
+use open_course_core::history::SessionSummary;
+use open_course_core::learning_items::LearningItem;
+use open_course_sync::backfill_outbox;
+
+#[tokio::test]
+async fn backfill_uploads_pre_sync_data_on_fresh_bind() {
+    let (state, base) = start_mock().await;
+    let (_dir, db) = temp_db().await;
+
+    // Data written before sync existed: straight to the tables, the outbox
+    // stays empty.
+    db.curriculum()
+        .upsert_with_timestamps(&topic("t1", "Greetings", Some("2025-01-01T00:00:00Z")))
+        .await
+        .unwrap();
+    db.progress()
+        .upsert_with_timestamps(&ProgressTopic {
+            topic_id: "t1".to_string(),
+            score: 66.0,
+            mastery: 66.0,
+            updated_at: Some("2025-01-02T00:00:00Z".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    db.history()
+        .append_with_timestamps(&SessionSummary {
+            id: "s1".to_string(),
+            date: "2025-01-02".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    db.learning_items()
+        .upsert(&LearningItem {
+            id: "i1".to_string(),
+            name: "Caro vs Rico".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(db.outbox().len().await.unwrap(), 0, "pre-sync data only");
+
+    backfill_outbox(&db, true).await.unwrap();
+    client(&base).push(&db, "ru-fr").await.unwrap();
+
+    {
+        let st = state.lock().unwrap();
+        let canon = st.canonical.as_ref().expect("canon set by the backfill");
+        assert!(canon.topics.iter().any(|t| t.id == "t1"));
+        for entity in ["progress", "session", "learningItem"] {
+            assert!(
+                st.changes.iter().any(|c| c.entity == entity),
+                "backfilled {entity} reached the server"
+            );
+        }
+    }
+    assert_eq!(db.outbox().len().await.unwrap(), 0, "outbox drained");
+}
+
+#[tokio::test]
+async fn merge_bind_uploads_local_only_progress_and_sessions() {
+    let (state, base) = start_mock().await;
+    seed_cloud_topics(
+        &state,
+        &base,
+        "ru-de",
+        &[topic("t1", "Greetings", Some("2025-06-01T00:00:00Z"))],
+    )
+    .await;
+
+    let (_dir, db) = temp_db().await;
+    db.curriculum()
+        .upsert_with_timestamps(&topic("t1", "Greetings", Some("2025-01-01T00:00:00Z")))
+        .await
+        .unwrap();
+    db.progress()
+        .upsert_with_timestamps(&ProgressTopic {
+            topic_id: "t1".to_string(),
+            score: 42.0,
+            mastery: 42.0,
+            updated_at: Some("2025-02-01T00:00:00Z".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    db.history()
+        .append_with_timestamps(&SessionSummary {
+            id: "local-session".to_string(),
+            date: "2025-02-01".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(db.outbox().len().await.unwrap(), 0);
+
+    client(&base).merge_bind(&db, "ru-de").await.unwrap();
+
+    {
+        let st = state.lock().unwrap();
+        assert!(
+            st.changes
+                .iter()
+                .any(|c| c.entity == "progress" && c.entity_id == "t1"),
+            "local progress uploaded by the merge"
+        );
+        assert!(
+            st.changes
+                .iter()
+                .any(|c| c.entity == "session" && c.entity_id == "local-session"),
+            "local session uploaded by the merge"
+        );
+    }
+    assert_eq!(db.outbox().len().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn backfill_is_safe_to_repeat() {
+    let (state, base) = start_mock().await;
+    let (_dir, db) = temp_db().await;
+    db.curriculum()
+        .upsert_with_timestamps(&topic("t1", "Greetings", Some("2025-01-01T00:00:00Z")))
+        .await
+        .unwrap();
+
+    backfill_outbox(&db, true).await.unwrap();
+    client(&base).push(&db, "ru-it").await.unwrap();
+    // A repeated full upload (e.g. the manual-sync heal running again)
+    // re-pushes the same rows; the server applies them last-writer-wins.
+    // The pull first mirrors the real flow (pull → backfill → push) and
+    // advances the cursor past our own echo.
+    client(&base).pull(&db, "ru-it").await.unwrap();
+    backfill_outbox(&db, true).await.unwrap();
+    client(&base).push(&db, "ru-it").await.unwrap();
+
+    let st = state.lock().unwrap();
+    let canon = st.canonical.as_ref().unwrap();
+    assert_eq!(
+        canon.topics.iter().filter(|t| t.id == "t1").count(),
+        1,
+        "no duplicate topics after a repeated backfill"
+    );
+}


### PR DESCRIPTION
The outbox only carries mutations made after sync was introduced, so a pair whose data predates sync pushed nothing: the FreshLocal branch of the sync-all bind was a no-op, and merge/replace/adopt only ever enqueued topics. New backfill_outbox() enqueues all local rows (topics, progress, sessions, learning items) and is called on every first-bind path; a manual sync heals already-enabled pairs that were never fully uploaded (no cloud_curriculum_version marker).

### Description
This PR addresses, and describes the problem or user story being addressed.

### Changes Made
Provide code snippets or screenshots as needed.

### Related Issues
Link related issues (`Closes #123`) or feature requests, if any.

### Additional Notes
Include any extra information or considerations for reviewers, such as impacted areas of the codebase.

### PR Checklist
- [ ] Code follows project coding guidelines.
- [ ] Documentation reflects the changes made.
- [ ] I have already covered the unit testing.
