### PR TITLE
fix(llm): anchor exercise complexity to the topic's CEFR level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/tests/prompts_test.rs
+++ b/crates/cli/tests/prompts_test.rs
@@ -21,7 +21,7 @@ fn topic(id: &str) -> Topic {
         name: format!("Topic {id}"),
         description: "desc".to_string(),
         difficulty: Difficulty::Beginner.as_str().to_string(),
-        level: None,
+        level: Some("A2".to_string()),
         order: None,
         tags: vec![],
         target_lang: "en".to_string(),
@@ -51,6 +51,10 @@ fn exercise_prompt_includes_profile() {
     assert!(prompt.contains("topicId: \"t1\""));
     assert!(prompt.contains("JSON object"));
     assert!(prompt.contains("exercises"));
+    // The topic's CEFR level anchors complexity, overriding the profile's B1.
+    assert!(prompt.contains("Topic t1 (difficulty: beginner, CEFR: A2)"));
+    assert!(prompt.contains("complexity MUST match CEFR level A2"));
+    assert!(prompt.contains("6-12 words per sentence"));
 }
 
 #[test]

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -1,8 +1,23 @@
-use crate::curriculum::{CURRICULUM_DOMAIN_DESCRIPTIONS, Topic, cefr_to_difficulty};
+use crate::curriculum::{
+    CURRICULUM_DOMAIN_DESCRIPTIONS, Topic, cefr_to_difficulty, cefr_to_numeric,
+    difficulty_to_cefr,
+};
 use crate::learning_items::LearningItem;
 use crate::profile::UserProfile;
 use crate::progress::ProgressTopic;
 use crate::session::{Exercise, NewTopicRef};
+
+/// Per-CEFR-level sentence shape limits for generated exercises, so that
+/// "coherent mini-story" does not turn into long multi-clause sentences.
+fn sentence_shape_guidance(level: &str) -> &'static str {
+    match level.to_uppercase().as_str() {
+        "A1" => "3-7 words per sentence, a single clause, present tense only, very common vocabulary.",
+        "A2" => "6-12 words per sentence, one clause preferred, at most one simple subordinate clause (because/when/that), common everyday vocabulary.",
+        "B1" => "8-15 words per sentence, up to two clauses, common connectors.",
+        "B2" => "up to about 20 words per sentence, subordinate clauses and some idiomatic vocabulary allowed.",
+        _ => "no length limit, natural sophisticated prose.",
+    }
+}
 
 pub fn build_exercise_prompt(
     profile: &UserProfile,
@@ -35,6 +50,21 @@ pub fn build_exercise_prompt(
         side_names
     };
 
+    let topic_level = |t: &Topic| -> Option<String> {
+        t.level
+            .as_deref()
+            .filter(|l| cefr_to_numeric(l).is_some())
+            .map(|l| l.to_uppercase())
+            .or_else(|| difficulty_to_cefr(&t.difficulty))
+    };
+    // The exercise complexity is anchored to the target topics' CEFR level
+    // (the highest one when a session mixes topics), not to the student's
+    // self-assessed level.
+    let effective_level = target_topics
+        .iter()
+        .filter_map(|t| topic_level(t))
+        .max_by_key(|l| cefr_to_numeric(l).unwrap_or(0));
+
     let cefr_hint = profile
         .self_assessed_cefr
         .as_ref()
@@ -46,20 +76,40 @@ pub fn build_exercise_prompt(
         "Student age: {age}. Use contexts and examples that fit the life experience of a typical {age}-year-old."
     );
 
+    let complexity_anchor = effective_level
+        .as_deref()
+        .unwrap_or("the student's CEFR level");
     let recent_rate_pct = (recent_success_rate * 100.0).round() as i32;
     let adaptive_hint = format!(
         "Recent session success rate: {recent_rate_pct}%. Target success rate: 80%. \
          If recent rate is below 75%, make sentences slightly easier. \
          If recent rate is above 85%, make sentences slightly more challenging. \
-         Keep the overall complexity appropriate to the student's CEFR level."
+         In both cases stay within the sentence-shape limits for {complexity_anchor}."
     );
+
+    let complexity_hint = match &effective_level {
+        Some(level) => format!(
+            "Exercise complexity level: {level} (from the target topics). \
+             Sentence complexity MUST match CEFR level {level}. This overrides the student's \
+             self-assessed level: the self-assessed level describes the student overall, but \
+             these exercises practice {level} material.\n\
+             Sentence shape for {level}: {}",
+            sentence_shape_guidance(level)
+        ),
+        None => {
+            "Adjust the overall complexity to the student's CEFR level if provided.".to_string()
+        }
+    };
 
     let difficulty_hint = if target_topics.is_empty() {
         "general".to_string()
     } else {
         target_topics
             .iter()
-            .map(|t| format!("{} ({})", t.name, t.difficulty))
+            .map(|t| {
+                let level = topic_level(t).unwrap_or_else(|| "unknown".to_string());
+                format!("{} (difficulty: {}, CEFR: {})", t.name, t.difficulty, level)
+            })
             .collect::<Vec<_>>()
             .join(", ")
     };
@@ -93,11 +143,12 @@ Native language: {native}
 {cefr_hint}
 {age_hint}
 {adaptive_hint}
+{complexity_hint}
 
 Use ONLY the following topic IDs when tagging exercises. Do not invent new IDs.
 {topic_list}{learning_items_hint}
 
-The {count} sentences should form a short coherent dialogue or mini-story. Keep each sentence natural and focused on the target topics (or general vocabulary if no topics are specified). Adjust the overall complexity to the student's CEFR level if provided.
+The {count} sentences should form a short coherent dialogue or mini-story while respecting the sentence-shape limits stated above. Keep each sentence natural and focused on the target topics (or general vocabulary if no topics are specified).
 
 For each exercise output a JSON object with these fields:
 - id: unique string

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -67,7 +67,7 @@ pub fn build_exercise_prompt(
     // self-assessed level.
     let effective_level = target_topics
         .iter()
-        .filter_map(|t| topic_level(t))
+        .filter_map(topic_level)
         .max_by_key(|l| cefr_to_numeric(l).unwrap_or(0));
 
     let cefr_hint = profile

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -1,6 +1,5 @@
 use crate::curriculum::{
-    CURRICULUM_DOMAIN_DESCRIPTIONS, Topic, cefr_to_difficulty, cefr_to_numeric,
-    difficulty_to_cefr,
+    CURRICULUM_DOMAIN_DESCRIPTIONS, Topic, cefr_to_difficulty, cefr_to_numeric, difficulty_to_cefr,
 };
 use crate::learning_items::LearningItem;
 use crate::profile::UserProfile;
@@ -11,10 +10,16 @@ use crate::session::{Exercise, NewTopicRef};
 /// "coherent mini-story" does not turn into long multi-clause sentences.
 fn sentence_shape_guidance(level: &str) -> &'static str {
     match level.to_uppercase().as_str() {
-        "A1" => "3-7 words per sentence, a single clause, present tense only, very common vocabulary.",
-        "A2" => "6-12 words per sentence, one clause preferred, at most one simple subordinate clause (because/when/that), common everyday vocabulary.",
+        "A1" => {
+            "3-7 words per sentence, a single clause, present tense only, very common vocabulary."
+        }
+        "A2" => {
+            "6-12 words per sentence, one clause preferred, at most one simple subordinate clause (because/when/that), common everyday vocabulary."
+        }
         "B1" => "8-15 words per sentence, up to two clauses, common connectors.",
-        "B2" => "up to about 20 words per sentence, subordinate clauses and some idiomatic vocabulary allowed.",
+        "B2" => {
+            "up to about 20 words per sentence, subordinate clauses and some idiomatic vocabulary allowed."
+        }
         _ => "no length limit, natural sophisticated prose.",
     }
 }


### PR DESCRIPTION
## Problem

Exercises generated for a topic were far more complex than the topic's CEFR level. E.g. a session on "Placement of Adjectives" (A2) produced long, multi-clause B1+ sentences.

Root causes in `build_exercise_prompt` (shared by CLI and server, both call `open_course_core`):

1. The topic's CEFR level never reached the model — only the coarse `difficulty` bucket (A1/A2 → "beginner") was rendered in `Target difficulties`.
2. The only CEFR anchor was the user-global `self_assessed_cefr` from onboarding, so a B1 profile got B1 sentences even for A2 topics (and no anchor at all when unset).
3. The "short coherent dialogue or mini-story" instruction pushed the model toward long, connected, multi-clause sentences with no length/clause bound.
4. The adaptive success-rate hint referred to "the student's CEFR level" instead of the topic's level.

## Fix (prompt-only)

- `Target difficulties` now includes each target topic's CEFR level: `Placement of Adjectives (difficulty: beginner, CEFR: A2)` (falls back to `difficulty_to_cefr` when `level` is unset).
- Explicit complexity anchor: "Sentence complexity MUST match CEFR level A2. This overrides the student's self-assessed level..." — computed as the max level across target topics.
- New `sentence_shape_guidance` helper with per-CEFR limits (A1: 3–7 words / one clause; A2: 6–12 words / at most one simple subordinate clause; B1: 8–15 words / two clauses; ...).
- The mini-story line and the adaptive hint now defer to those sentence-shape limits.

Server and web need no changes — they consume the same `open_course_core` prompt builder; a server rebuild/redeploy picks the fix up.

Out of scope: post-generation complexity validation/retry (no such mechanism exists today; can be added separately if the prompt fix proves insufficient).

## Tests

- `prompts_test.rs` fixture topic now carries `level: Some("A2")`; new assertions cover the `CEFR: A2` rendering, the complexity anchor, and the A2 sentence-shape limit.
- `cargo test --workspace` green; `cargo check` of open-course-server against the updated core passes.