### PR TITLE
fix: course progress percent is the share of completed topics

### DIFF
--- a/crates/cli/tests/dashboard_test.rs
+++ b/crates/cli/tests/dashboard_test.rs
@@ -63,7 +63,7 @@ fn course_progress() {
     assert_eq!(result.in_progress, 1);
     assert_eq!(result.not_started, 1);
     assert_eq!(result.total, 3);
-    assert_eq!(result.percent, 50.0);
+    assert_eq!(result.percent, 33.0); // 1 of 3 topics completed
 }
 
 #[test]

--- a/crates/core/src/dashboard.rs
+++ b/crates/core/src/dashboard.rs
@@ -134,13 +134,11 @@ pub fn get_course_progress(curriculum: &Curriculum, progress: &ProgressData) -> 
     let mut completed = 0;
     let mut in_progress = 0;
     let mut not_started = 0;
-    let mut total_score = 0.0;
 
     for topic in &curriculum.topics {
         match progress_map.get(&topic.id) {
             None => not_started += 1,
             Some(pt) => {
-                total_score += pt.score;
                 if pt.score >= COMPLETED_THRESHOLD {
                     completed += 1;
                 } else if pt.last_practiced.is_some() {
@@ -152,8 +150,10 @@ pub fn get_course_progress(curriculum: &Curriculum, progress: &ProgressData) -> 
         }
     }
 
+    // Share of completed topics in the whole curriculum, not average score:
+    // the headline number must read as "how much of the course is done".
     let percent = if total > 0 {
-        (total_score / total as f64).round()
+        (completed as f64 / total as f64 * 100.0).round()
     } else {
         0.0
     };


### PR DESCRIPTION
The course `percent` was `avg(score)` across all topics, which did not match user expectations next to the completed / in-progress / new counters.

Now `percent = completed / total * 100` in `get_course_progress` (core). Per-level percents and `calculate_current_level` are untouched.

Tests: `dashboard_test` updated (1 of 3 completed = 33%), `cargo test`, `fmt --check`, `clippy` all green.

Follow-up after merge: CLI release, then a server `open-course-core` bump so the web dashboard picks it up (server redeploy also finally ships the merged 365-day activity window).