### PR TITLE
fix: подбор следующей темы и сайд-тем с учётом CEFR-лесенки

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/tests/session_test.rs
+++ b/crates/cli/tests/session_test.rs
@@ -1109,3 +1109,74 @@ fn pick_next_extends_curriculum_when_nothing_to_do() {
         other => panic!("expected ExtendCurriculum, got {other:?}"),
     }
 }
+
+fn make_level_topic(id: &str, level: &str) -> Topic {
+    Topic {
+        level: Some(level.to_string()),
+        ..make_topic(id, Difficulty::Beginner)
+    }
+}
+
+#[test]
+fn pick_next_does_not_jump_levels_for_new_topics() {
+    // Weak practiced A2 topic plus an untouched C1 topic: the fresh C1
+    // topic is more than one level above the A2 frontier, so it must not be
+    // offered — the A2 review wins even on a non-review session.
+    let topics = vec![make_level_topic("a2", "A2"), make_level_topic("c1", "C1")];
+    let progress = progress_with(vec![practiced("a2", 30.0, 0)], 0);
+
+    match pick_next_session_topic(&topics, &progress, Utc::now()) {
+        NextSessionTopic::Review(t) => assert_eq!(t.id, "a2"),
+        other => panic!("expected Review(a2), got {other:?}"),
+    }
+}
+
+#[test]
+fn pick_next_allows_new_topic_one_level_above_frontier() {
+    // Unfinished A1 work does not block a fresh A2 topic.
+    let topics = vec![make_level_topic("a1", "A1"), make_level_topic("a2", "A2")];
+    let progress = progress_with(vec![practiced("a1", 30.0, 0)], 0);
+
+    match pick_next_session_topic(&topics, &progress, Utc::now()) {
+        NextSessionTopic::New(t) => assert_eq!(t.id, "a2"),
+        other => panic!("expected New(a2), got {other:?}"),
+    }
+}
+
+#[test]
+fn pick_next_due_orders_by_level_then_mastery() {
+    // A crushed C1 topic (mastery 10) must not outrank a weak A2 topic
+    // (mastery 40): lower-level gaps close first.
+    let topics = vec![make_level_topic("c1", "C1"), make_level_topic("a2", "A2")];
+    let progress = progress_with(vec![practiced("c1", 10.0, 0), practiced("a2", 40.0, 0)], 0);
+
+    match pick_next_session_topic(&topics, &progress, Utc::now()) {
+        NextSessionTopic::Review(t) => assert_eq!(t.id, "a2"),
+        other => panic!("expected Review(a2), got {other:?}"),
+    }
+}
+
+#[test]
+fn side_topics_capped_one_level_above_target() {
+    let topics = vec![
+        make_level_topic("target", "A2"),
+        make_level_topic("a1", "A1"),
+        make_level_topic("b1", "B1"),
+        make_level_topic("c1", "C1"),
+    ];
+    let progress = progress_with(
+        vec![
+            practiced("target", 30.0, 0),
+            practiced("a1", 20.0, 0),
+            practiced("b1", 25.0, 0),
+            practiced("c1", 5.0, 0),
+        ],
+        0,
+    );
+
+    let target = topics[0].clone();
+    let sides = select_side_topics(&topics, &[target], 3, &progress, Utc::now());
+    let ids: Vec<&str> = sides.iter().map(|t| t.id.as_str()).collect();
+    // c1 is the weakest but two levels above the A2 target — excluded.
+    assert_eq!(ids, ["a1", "b1"]);
+}

--- a/crates/core/src/session/topic_selection.rs
+++ b/crates/core/src/session/topic_selection.rs
@@ -11,6 +11,22 @@ use crate::progress::{ProgressData, ProgressTopic};
 use super::MASTERY_THRESHOLD;
 use super::scoring::clamp_score;
 
+/// Numeric CEFR level of a topic (A1=1..C2=6), falling back to the coarse
+/// difficulty bucket when the level is missing. 0 means "unknown" — such
+/// topics are exempt from level gating.
+fn topic_level_numeric(topic: &Topic) -> i32 {
+    let n = topic.cefr_numeric();
+    if n > 0 {
+        return n;
+    }
+    match topic.difficulty.as_str() {
+        "beginner" => 1,
+        "intermediate" => 3,
+        "advanced" => 5,
+        _ => 0,
+    }
+}
+
 pub fn select_target_topics(
     topics: &[Topic],
     progress: &ProgressData,
@@ -31,6 +47,11 @@ pub fn select_target_topics(
 /// (never-practiced first). Returns fewer than `count` topics when not
 /// enough qualify — the list is never padded, which keeps the side-topic
 /// context rotating instead of repeating the first curriculum topics.
+///
+/// Candidates are capped at one CEFR level above the target topic (the
+/// first entry of `exclude`): practicing much harder material on the side
+/// produces errors that pollute the topic's progress record and later
+/// surface it as a suggested topic far above the user's level.
 pub fn select_side_topics(
     topics: &[Topic],
     exclude: &[Topic],
@@ -42,6 +63,12 @@ pub fn select_side_topics(
     let progress_map: HashMap<&String, &ProgressTopic> =
         progress.topics.iter().map(|t| (&t.topic_id, t)).collect();
 
+    let level_cap = exclude
+        .first()
+        .map(|t| topic_level_numeric(t))
+        .filter(|n| *n > 0)
+        .map(|n| n + 1);
+
     let mastery_of = |id: &String| -> f64 {
         progress_map
             .get(id)
@@ -52,6 +79,13 @@ pub fn select_side_topics(
     let mut candidates: Vec<&Topic> = topics
         .iter()
         .filter(|t| !exclude_ids.contains(&t.id) && mastery_of(&t.id) < MASTERY_THRESHOLD)
+        .filter(|t| match level_cap {
+            Some(cap) => {
+                let level = topic_level_numeric(t);
+                level == 0 || level <= cap
+            }
+            None => true,
+        })
         .collect();
 
     candidates.sort_by(|a, b| {
@@ -191,9 +225,17 @@ const REVIEW_BACKLOG_THRESHOLD: usize = 5;
 
 /// Balances new material against spaced review. Due topics are practiced
 /// topics whose effective mastery decayed below the mastery threshold,
-/// weakest first. When both candidates exist, every third session is a
-/// review (every second when the backlog is large), so new topics keep
-/// flowing at a predictable pace.
+/// lowest CEFR level first (weakest inside the level), so lower-level
+/// weaknesses are closed before higher-level ones. When both candidates
+/// exist, every third session is a review (every second when the backlog
+/// is large), so new topics keep flowing at a predictable pace.
+///
+/// New topics follow a level ladder: the candidate is the first
+/// never-practiced topic in level order, and it is rejected when its level
+/// is more than one step above the lowest level that still has unfinished
+/// work (the frontier). This keeps the course from jumping to fresh C-level
+/// material while A-level topics are still unmastered; topics without level
+/// information are exempt from the gate.
 pub fn pick_next_session_topic(
     topics: &[Topic],
     progress: &ProgressData,
@@ -202,7 +244,30 @@ pub fn pick_next_session_topic(
     let progress_map: HashMap<&String, &ProgressTopic> =
         progress.topics.iter().map(|t| (&t.topic_id, t)).collect();
 
-    let new_topic = topics
+    let is_unfinished = |t: &Topic| -> bool {
+        match progress_map.get(&t.id) {
+            Some(p) => match p.last_practiced.as_ref() {
+                None => true,
+                Some(_) => effective_mastery(p, now) < MASTERY_THRESHOLD,
+            },
+            None => true,
+        }
+    };
+
+    // Lowest level with unfinished work; 0 when it cannot be determined.
+    let frontier = topics
+        .iter()
+        .filter(|t| is_unfinished(t))
+        .map(topic_level_numeric)
+        .filter(|n| *n > 0)
+        .min()
+        .unwrap_or(0);
+
+    // First never-practiced topic in level order (stable sort keeps the
+    // original order within a level).
+    let mut by_level: Vec<&Topic> = topics.iter().collect();
+    by_level.sort_by_key(|t| topic_level_numeric(t));
+    let new_topic = by_level
         .iter()
         .find(|t| {
             progress_map
@@ -210,7 +275,11 @@ pub fn pick_next_session_topic(
                 .map(|p| p.last_practiced.is_none())
                 .unwrap_or(true)
         })
-        .cloned();
+        .filter(|t| {
+            let level = topic_level_numeric(t);
+            level == 0 || frontier == 0 || level <= frontier + 1
+        })
+        .map(|t| (*t).clone());
 
     let mut due: Vec<(Topic, f64)> = topics
         .iter()
@@ -221,7 +290,11 @@ pub fn pick_next_session_topic(
             (mastery < MASTERY_THRESHOLD).then(|| (t.clone(), mastery))
         })
         .collect();
-    due.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    due.sort_by(|a, b| {
+        topic_level_numeric(&a.0)
+            .cmp(&topic_level_numeric(&b.0))
+            .then_with(|| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+    });
 
     match (due.first(), new_topic) {
         (None, Some(new)) => NextSessionTopic::New(new),


### PR DESCRIPTION
Проблема: при почти полностью «тронутой» программе dashboard предлагал нетронутую C1-тему, хотя A2 не завершён. Ошибка по сайд-теме высокого уровня дополнительно выносила её в топ предложений.

Логика общая для CLI и сервера (open-course-core), web не затронут.

Изменения в crates/core/src/session/topic_selection.rs:
- new-кандидат сканируется в порядке уровней и отклоняется, если он выше frontier+1 (frontier — самый низкий уровень с незавершёнными темами);
- due-кандидаты сортируются сначала по уровню, потом по mastery — слабости нижних уровней закрываются раньше;
- select_side_topics: потолок — уровень целевой темы + 1, чтобы сайд-ошибки по слишком сложным темам не загрязняли прогресс;
- темы без уровня освобождены от ограничений (старое поведение).

Тесты: 4 новых кейса в session_test.rs; весь workspace зелёный, интеграционные тесты сервера (60 шт.) тоже зелёные.

После мерджа и релиза release-please обновлю тег в Dockerfile сервера отдельным PR.