### PR TITLE
fix: satisfy clippy redundant_closure lint in topic selection

### DIFF
--- a/crates/core/src/session/topic_selection.rs
+++ b/crates/core/src/session/topic_selection.rs
@@ -65,7 +65,7 @@ pub fn select_side_topics(
 
     let level_cap = exclude
         .first()
-        .map(|t| topic_level_numeric(t))
+        .map(topic_level_numeric)
         .filter(|n| *n > 0)
         .map(|n| n + 1);
 


### PR DESCRIPTION
Fixes a `clippy::redundant_closure` error in `crates/core/src/session/topic_selection.rs:68` that broke CI (`-D warnings`):

- Replace `.map(|t| topic_level_numeric(t))` with `.map(topic_level_numeric)`.

Verified locally with `cargo clippy -p open-course-core --all-targets -- -D warnings` — clean.