### PR TITLE
feat: vocabulary system with lemmas, UD forms, and CEFR levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/src/app/llm_results.rs
+++ b/crates/cli/src/app/llm_results.rs
@@ -175,15 +175,17 @@ async fn handle_analysis(state: &mut AppState, res: Result<AnalysisResult>) {
     state.session.loading = false;
     state.stream_status = None;
     match res {
-        Ok(analysis) => {
+        Ok(mut analysis) => {
             if let Some(session) = state.session.mentor_session.take() {
                 let forced_learning_item_ids = state.session.learning_item_ids.clone();
+                let forced_lemma_ids = state.session.lemma_ids.clone();
                 let applied = match open_course_service::session::apply_analysis(
                     &state.db,
                     state.config.as_ref(),
                     &session,
-                    &analysis,
+                    &mut analysis,
                     &forced_learning_item_ids,
+                    &forced_lemma_ids,
                     &state.data_dir,
                 )
                 .await
@@ -237,6 +239,8 @@ async fn handle_analysis(state: &mut AppState, res: Result<AnalysisResult>) {
                         .collect(),
                     new_topics: analysis.new_topics.clone(),
                     new_learning_items: analysis.new_learning_items.clone(),
+                    new_lemmas: analysis.new_lemmas.clone(),
+                    new_forms: analysis.new_forms.clone(),
                 };
 
                 let target_topic_name = state

--- a/crates/cli/src/ui/views/report.rs
+++ b/crates/cli/src/ui/views/report.rs
@@ -37,6 +37,8 @@ impl Default for ReportState {
                 evaluated_topics: Vec::new(),
                 new_topics: Vec::new(),
                 new_learning_items: Vec::new(),
+                new_lemmas: Vec::new(),
+                new_forms: Vec::new(),
             },
             session: MentorSession {
                 id: String::new(),

--- a/crates/cli/src/ui/views/session.rs
+++ b/crates/cli/src/ui/views/session.rs
@@ -37,6 +37,7 @@ pub struct SessionState {
     pub pending_new_topic: bool,
     pub target_topic_id: Option<String>,
     pub learning_item_ids: Vec<String>,
+    pub lemma_ids: Vec<String>,
 }
 
 impl SessionState {
@@ -408,6 +409,7 @@ pub(crate) async fn start_exercises_for_topic(
     .await?;
 
     state.session.learning_item_ids = preparation.forced_learning_item_ids;
+    state.session.lemma_ids = preparation.forced_lemma_ids;
 
     let labels = get_report_labels(native_language_code(state.config.as_ref()));
     state.session.loading = true;

--- a/crates/cli/tests/debug_exercises.rs
+++ b/crates/cli/tests/debug_exercises.rs
@@ -55,6 +55,7 @@ async fn debug_generate_exercises() {
         &[side_topic],
         &candidate_topics,
         &[],
+        &[],
         3,
         0.75,
     );

--- a/crates/cli/tests/prompts_test.rs
+++ b/crates/cli/tests/prompts_test.rs
@@ -37,7 +37,7 @@ fn exercise_prompt_includes_profile() {
     let all = vec![topic("t1"), topic("t2")];
     let target = vec![topic("t1")];
     let side = vec![topic("t2")];
-    let prompt = build_exercise_prompt(&p, &target, &side, &all, &[], 3, 0.75);
+    let prompt = build_exercise_prompt(&p, &target, &side, &all, &[], &[], 3, 0.75);
 
     assert!(prompt.contains("ru to en"));
     assert!(prompt.contains("Target topics: Topic t1"));
@@ -74,11 +74,44 @@ fn exercise_prompt_includes_forced_learning_items() {
         practice_count: 0,
         ..Default::default()
     }];
-    let prompt = build_exercise_prompt(&p, &target, &[], &all, &items, 3, 0.75);
+    let prompt = build_exercise_prompt(&p, &target, &[], &all, &items, &[], 3, 0.75);
 
     assert!(prompt.contains("learning items"));
     assert!(prompt.contains("a/an"));
     assert!(prompt.contains("articles"));
+}
+
+#[test]
+fn exercise_prompt_includes_forced_vocabulary() {
+    use open_course_cli::core::vocabulary::Lemma;
+
+    let p = profile();
+    let all = vec![topic("t1")];
+    let target = vec![topic("t1")];
+    let lemmas = vec![
+        Lemma {
+            id: "en-colleague".to_string(),
+            lemma: "colleague".to_string(),
+            pos: "NOUN".to_string(),
+            target_lang: "en".to_string(),
+            native_lang: "ru".to_string(),
+            translation: "коллега".to_string(),
+            ..Default::default()
+        },
+        Lemma {
+            id: "en-resilient".to_string(),
+            lemma: "resilient".to_string(),
+            pos: "ADJ".to_string(),
+            target_lang: "en".to_string(),
+            native_lang: "ru".to_string(),
+            ..Default::default()
+        },
+    ];
+    let prompt = build_exercise_prompt(&p, &target, &[], &all, &[], &lemmas, 3, 0.75);
+
+    assert!(prompt.contains("words need extra practice"));
+    assert!(prompt.contains("- colleague (коллега)"));
+    assert!(prompt.contains("- resilient"));
 }
 
 #[test]

--- a/crates/cli/tests/session_test.rs
+++ b/crates/cli/tests/session_test.rs
@@ -3,14 +3,16 @@ use tempfile::TempDir;
 
 use open_course_cli::core::session::{
     AnalysisResult, EvaluatedTopic, Exercise, FeedbackComment, GrammarError, GrammarErrorType,
-    MentorSession, NextSessionTopic, SemanticVerdict, SentenceAnalysis, create_session,
-    get_due_review_topics, get_weak_review_topics, pick_next_session_topic, select_side_topics,
-    select_target_topics,
+    MentorSession, NextSessionTopic, SemanticVerdict, SentenceAnalysis, VocabularyUse,
+    create_session, get_due_review_topics, get_weak_review_topics, pick_next_session_topic,
+    select_side_topics, select_target_topics,
 };
 use open_course_cli::db::Database;
 use open_course_cli::db::apply::{apply_analysis, apply_analysis_to_db};
 use open_course_cli::db::curriculum::{Curriculum, Difficulty, Topic};
 use open_course_cli::db::learning_items::{LearningItem, LearningItemsTable};
+use open_course_cli::db::forms::Form;
+use open_course_cli::db::lemmas::{Lemma, STATUS_PRACTICING};
 use open_course_cli::db::progress::{ProgressData, ProgressTopic};
 
 fn make_topic(id: &str, difficulty: Difficulty) -> Topic {
@@ -245,6 +247,7 @@ async fn apply_analysis_updates_progress() {
                 per_sentence_feedback: vec![FeedbackComment {
                     comment: "Good".to_string(),
                 }],
+                used_vocabulary: vec![],
             },
             SentenceAnalysis {
                 sentence_number: 2,
@@ -261,6 +264,7 @@ async fn apply_analysis_updates_progress() {
                 per_sentence_feedback: vec![FeedbackComment {
                     comment: "OK".to_string(),
                 }],
+                used_vocabulary: vec![],
             },
         ],
         evaluated_topics: vec![
@@ -277,6 +281,8 @@ async fn apply_analysis_updates_progress() {
         ],
         new_topics: vec![],
         new_learning_items: vec![],
+        new_lemmas: vec![],
+        new_forms: vec![],
     };
 
     let mut progress = ProgressData {
@@ -342,6 +348,7 @@ async fn errors_decrease_existing_score() {
                 ..Default::default()
             }],
             per_sentence_feedback: vec![],
+            used_vocabulary: vec![],
         }],
         evaluated_topics: vec![EvaluatedTopic {
             topic_id: "t1".to_string(),
@@ -350,6 +357,8 @@ async fn errors_decrease_existing_score() {
         }],
         new_topics: vec![],
         new_learning_items: vec![],
+        new_lemmas: vec![],
+        new_forms: vec![],
     };
 
     let mut progress = ProgressData {
@@ -399,6 +408,7 @@ async fn new_topic_with_errors_grows_mastery() {
                 ..Default::default()
             }],
             per_sentence_feedback: vec![],
+            used_vocabulary: vec![],
         }],
         evaluated_topics: vec![EvaluatedTopic {
             topic_id: "t1".to_string(),
@@ -407,6 +417,8 @@ async fn new_topic_with_errors_grows_mastery() {
         }],
         new_topics: vec![],
         new_learning_items: vec![],
+        new_lemmas: vec![],
+        new_forms: vec![],
     };
 
     let mut progress = ProgressData {
@@ -465,7 +477,7 @@ async fn apply_analysis_to_db_updates_learning_items() {
     }];
     let session = create_session(exercises, 1);
 
-    let analysis = AnalysisResult {
+    let mut analysis = AnalysisResult {
         session_score: Some(50.0),
         sentences: vec![SentenceAnalysis {
             sentence_number: 1,
@@ -480,16 +492,20 @@ async fn apply_analysis_to_db_updates_learning_items() {
                 ..Default::default()
             }],
             per_sentence_feedback: vec![],
+            used_vocabulary: vec![],
         }],
         evaluated_topics: vec![],
         new_topics: vec![],
         new_learning_items: vec![],
+        new_lemmas: vec![],
+        new_forms: vec![],
     };
 
     apply_analysis_to_db(
-        &analysis,
+        &mut analysis,
         &session,
         &["es-pequeno-pequena".to_string()],
+        &[],
         &db,
     )
     .await
@@ -543,7 +559,7 @@ async fn apply_analysis_to_db_routes_word_topics_to_learning_items() {
         ..Default::default()
     };
 
-    let analysis = AnalysisResult {
+    let mut analysis = AnalysisResult {
         session_score: Some(50.0),
         sentences: vec![SentenceAnalysis {
             sentence_number: 1,
@@ -558,13 +574,16 @@ async fn apply_analysis_to_db_routes_word_topics_to_learning_items() {
                 ..Default::default()
             }],
             per_sentence_feedback: vec![],
+            used_vocabulary: vec![],
         }],
         evaluated_topics: vec![],
         new_topics: vec![word_topic],
         new_learning_items: vec![],
+        new_lemmas: vec![],
+        new_forms: vec![],
     };
 
-    apply_analysis_to_db(&analysis, &session, &[], &db)
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
         .await
         .unwrap();
 
@@ -598,7 +617,7 @@ async fn apply_analysis_to_db_routes_word_topics_to_learning_items() {
     practiced.practice_count = 3;
     db.learning_items().upsert(&practiced).await.unwrap();
 
-    apply_analysis_to_db(&analysis, &session, &[], &db)
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
         .await
         .unwrap();
 
@@ -656,10 +675,13 @@ fn exercise_analysis(
             },
             errors,
             per_sentence_feedback: vec![],
+            used_vocabulary: vec![],
         }],
         evaluated_topics: vec![],
         new_topics: vec![],
         new_learning_items: vec![],
+        new_lemmas: vec![],
+        new_forms: vec![],
     };
     (session, analysis)
 }
@@ -674,8 +696,8 @@ async fn learning_item_not_practiced_keeps_stats_untouched() {
 
     // The item exists but is not forced this session and no new learning
     // item dedupes into it.
-    let (session, analysis) = exercise_analysis("Hello", "Привет", "Привет", vec![]);
-    apply_analysis_to_db(&analysis, &session, &[], &db)
+    let (session, mut analysis) = exercise_analysis("Hello", "Привет", "Привет", vec![]);
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
         .await
         .unwrap();
 
@@ -695,12 +717,13 @@ async fn learning_item_in_session_without_errors_scores_100() {
     let item = make_learning_item("es-pequeno-pequena", "pequeño/pequeña");
     db.learning_items().upsert(&item).await.unwrap();
 
-    let (session, analysis) =
+    let (session, mut analysis) =
         exercise_analysis("small table", "mesa pequeña", "mesa pequeña", vec![]);
     apply_analysis_to_db(
-        &analysis,
+        &mut analysis,
         &session,
         &["es-pequeno-pequena".to_string()],
+        &[],
         &db,
     )
     .await
@@ -730,13 +753,13 @@ async fn learning_item_mentioned_in_error_scores_0() {
     }];
     // The item's words occur in the student translation ("rico") and in the
     // error pattern.
-    let (session, analysis) = exercise_analysis(
+    let (session, mut analysis) = exercise_analysis(
         "The chairs were expensive",
         "Las sillas eran caras",
         "Las sillas eran rico",
         errors,
     );
-    apply_analysis_to_db(&analysis, &session, &["es-caro-rico".to_string()], &db)
+    apply_analysis_to_db(&mut analysis, &session, &["es-caro-rico".to_string()], &[], &db)
         .await
         .unwrap();
 
@@ -762,13 +785,13 @@ async fn learning_item_matches_by_significant_words_not_full_name() {
     }];
     // The full item name never appears anywhere; the words "вслух"/"out loud"
     // occur in the exercise and the error mentions "вслух"/"aloud".
-    let (session, analysis) = exercise_analysis(
+    let (session, mut analysis) = exercise_analysis(
         "She said it out loud",
         "Она сказала это вслух",
         "Она сказала это громко",
         errors,
     );
-    apply_analysis_to_db(&analysis, &session, &["es-vsluh-aloud".to_string()], &db)
+    apply_analysis_to_db(&mut analysis, &session, &["es-vsluh-aloud".to_string()], &[], &db)
         .await
         .unwrap();
 
@@ -791,13 +814,13 @@ async fn forced_item_with_foreign_name_still_gets_credit() {
     let item = make_learning_item("es-colleague", "colleague");
     db.learning_items().upsert(&item).await.unwrap();
 
-    let (session, analysis) = exercise_analysis(
+    let (session, mut analysis) = exercise_analysis(
         "Мой коллега купил стол",
         "Mi colega compró una mesa",
         "Mi colega compró una mesa",
         vec![],
     );
-    apply_analysis_to_db(&analysis, &session, &["es-colleague".to_string()], &db)
+    apply_analysis_to_db(&mut analysis, &session, &["es-colleague".to_string()], &[], &db)
         .await
         .unwrap();
 
@@ -818,13 +841,13 @@ async fn clean_sessions_graduate_item_out_of_weakest() {
 
     // Two clean sessions: 0 -> 34 -> 56, crossing the mastery threshold (50).
     for _ in 0..2 {
-        let (session, analysis) = exercise_analysis(
+        let (session, mut analysis) = exercise_analysis(
             "Мой коллега купил стол",
             "Mi colega compró una mesa",
             "Mi colega compró una mesa",
             vec![],
         );
-        apply_analysis_to_db(&analysis, &session, &["es-colleague".to_string()], &db)
+        apply_analysis_to_db(&mut analysis, &session, &["es-colleague".to_string()], &[], &db)
             .await
             .unwrap();
     }
@@ -858,7 +881,7 @@ async fn new_learning_item_deduped_into_existing() {
     );
     analysis.new_learning_items = vec![new_item];
 
-    apply_analysis_to_db(&analysis, &session, &[], &db)
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
         .await
         .unwrap();
 
@@ -885,7 +908,7 @@ async fn new_topic_deduped_into_existing_curriculum_topic() {
     let (session, mut analysis) = exercise_analysis("Hello", "Привет", "Привет", vec![]);
     analysis.new_topics = vec![dup_topic];
 
-    apply_analysis_to_db(&analysis, &session, &[], &db)
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
         .await
         .unwrap();
 
@@ -959,10 +982,13 @@ async fn acceptable_translation_grows_mastery() {
                 ..Default::default()
             }],
             per_sentence_feedback: vec![],
+            used_vocabulary: vec![],
         }],
         evaluated_topics: vec![],
         new_topics: vec![],
         new_learning_items: vec![],
+        new_lemmas: vec![],
+        new_forms: vec![],
     };
 
     let mut progress = ProgressData {
@@ -1179,4 +1205,377 @@ fn side_topics_capped_one_level_above_target() {
     let ids: Vec<&str> = sides.iter().map(|t| t.id.as_str()).collect();
     // c1 is the weakest but two levels above the A2 target — excluded.
     assert_eq!(ids, ["a1", "b1"]);
+}
+
+fn make_vocabulary_use(lemma: &str, cefr_level: Option<&str>) -> VocabularyUse {
+    VocabularyUse {
+        lemma: lemma.to_string(),
+        pos: "VERB".to_string(),
+        side: "target".to_string(),
+        cefr_level: cefr_level.map(|s| s.to_string()),
+        ..Default::default()
+    }
+}
+
+fn vocabulary_session(target_topics: &[&str]) -> MentorSession {
+    create_session(
+        vec![Exercise {
+            id: "e1".to_string(),
+            target_sentence: "hablo".to_string(),
+            expected_translation: "hablo".to_string(),
+            acceptable_translations: vec![],
+            target_topic_ids: target_topics.iter().map(|s| s.to_string()).collect(),
+            side_topic_ids: vec![],
+            expected_patterns: vec![],
+            hint: None,
+        }],
+        1,
+    )
+}
+
+fn vocabulary_analysis(vocabulary_use: VocabularyUse) -> AnalysisResult {
+    AnalysisResult {
+        session_score: Some(100.0),
+        sentences: vec![SentenceAnalysis {
+            sentence_number: 1,
+            student_translation: "hablo".to_string(),
+            expected_translation: "hablo".to_string(),
+            acceptable_translations: vec![],
+            semantic_verdict: SemanticVerdict::Correct,
+            errors: vec![],
+            per_sentence_feedback: vec![],
+            used_vocabulary: vec![vocabulary_use],
+        }],
+        evaluated_topics: vec![],
+        new_topics: vec![],
+        new_learning_items: vec![],
+        new_lemmas: vec![],
+        new_forms: vec![],
+    }
+}
+
+async fn vocabulary_db(dir: &TempDir, topics: Vec<Topic>) -> Database {
+    let db = Database::connect(&dir.path().join("db")).await.unwrap();
+    for topic in &topics {
+        db.curriculum().upsert(topic).await.unwrap();
+    }
+    db
+}
+
+#[tokio::test]
+async fn apply_assigns_cefr_from_target_topic() {
+    let dir = TempDir::new().unwrap();
+    // The exercise targets two leveled topics: the lemma takes the minimum.
+    let db = vocabulary_db(
+        &dir,
+        vec![make_level_topic("t-b1", "B1"), make_level_topic("t-a2", "A2")],
+    )
+    .await;
+
+    let session = vocabulary_session(&["t-b1", "t-a2"]);
+    let mut analysis = vocabulary_analysis(make_vocabulary_use("hablar", Some("C1")));
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
+        .await
+        .unwrap();
+
+    let lemmas = db.lemmas().read_all().await.unwrap();
+    assert_eq!(lemmas.len(), 1);
+    assert_eq!(lemmas[0].cefr_level.as_deref(), Some("A2"));
+    assert_eq!(lemmas[0].cefr_source.as_deref(), Some("topic"));
+}
+
+#[tokio::test]
+async fn apply_falls_back_to_llm_cefr() {
+    let dir = TempDir::new().unwrap();
+    // Topic without level information: the LLM estimate is used.
+    let db = vocabulary_db(&dir, vec![make_topic("t1", Difficulty::Beginner)]).await;
+
+    let session = vocabulary_session(&["t1"]);
+    let mut analysis = vocabulary_analysis(make_vocabulary_use("hablar", Some("B1")));
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
+        .await
+        .unwrap();
+
+    let lemmas = db.lemmas().read_all().await.unwrap();
+    assert_eq!(lemmas.len(), 1);
+    assert_eq!(lemmas[0].cefr_level.as_deref(), Some("B1"));
+    assert_eq!(lemmas[0].cefr_source.as_deref(), Some("llm"));
+}
+
+#[tokio::test]
+async fn apply_upgrades_llm_cefr_to_topic() {
+    let dir = TempDir::new().unwrap();
+    let db = vocabulary_db(&dir, vec![make_level_topic("t1", "A2")]).await;
+
+    let existing = Lemma {
+        id: "en-hablar".to_string(),
+        lemma: "hablar".to_string(),
+        pos: "VERB".to_string(),
+        target_lang: "en".to_string(),
+        native_lang: "ru".to_string(),
+        cefr_level: Some("B1".to_string()),
+        cefr_source: Some("llm".to_string()),
+        ..Default::default()
+    };
+    db.lemmas().upsert(&existing).await.unwrap();
+
+    // The reappearance carries no LLM level; the topic level upgrades the
+    // stored estimate even without scoring evidence.
+    let session = vocabulary_session(&["t1"]);
+    let mut analysis = vocabulary_analysis(make_vocabulary_use("hablar", None));
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
+        .await
+        .unwrap();
+
+    let lemmas = db.lemmas().read_all().await.unwrap();
+    assert_eq!(lemmas.len(), 1);
+    assert_eq!(lemmas[0].cefr_level.as_deref(), Some("A2"));
+    assert_eq!(lemmas[0].cefr_source.as_deref(), Some("topic"));
+}
+
+#[tokio::test]
+async fn apply_does_not_overwrite_topic_cefr_with_llm() {
+    let dir = TempDir::new().unwrap();
+    let db = vocabulary_db(&dir, vec![make_topic("t1", Difficulty::Beginner)]).await;
+
+    let existing = Lemma {
+        id: "en-hablar".to_string(),
+        lemma: "hablar".to_string(),
+        pos: "VERB".to_string(),
+        target_lang: "en".to_string(),
+        native_lang: "ru".to_string(),
+        cefr_level: Some("A2".to_string()),
+        cefr_source: Some("topic".to_string()),
+        ..Default::default()
+    };
+    db.lemmas().upsert(&existing).await.unwrap();
+
+    let session = vocabulary_session(&["t1"]);
+    let mut analysis = vocabulary_analysis(make_vocabulary_use("hablar", Some("C1")));
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
+        .await
+        .unwrap();
+
+    let lemmas = db.lemmas().read_all().await.unwrap();
+    assert_eq!(lemmas.len(), 1);
+    assert_eq!(lemmas[0].cefr_level.as_deref(), Some("A2"));
+    assert_eq!(lemmas[0].cefr_source.as_deref(), Some("topic"));
+}
+
+#[tokio::test]
+async fn apply_ignores_garbage_cefr_level() {
+    let dir = TempDir::new().unwrap();
+    let db = vocabulary_db(&dir, vec![make_topic("t1", Difficulty::Beginner)]).await;
+
+    let session = vocabulary_session(&["t1"]);
+    let mut analysis = vocabulary_analysis(make_vocabulary_use("hablar", Some("Z9")));
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
+        .await
+        .unwrap();
+
+    let lemmas = db.lemmas().read_all().await.unwrap();
+    assert_eq!(lemmas.len(), 1);
+    assert_eq!(lemmas[0].cefr_level, None);
+    assert_eq!(lemmas[0].cefr_source, None);
+}
+
+fn student_use(lemma: &str, surface: &str, feats: &str) -> VocabularyUse {
+    VocabularyUse {
+        lemma: lemma.to_string(),
+        pos: "VERB".to_string(),
+        surface: surface.to_string(),
+        feats: feats.to_string(),
+        side: "student".to_string(),
+        usage_ok: Some(true),
+        ..Default::default()
+    }
+}
+
+fn stored_hablar_lemma() -> Lemma {
+    Lemma {
+        id: "en-hablar".to_string(),
+        lemma: "hablar".to_string(),
+        pos: "VERB".to_string(),
+        target_lang: "en".to_string(),
+        native_lang: "ru".to_string(),
+        ..Default::default()
+    }
+}
+
+fn stored_hablo_form(feats: &str, feats_key: &str) -> Form {
+    Form {
+        id: "en-hablar--hablo".to_string(),
+        lemma_id: "en-hablar".to_string(),
+        surface: "hablo".to_string(),
+        feats: feats.to_string(),
+        feats_key: feats_key.to_string(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn apply_fuzzy_merges_form_with_feats_subset() {
+    let dir = TempDir::new().unwrap();
+    let db = vocabulary_db(&dir, vec![make_topic("t1", Difficulty::Beginner)]).await;
+    db.lemmas().upsert(&stored_hablar_lemma()).await.unwrap();
+    db.forms()
+        .upsert(&stored_hablo_form(
+            "Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin",
+            "mood=ind|number=sing|person=1|tense=pres|verbform=fin",
+        ))
+        .await
+        .unwrap();
+
+    let session = vocabulary_session(&["t1"]);
+    // The incoming feats set is a subset of the stored one: the use merges
+    // into the existing form instead of creating a near-duplicate.
+    let mut analysis = vocabulary_analysis(student_use("hablar", "hablo", "Tense=Pres|Mood=Ind"));
+    let (_, _, touched_forms) = apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
+        .await
+        .unwrap();
+
+    let forms = db.forms().read_all().await.unwrap();
+    assert_eq!(forms.len(), 1);
+    assert_eq!(forms[0].id, "en-hablar--hablo");
+    // Evidence landed on the existing form; the richer feats were kept.
+    assert_eq!(forms[0].correct, 1);
+    assert_eq!(forms[0].mastery, 34.0);
+    assert_eq!(
+        forms[0].feats_key,
+        "mood=ind|number=sing|person=1|tense=pres|verbform=fin"
+    );
+    assert!(touched_forms.contains(&"en-hablar--hablo".to_string()));
+    assert!(analysis.new_forms.is_empty());
+}
+
+#[tokio::test]
+async fn apply_fuzzy_merge_enriches_sparse_feats() {
+    let dir = TempDir::new().unwrap();
+    let db = vocabulary_db(&dir, vec![make_topic("t1", Difficulty::Beginner)]).await;
+    db.lemmas().upsert(&stored_hablar_lemma()).await.unwrap();
+    db.forms()
+        .upsert(&stored_hablo_form("Tense=Pres", "tense=pres"))
+        .await
+        .unwrap();
+
+    let session = vocabulary_session(&["t1"]);
+    // Target-side use (no scoring evidence) with a richer feats set: the
+    // stored feats/feats_key are upgraded and the form is persisted.
+    let mut vocabulary_use = student_use("hablar", "hablo", "Mood=Ind|Tense=Pres");
+    vocabulary_use.side = "target".to_string();
+    vocabulary_use.usage_ok = None;
+    let mut analysis = vocabulary_analysis(vocabulary_use);
+    let (_, _, touched_forms) = apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
+        .await
+        .unwrap();
+
+    let forms = db.forms().read_all().await.unwrap();
+    assert_eq!(forms.len(), 1);
+    assert_eq!(forms[0].feats, "Mood=Ind|Tense=Pres");
+    assert_eq!(forms[0].feats_key, "mood=ind|tense=pres");
+    assert!(touched_forms.contains(&"en-hablar--hablo".to_string()));
+}
+
+#[tokio::test]
+async fn apply_creates_new_form_when_feats_diverge() {
+    let dir = TempDir::new().unwrap();
+    let db = vocabulary_db(&dir, vec![make_topic("t1", Difficulty::Beginner)]).await;
+    db.lemmas().upsert(&stored_hablar_lemma()).await.unwrap();
+    db.forms()
+        .upsert(&stored_hablo_form(
+            "Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin",
+            "mood=ind|number=sing|person=1|tense=pres|verbform=fin",
+        ))
+        .await
+        .unwrap();
+
+    let session = vocabulary_session(&["t1"]);
+    // Indicative vs subjunctive: similarity far below the merge threshold,
+    // so a separate form is created.
+    let mut analysis = vocabulary_analysis(student_use("hablar", "hablo", "Mood=Sub|Tense=Pres"));
+    apply_analysis_to_db(&mut analysis, &session, &[], &[], &db)
+        .await
+        .unwrap();
+
+    let forms = db.forms().read_all().await.unwrap();
+    assert_eq!(forms.len(), 2);
+    assert!(forms.iter().any(|f| f.id == "en-hablar--hablo-1"));
+}
+
+#[tokio::test]
+async fn forced_lemma_without_evidence_is_untouched() {
+    let dir = TempDir::new().unwrap();
+    let db = vocabulary_db(&dir, vec![make_topic("t1", Difficulty::Beginner)]).await;
+    let mut lemma = stored_hablar_lemma();
+    lemma.mastery = 40.0;
+    lemma.practice_count = 2;
+    lemma.correct_uses = 1;
+    lemma.status = STATUS_PRACTICING;
+    lemma.last_seen = Some("2024-01-01T00:00:00Z".to_string());
+    db.lemmas().upsert(&lemma).await.unwrap();
+
+    let session = vocabulary_session(&["t1"]);
+    let mut analysis = vocabulary_analysis(make_vocabulary_use("hablar", None));
+    // The forced lemma never appeared in the session: neutral non-use, no
+    // credit at all (replaces the former soft credit with a perfect score).
+    analysis.sentences[0].used_vocabulary.clear();
+
+    let (_, touched_lemmas, _) = apply_analysis_to_db(
+        &mut analysis,
+        &session,
+        &[],
+        &["en-hablar".to_string()],
+        &db,
+    )
+    .await
+    .unwrap();
+
+    assert!(!touched_lemmas.contains(&"en-hablar".to_string()));
+    let stored = db.lemmas().read_all().await.unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].mastery, 40.0);
+    assert_eq!(stored[0].practice_count, 2);
+    assert_eq!(stored[0].correct_uses, 1);
+    assert_eq!(
+        stored[0].last_seen.as_deref(),
+        Some("2024-01-01T00:00:00Z")
+    );
+    assert_eq!(stored[0].status, STATUS_PRACTICING);
+}
+
+#[tokio::test]
+async fn forced_lemma_with_evidence_scores_as_before() {
+    let dir = TempDir::new().unwrap();
+    let db = vocabulary_db(&dir, vec![make_topic("t1", Difficulty::Beginner)]).await;
+    let mut lemma = stored_hablar_lemma();
+    lemma.mastery = 40.0;
+    lemma.practice_count = 2;
+    lemma.correct_uses = 1;
+    lemma.status = STATUS_PRACTICING;
+    lemma.last_seen = Some("2024-01-01T00:00:00Z".to_string());
+    db.lemmas().upsert(&lemma).await.unwrap();
+
+    let session = vocabulary_session(&["t1"]);
+    let mut analysis = vocabulary_analysis(student_use("hablar", "hablo", "Tense=Pres"));
+    let (_, touched_lemmas, _) = apply_analysis_to_db(
+        &mut analysis,
+        &session,
+        &[],
+        &["en-hablar".to_string()],
+        &db,
+    )
+    .await
+    .unwrap();
+
+    assert!(touched_lemmas.contains(&"en-hablar".to_string()));
+    let stored = db.lemmas().read_all().await.unwrap();
+    assert_eq!(stored.len(), 1);
+    // ema_update(40, 100) = 40 * 0.66 + 100 * 0.34 = 60.4 -> 60.
+    assert_eq!(stored[0].mastery, 60.0);
+    assert_eq!(stored[0].practice_count, 3);
+    assert_eq!(stored[0].correct_uses, 2);
+    assert_ne!(
+        stored[0].last_seen.as_deref(),
+        Some("2024-01-01T00:00:00Z")
+    );
 }

--- a/crates/cli/tests/session_test.rs
+++ b/crates/cli/tests/session_test.rs
@@ -10,8 +10,8 @@ use open_course_cli::core::session::{
 use open_course_cli::db::Database;
 use open_course_cli::db::apply::{apply_analysis, apply_analysis_to_db};
 use open_course_cli::db::curriculum::{Curriculum, Difficulty, Topic};
-use open_course_cli::db::learning_items::{LearningItem, LearningItemsTable};
 use open_course_cli::db::forms::Form;
+use open_course_cli::db::learning_items::{LearningItem, LearningItemsTable};
 use open_course_cli::db::lemmas::{Lemma, STATUS_PRACTICING};
 use open_course_cli::db::progress::{ProgressData, ProgressTopic};
 
@@ -759,9 +759,15 @@ async fn learning_item_mentioned_in_error_scores_0() {
         "Las sillas eran rico",
         errors,
     );
-    apply_analysis_to_db(&mut analysis, &session, &["es-caro-rico".to_string()], &[], &db)
-        .await
-        .unwrap();
+    apply_analysis_to_db(
+        &mut analysis,
+        &session,
+        &["es-caro-rico".to_string()],
+        &[],
+        &db,
+    )
+    .await
+    .unwrap();
 
     let updated = db.learning_items().read_all().await.unwrap();
     assert_eq!(updated.len(), 1);
@@ -791,9 +797,15 @@ async fn learning_item_matches_by_significant_words_not_full_name() {
         "Она сказала это громко",
         errors,
     );
-    apply_analysis_to_db(&mut analysis, &session, &["es-vsluh-aloud".to_string()], &[], &db)
-        .await
-        .unwrap();
+    apply_analysis_to_db(
+        &mut analysis,
+        &session,
+        &["es-vsluh-aloud".to_string()],
+        &[],
+        &db,
+    )
+    .await
+    .unwrap();
 
     let updated = db.learning_items().read_all().await.unwrap();
     assert_eq!(updated.len(), 1);
@@ -820,9 +832,15 @@ async fn forced_item_with_foreign_name_still_gets_credit() {
         "Mi colega compró una mesa",
         vec![],
     );
-    apply_analysis_to_db(&mut analysis, &session, &["es-colleague".to_string()], &[], &db)
-        .await
-        .unwrap();
+    apply_analysis_to_db(
+        &mut analysis,
+        &session,
+        &["es-colleague".to_string()],
+        &[],
+        &db,
+    )
+    .await
+    .unwrap();
 
     let updated = db.learning_items().read_all().await.unwrap();
     assert_eq!(updated.len(), 1);
@@ -847,9 +865,15 @@ async fn clean_sessions_graduate_item_out_of_weakest() {
             "Mi colega compró una mesa",
             vec![],
         );
-        apply_analysis_to_db(&mut analysis, &session, &["es-colleague".to_string()], &[], &db)
-            .await
-            .unwrap();
+        apply_analysis_to_db(
+            &mut analysis,
+            &session,
+            &["es-colleague".to_string()],
+            &[],
+            &db,
+        )
+        .await
+        .unwrap();
     }
 
     let updated = db.learning_items().read_all().await.unwrap();
@@ -1268,7 +1292,10 @@ async fn apply_assigns_cefr_from_target_topic() {
     // The exercise targets two leveled topics: the lemma takes the minimum.
     let db = vocabulary_db(
         &dir,
-        vec![make_level_topic("t-b1", "B1"), make_level_topic("t-a2", "A2")],
+        vec![
+            make_level_topic("t-b1", "B1"),
+            make_level_topic("t-a2", "A2"),
+        ],
     )
     .await;
 
@@ -1536,10 +1563,7 @@ async fn forced_lemma_without_evidence_is_untouched() {
     assert_eq!(stored[0].mastery, 40.0);
     assert_eq!(stored[0].practice_count, 2);
     assert_eq!(stored[0].correct_uses, 1);
-    assert_eq!(
-        stored[0].last_seen.as_deref(),
-        Some("2024-01-01T00:00:00Z")
-    );
+    assert_eq!(stored[0].last_seen.as_deref(), Some("2024-01-01T00:00:00Z"));
     assert_eq!(stored[0].status, STATUS_PRACTICING);
 }
 
@@ -1574,8 +1598,5 @@ async fn forced_lemma_with_evidence_scores_as_before() {
     assert_eq!(stored[0].mastery, 60.0);
     assert_eq!(stored[0].practice_count, 3);
     assert_eq!(stored[0].correct_uses, 2);
-    assert_ne!(
-        stored[0].last_seen.as_deref(),
-        Some("2024-01-01T00:00:00Z")
-    );
+    assert_ne!(stored[0].last_seen.as_deref(), Some("2024-01-01T00:00:00Z"));
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,3 +10,4 @@ pub mod progress;
 pub mod reviews;
 pub mod session;
 pub mod sync_protocol;
+pub mod vocabulary;

--- a/crates/core/src/llm/parse.rs
+++ b/crates/core/src/llm/parse.rs
@@ -82,6 +82,8 @@ pub fn parse_analysis(
             evaluated_topics: vec![],
             new_topics: vec![],
             new_learning_items: vec![],
+            new_lemmas: vec![],
+            new_forms: vec![],
         }
     } else if let Ok(value) = from_str::<serde_json::Value>(cleaned)
         && let Some(sentences_value) = value.get("sentences")
@@ -94,6 +96,8 @@ pub fn parse_analysis(
             evaluated_topics: vec![],
             new_topics: vec![],
             new_learning_items: vec![],
+            new_lemmas: vec![],
+            new_forms: vec![],
         }
     } else {
         return Err(AppError::Llm(
@@ -539,6 +543,54 @@ mod tests {
         );
     }
 
+    // --- usedVocabulary ---
+
+    fn used_vocabulary_json() -> String {
+        r#""usedVocabulary": [
+            {"surface": "manzana", "lemma": "manzana", "pos": "NOUN", "feats": "Gender=Fem|Number=Sing", "side": "target", "expectedForm": true, "cefrLevel": "A1"},
+            {"surface": "komo", "lemma": "comer", "pos": "VERB", "feats": "Mood=Ind|Number=Sing|Person=1|Tense=Pres", "side": "student", "spellingOk": false, "usageOk": true, "expectedForm": true}
+        ]"#
+        .to_string()
+    }
+
+    #[test]
+    fn parse_analysis_parses_used_vocabulary() {
+        let cleaned = format!(
+            r#"{{"sentences": [{{"sentenceNumber": 1, "errors": [], "perSentenceFeedback": [], {}}}]}}"#,
+            used_vocabulary_json()
+        );
+        let result = parse_analysis(&cleaned, 1, 0, 0).unwrap();
+        let used = &result.sentences[0].used_vocabulary;
+        assert_eq!(used.len(), 2);
+        assert_eq!(used[0].side, "target");
+        assert_eq!(used[0].spelling_ok, None);
+        assert!(used[0].expected_form);
+        assert_eq!(used[0].cefr_level.as_deref(), Some("A1"));
+        assert_eq!(used[1].lemma, "comer");
+        assert_eq!(used[1].spelling_ok, Some(false));
+        assert_eq!(used[1].usage_ok, Some(true));
+        assert_eq!(used[1].cefr_level, None);
+    }
+
+    #[test]
+    fn parse_analysis_defaults_used_vocabulary_when_absent() {
+        let cleaned = format!("[{}]", sentence_json(1));
+        let result = parse_analysis(&cleaned, 1, 0, 0).unwrap();
+        assert!(result.sentences[0].used_vocabulary.is_empty());
+    }
+
+    #[test]
+    fn parse_analysis_keeps_used_vocabulary_through_value_fallback() {
+        // A malformed top-level field ("sessionScore" as a string) forces the
+        // `Value.get("sentences")` fallback; usedVocabulary must survive it.
+        let cleaned = format!(
+            r#"{{"sessionScore": "high", "sentences": [{{"sentenceNumber": 1, "errors": [], "perSentenceFeedback": [], {}}}]}}"#,
+            used_vocabulary_json()
+        );
+        let result = parse_analysis(&cleaned, 1, 0, 0).unwrap();
+        assert_eq!(result.sentences[0].used_vocabulary.len(), 2);
+    }
+
     // --- validate_analysis_sentences ---
 
     fn sentence(number: i32) -> SentenceAnalysis {
@@ -550,6 +602,7 @@ mod tests {
             semantic_verdict: SemanticVerdict::Correct,
             errors: vec![],
             per_sentence_feedback: vec![],
+            used_vocabulary: vec![],
         }
     }
 
@@ -560,6 +613,8 @@ mod tests {
             evaluated_topics: vec![],
             new_topics: vec![],
             new_learning_items: vec![],
+            new_lemmas: vec![],
+            new_forms: vec![],
         }
     }
 

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -612,7 +612,6 @@ pub fn build_new_topic_metadata_prompt(profile: &UserProfile, new_topic: &NewTop
     )
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -5,6 +5,7 @@ use crate::learning_items::LearningItem;
 use crate::profile::UserProfile;
 use crate::progress::ProgressTopic;
 use crate::session::{Exercise, NewTopicRef};
+use crate::vocabulary::Lemma;
 
 /// Per-CEFR-level sentence shape limits for generated exercises, so that
 /// "coherent mini-story" does not turn into long multi-clause sentences.
@@ -24,12 +25,14 @@ fn sentence_shape_guidance(level: &str) -> &'static str {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn build_exercise_prompt(
     profile: &UserProfile,
     target_topics: &[Topic],
     side_topics: &[Topic],
     candidate_topics: &[Topic],
     forced_learning_items: &[LearningItem],
+    forced_vocabulary: &[Lemma],
     count: u32,
     recent_success_rate: f64,
 ) -> String {
@@ -138,6 +141,25 @@ pub fn build_exercise_prompt(
         )
     };
 
+    let vocabulary_hint = if forced_vocabulary.is_empty() {
+        String::new()
+    } else {
+        let words = forced_vocabulary
+            .iter()
+            .map(|l| {
+                if l.translation.is_empty() {
+                    format!("- {}", l.lemma)
+                } else {
+                    format!("- {} ({})", l.lemma, l.translation)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "\nThe following words need extra practice. Include each of these words if it fits naturally, distributing them across different exercises and without distorting the target topics; skip a word rather than distort the sentence:\n{words}\n"
+        )
+    };
+
     format!(
         "You are a language tutor. Generate {count} connected translation exercises from {native} to {target}.
 
@@ -151,7 +173,7 @@ Native language: {native}
 {complexity_hint}
 
 Use ONLY the following topic IDs when tagging exercises. Do not invent new IDs.
-{topic_list}{learning_items_hint}
+{topic_list}{learning_items_hint}{vocabulary_hint}
 
 The {count} sentences should form a short coherent dialogue or mini-story while respecting the sentence-shape limits stated above. Keep each sentence natural and focused on the target topics (or general vocabulary if no topics are specified).
 
@@ -229,8 +251,19 @@ New topic rules (CRITICAL):
 - Bad topic examples: "Common Spelling Errors", "Grammar mistakes", "Basic vocabulary", "Adjective: Caro vs Rico".
 - The name should be 2-6 words and describe a concrete rule or pattern.
 - Do NOT create newTopics for spelling-only errors.
+- Do NOT report newTopics for errors fully explained by a single word form (a wrong inflection, agreement, or choice of one word) — these are already captured through usedVocabulary with spellingOk/usageOk false. Report newTopics only for constructions, multi-word patterns, word pairs, or false friends.
 - Every newTopic must be a {target} grammar or usage topic. NEVER create newTopics about any other language.
 - If the student answered in the wrong language (e.g. a language other than {target}), mark the affected words as errors, give the correct {target} translation in the explanation, and do NOT create newTopics for that other language.
+
+Vocabulary extraction rules (usedVocabulary):
+- For each sentence, list the CONTENT words (NOUN, VERB, ADJ, ADV, PROPN only) in `usedVocabulary`. Skip function words (articles, prepositions, pronouns, auxiliaries, conjunctions).
+- Words from the expected translation: side "target", no spellingOk/usageOk fields.
+- Words from the student's translation: side "student", WITH spellingOk and usageOk.
+- spellingOk is false ONLY for a real misspelling; missing accents, diacritics, punctuation, or capitalization do NOT make spellingOk false.
+- usageOk is false when the word is misused: wrong word choice, wrong inflected form, or broken agreement.
+- expectedForm is true when the surface matches a form used in the expected (or an acceptable) translation; target-side entries always have expectedForm true.
+- `lemma` is the dictionary headword, `pos` is the Universal Dependencies POS tag, `feats` are UD morphological features strictly in "Attr=Val|Attr=Val" format (e.g. "Mood=Ind|Number=Sing|Person=3|Tense=Pres"). Include the full standard UD feature set for the language: always include VerbForm for verbs (e.g. VerbForm=Fin), plus Mood/Tense/Person/Number for finite forms and Gender/Number for nominals, whenever they apply. Use an empty string when no features apply.
+- `cefrLevel`: Estimate approximate CEFR level (A1–C2) for the lemma for a typical adult general learner. Prefer high-frequency / early textbook order. Ignore rare or specialized senses.
 
 Return a JSON object exactly in this shape:
 {{
@@ -242,13 +275,17 @@ Return a JSON object exactly in this shape:
       "acceptableTranslations": ["...", "..."],
       "semanticVerdict": "correct",
       "errors": [{{ "type": "major", "pattern": "...", "explanation": "...", "topicIds": ["..."], "newTopics": [{{ "name": "...", "description": "...", "level": "A1" }}] }}],
-      "perSentenceFeedback": [{{ "comment": "..." }}]
+      "perSentenceFeedback": [{{ "comment": "..." }}],
+      "usedVocabulary": [
+        {{ "surface": "...", "lemma": "...", "pos": "NOUN", "feats": "Gender=Fem|Number=Sing", "side": "target", "expectedForm": true, "cefrLevel": "A2" }},
+        {{ "surface": "...", "lemma": "...", "pos": "VERB", "feats": "Mood=Ind|Number=Sing|Person=3|Tense=Pres", "side": "student", "spellingOk": true, "usageOk": true, "expectedForm": true, "cefrLevel": "A1" }}
+      ]
     }}
   ],
   "evaluatedTopics": [{{ "topicId": "...", "score": 80.0 }}]
 }}
 
-The "errors" array may be empty. When an error has no known curriculum topic, `topicIds` may be empty; use `newTopics` to suggest a new topic. When `topicIds` is empty and no `newTopics` are given, the error will be treated as affecting all topics practiced in that sentence.
+The "errors" and "usedVocabulary" arrays may be empty. When an error has no known curriculum topic, `topicIds` may be empty; use `newTopics` to suggest a new topic. When `topicIds` is empty and no `newTopics` are given, the error will be treated as affecting all topics practiced in that sentence.
 
 CRITICAL: the top-level object MUST contain the key "sentences" with exactly {n} items.
 CRITICAL: explanations and comments must be in {native}.
@@ -573,4 +610,76 @@ pub fn build_new_topic_metadata_prompt(profile: &UserProfile, new_topic: &NewTop
         description = new_topic.description,
         level = proposed_level,
     )
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile() -> UserProfile {
+        UserProfile {
+            native_language: "Russian".to_string(),
+            target_language: "Spanish".to_string(),
+            age: Some(30),
+            self_assessed_cefr: Some("A2".to_string()),
+        }
+    }
+
+    #[test]
+    fn exercise_prompt_includes_forced_vocabulary_block() {
+        let lemmas = vec![
+            Lemma {
+                lemma: "comer".to_string(),
+                translation: "есть".to_string(),
+                ..Default::default()
+            },
+            Lemma {
+                lemma: "pequeño".to_string(),
+                ..Default::default()
+            },
+        ];
+        let prompt = build_exercise_prompt(&profile(), &[], &[], &[], &[], &lemmas, 3, 0.8);
+        assert!(prompt.contains("The following words need extra practice"));
+        assert!(prompt.contains("- comer (есть)"));
+        assert!(prompt.contains("- pequeño\n"));
+        // Forced words are included only when they fit naturally.
+        assert!(prompt.contains("if it fits naturally"));
+        assert!(prompt.contains("skip a word rather than distort the sentence"));
+    }
+
+    #[test]
+    fn exercise_prompt_omits_forced_vocabulary_block_when_empty() {
+        let prompt = build_exercise_prompt(&profile(), &[], &[], &[], &[], &[], 3, 0.8);
+        assert!(!prompt.contains("need extra practice"));
+    }
+
+    #[test]
+    fn batch_analysis_prompt_describes_used_vocabulary() {
+        let exercise = Exercise {
+            id: "ex1".to_string(),
+            target_sentence: "Я ем".to_string(),
+            expected_translation: "Como".to_string(),
+            acceptable_translations: vec![],
+            target_topic_ids: vec![],
+            side_topic_ids: vec![],
+            expected_patterns: vec![],
+            hint: None,
+        };
+        let pairs = vec![(exercise, "Como".to_string())];
+        let prompt = build_batch_analysis_prompt(&profile(), &pairs, &[]);
+        assert!(prompt.contains("\"usedVocabulary\""));
+        assert!(prompt.contains("side \"target\""));
+        assert!(prompt.contains("side \"student\""));
+        assert!(prompt.contains("spellingOk"));
+        assert!(prompt.contains("Attr=Val"));
+        assert!(prompt.contains("NOUN, VERB, ADJ, ADV, PROPN"));
+        assert!(prompt.contains("\"cefrLevel\""));
+        assert!(prompt.contains("Estimate approximate CEFR level (A1–C2) for the lemma for a typical adult general learner. Prefer high-frequency / early textbook order. Ignore rare or specialized senses."));
+        // Full UD feature set is requested, including VerbForm for verbs.
+        assert!(prompt.contains("full standard UD feature set"));
+        assert!(prompt.contains("VerbForm=Fin"));
+        // Single-word-form errors must not produce newTopics.
+        assert!(prompt.contains("errors fully explained by a single word form"));
+    }
 }

--- a/crates/core/src/session/mod.rs
+++ b/crates/core/src/session/mod.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 pub use models::{
     AnalysisResult, EvaluatedTopic, Exercise, FeedbackComment, GrammarError, GrammarErrorType,
-    NewTopicRef, SemanticVerdict, SentenceAnalysis,
+    NewTopicRef, SemanticVerdict, SentenceAnalysis, VocabularyUse,
 };
 pub use scoring::{
     average, clamp_score, collect_topic_errors, count_topic_occurrences, error_based_score,

--- a/crates/core/src/session/models.rs
+++ b/crates/core/src/session/models.rs
@@ -70,6 +70,15 @@ pub struct AnalysisResult {
     #[serde(skip, default)]
     #[schemars(skip)]
     pub new_learning_items: Vec<crate::learning_items::LearningItem>,
+    /// Vocabulary entries created or updated while applying the analysis.
+    /// Filled by the pipeline, never by the LLM, so they are excluded from
+    /// serde and the JSON schema.
+    #[serde(skip, default)]
+    #[schemars(skip)]
+    pub new_lemmas: Vec<crate::vocabulary::Lemma>,
+    #[serde(skip, default)]
+    #[schemars(skip)]
+    pub new_forms: Vec<crate::vocabulary::Form>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
@@ -87,6 +96,48 @@ pub struct SentenceAnalysis {
     pub semantic_verdict: SemanticVerdict,
     pub errors: Vec<GrammarError>,
     pub per_sentence_feedback: Vec<FeedbackComment>,
+    /// Content words extracted from the expected translation (side "target")
+    /// and from the student's translation (side "student", with per-use
+    /// assessments). Defaults to empty for older LLM responses.
+    #[serde(default)]
+    pub used_vocabulary: Vec<VocabularyUse>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct VocabularyUse {
+    /// The surface form as it appeared in the sentence.
+    #[serde(default)]
+    pub surface: String,
+    /// Dictionary headword (lemma) of the surface form.
+    #[serde(default)]
+    pub lemma: String,
+    /// Universal Dependencies part-of-speech tag ("NOUN", "VERB", ...).
+    #[serde(default)]
+    pub pos: String,
+    /// UD features in "Attr=Val|..." format, as returned by the LLM.
+    #[serde(default)]
+    pub feats: String,
+    /// "target" — from the expected translation; "student" — from the
+    /// student's translation.
+    #[serde(default)]
+    pub side: String,
+    /// Student-side only: whether the surface is spelled acceptably
+    /// (missing diacritics/punctuation do NOT count as misspellings).
+    #[serde(default)]
+    pub spelling_ok: Option<bool>,
+    /// Student-side only: whether the word/form is used correctly.
+    #[serde(default)]
+    pub usage_ok: Option<bool>,
+    /// Whether the surface matches a form used in the expected (or an
+    /// acceptable) translation. Target-side uses are always expected.
+    #[serde(default)]
+    pub expected_form: bool,
+    /// LLM estimate of the lemma's approximate CEFR level ("A1"–"C2");
+    /// `None` when the model omits it.
+    #[serde(default)]
+    pub cefr_level: Option<String>,
 }
 
 #[derive(

--- a/crates/core/src/sync_protocol.rs
+++ b/crates/core/src/sync_protocol.rs
@@ -44,7 +44,7 @@ pub struct ErrorBody {
 
 /// A single change entry. `op` is one of "upsert" | "delete" |
 /// "tombstoneReset"; `entity` is one of "topic" | "progress" | "session" |
-/// "learningItem" | "metadata".
+/// "learningItem" | "lemma" | "form" | "metadata".
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
@@ -161,4 +161,16 @@ pub fn op_is_tombstone_reset(op: &str) -> bool {
 /// Whether a wire `entity` names learning items (accepts both styles).
 pub fn entity_is_learning_item(entity: &str) -> bool {
     entity == "learningItem" || entity == "learning_item"
+}
+
+/// Whether a wire `entity` names vocabulary lemmas (single-word entity,
+/// passes through `entity_to_wire` unchanged).
+pub fn entity_is_lemma(entity: &str) -> bool {
+    entity == "lemma"
+}
+
+/// Whether a wire `entity` names vocabulary forms (single-word entity,
+/// passes through `entity_to_wire` unchanged).
+pub fn entity_is_form(entity: &str) -> bool {
+    entity == "form"
 }

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -1,0 +1,664 @@
+//! Vocabulary domain model: lemmas (dictionary headwords) and their
+//! inflected forms, described with Universal Dependencies morphology.
+//! Flat fields, snake_case JSON, and the same `updated_at`/`deleted_at`
+//! LWW-sync contract as `learning_items.rs`.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use unicode_normalization::UnicodeNormalization;
+
+use crate::learning_items::{significant_words, slugify, text_contains_any_word};
+use crate::session::{COMPLETED_THRESHOLD, GrammarError, MASTERY_THRESHOLD, SentenceAnalysis};
+
+/// Content-word POS tags eligible for forced vocabulary practice.
+pub const CONTENT_POS: &[&str] = &["NOUN", "VERB", "ADJ", "ADV", "PROPN"];
+
+/// Function-word POS tags (the closed UD set) excluded from forced
+/// vocabulary practice.
+const FUNCTION_POS: &[&str] = &[
+    "ADP", "AUX", "CCONJ", "DET", "INTJ", "PART", "PRON", "PUNCT", "SCONJ", "SYM", "X",
+];
+
+/// Whether a lemma with this POS tag is a content-word candidate for
+/// forced practice. Case-insensitive; empty or unrecognized tags are
+/// lazily accepted so incomplete metadata never hides a lemma.
+pub fn is_content_pos(pos: &str) -> bool {
+    let trimmed = pos.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    !FUNCTION_POS.iter().any(|p| p.eq_ignore_ascii_case(trimmed))
+}
+
+/// Freshly extracted, never practiced.
+pub const STATUS_NEW: i32 = 0;
+/// Practiced but not yet mastered (mastery ≥ 50).
+pub const STATUS_PRACTICING: i32 = 1;
+/// Mastered (mastery ≥ 80).
+pub const STATUS_KNOWN: i32 = 2;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct Lemma {
+    /// Deterministic id: `"{target_lang}-{slug(lemma)}"`; callers
+    /// disambiguate (lemma, pos) collisions with a `-{pos}` suffix.
+    pub id: String,
+    pub lemma: String,
+    /// Universal Dependencies part-of-speech tag ("VERB", "ADJ", ...).
+    pub pos: String,
+    pub target_lang: String,
+    pub native_lang: String,
+    /// Main translation; may be empty until the pipeline fills it.
+    pub translation: String,
+    /// Derived from mastery via `derive_status`; stored for reads/UI.
+    pub status: i32,
+    pub mastery: f64,
+    /// RFC3339 timestamp of the last session that touched this lemma.
+    pub last_seen: Option<String>,
+    pub practice_count: i32,
+    pub correct_uses: i32,
+    pub incorrect_uses: i32,
+    /// Approximate CEFR level of the lemma ("A1"–"C2"); `None` until a
+    /// source assigns one.
+    #[serde(default)]
+    pub cefr_level: Option<String>,
+    /// Where `cefr_level` came from: "topic" (curriculum level of the topic
+    /// the lemma appeared in), "llm" (model estimate), "manual" (user-set),
+    /// or "list" (imported word list). A new value replaces the stored one
+    /// only when its source ranks strictly higher (see `cefr_source_rank`).
+    #[serde(default)]
+    pub cefr_source: Option<String>,
+    /// RFC3339 timestamp of the last modification; `None` means "unknown"
+    /// (predates sync support) and sorts as the oldest.
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    /// RFC3339 tombstone marker; `Some` rows are hidden from reads.
+    #[serde(default)]
+    pub deleted_at: Option<String>,
+}
+
+impl Lemma {
+    pub fn slug_id(lemma: &str, target_lang: &str) -> String {
+        let base = format!("{}-{}", target_lang, slugify(lemma));
+        base.trim_matches('-').to_string()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct Form {
+    /// Deterministic id: `"{lemma_id}--{slug(surface)}"`; callers
+    /// disambiguate feats_key collisions with `-1`, `-2`, ... suffixes.
+    pub id: String,
+    pub lemma_id: String,
+    pub surface: String,
+    /// UD features as returned by the LLM ("Mood=Ind|Number=Sing|...").
+    pub feats: String,
+    /// Normalized (sorted) form of `feats`, used for deduplication.
+    pub feats_key: String,
+    pub status: i32,
+    pub mastery: f64,
+    pub correct: i32,
+    pub incorrect: i32,
+    /// RFC3339 timestamp of the last session that touched this form.
+    pub last_seen: Option<String>,
+    /// RFC3339 timestamp of the last modification; `None` means "unknown"
+    /// (predates sync support) and sorts as the oldest.
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    /// RFC3339 tombstone marker; `Some` rows are hidden from reads.
+    #[serde(default)]
+    pub deleted_at: Option<String>,
+}
+
+impl Form {
+    pub fn id(lemma_id: &str, surface: &str) -> String {
+        format!("{}--{}", lemma_id, slugify(surface))
+    }
+}
+
+/// Canonical short form of a full lowercased `key=value` UD pair, or the
+/// input unchanged when no canonicalization applies. Only complete pairs
+/// are rewritten — never bare keys or values — to avoid collisions like
+/// "Imperfect" vs "Imperative".
+fn canonicalize_feat(segment: &str) -> &str {
+    match segment {
+        "tense=present" => "tense=pres",
+        "tense=preterite" => "tense=past",
+        "mood=indicative" => "mood=ind",
+        "number=singular" => "number=sing",
+        "number=plural" => "number=plur",
+        "gender=masculine" => "gender=masc",
+        "gender=feminine" => "gender=fem",
+        "person=first" => "person=1",
+        "person=second" => "person=2",
+        "person=third" => "person=3",
+        "verbform=finite" => "verbform=fin",
+        other => other,
+    }
+}
+
+/// Normalized dedup key for UD features: split on '|', trim, drop empty
+/// segments, lowercase, canonicalize known `key=value` pairs, sort,
+/// dedup, rejoin. Best-effort — malformed segments are kept as-is
+/// (garbage feats must not block form creation).
+pub fn normalize_feats_key(feats: &str) -> String {
+    let mut parts: Vec<String> = feats
+        .split('|')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(|p| {
+            let lowered = p.to_lowercase();
+            canonicalize_feat(&lowered).to_string()
+        })
+        .collect();
+    parts.sort_unstable();
+    parts.dedup();
+    parts.join("|")
+}
+
+/// Unicode-aware comparison key for lemmas and surface forms: NFKC
+/// normalization plus lowercase. Diacritics are kept ("año" ≠ "ano").
+pub fn normalize_key(s: &str) -> String {
+    s.nfkc().collect::<String>().to_lowercase()
+}
+
+/// Priority rank of a CEFR source: user-curated data ("manual"/"list") is 4,
+/// curriculum topics ("topic") 3, LLM estimates ("llm") 2, and anything else
+/// or `None` is 0.
+pub fn cefr_source_rank(source: Option<&str>) -> u8 {
+    match source {
+        Some("manual") | Some("list") => 4,
+        Some("topic") => 3,
+        Some("llm") => 2,
+        _ => 0,
+    }
+}
+
+/// Whether a CEFR value from `new_source` should replace the stored one from
+/// `existing_source`: only when the new source ranks strictly higher, so an
+/// LLM estimate never overwrites a topic- or user-derived level.
+pub fn should_replace_cefr(existing_source: Option<&str>, new_source: &str) -> bool {
+    cefr_source_rank(Some(new_source)) > cefr_source_rank(existing_source)
+}
+
+/// Vocabulary status derived from mastery: 0 below 50, 1 from 50, 2 from 80.
+/// An observed error caps the status at `STATUS_PRACTICING`: one mistake
+/// means the word is not fully known yet.
+pub fn derive_status(mastery: f64, had_error: bool) -> i32 {
+    let base = if mastery >= COMPLETED_THRESHOLD {
+        STATUS_KNOWN
+    } else if mastery >= MASTERY_THRESHOLD {
+        STATUS_PRACTICING
+    } else {
+        STATUS_NEW
+    };
+    if had_error {
+        base.min(STATUS_PRACTICING)
+    } else {
+        base
+    }
+}
+
+/// Per-use session score for a student-side vocabulary use: 100 when both
+/// spelling and usage are fine, 30 for a spelling-only problem, 0 when the
+/// word is misused (wrong choice, form, or agreement).
+pub fn vocabulary_session_score(spelling_ok: bool, usage_ok: bool) -> f64 {
+    if !usage_ok {
+        0.0
+    } else if !spelling_ok {
+        30.0
+    } else {
+        100.0
+    }
+}
+
+/// Index of the existing lemma matching `(target_lang, lemma, pos)`. The
+/// headword and POS are compared with `normalize_key` because the LLM does
+/// not guarantee consistent casing or Unicode normalization.
+pub fn find_lemma(existing: &[Lemma], target_lang: &str, lemma: &str, pos: &str) -> Option<usize> {
+    existing.iter().position(|l| {
+        l.target_lang == target_lang
+            && normalize_key(&l.lemma) == normalize_key(lemma)
+            && normalize_key(&l.pos) == normalize_key(pos)
+    })
+}
+
+/// Index of the existing form matching `(lemma_id, feats_key)`. Falls back
+/// to a surface match when `feats_key` is empty, so malformed LLM feats do
+/// not produce duplicate forms.
+pub fn find_form(existing: &[Form], lemma_id: &str, surface: &str, feats_key: &str) -> Option<usize> {
+    existing.iter().position(|f| {
+        f.lemma_id == lemma_id
+            && if feats_key.is_empty() {
+                normalize_key(&f.surface) == normalize_key(surface)
+            } else {
+                f.feats_key == feats_key
+            }
+    })
+}
+
+/// Minimum feats similarity for `find_form_fuzzy` to treat two forms of
+/// the same surface as one inflected form.
+pub const FORM_MERGE_SIMILARITY: f64 = 0.8;
+
+/// Similarity of two normalized feats keys: Jaccard over their segment
+/// sets, with a subset (or two empty keys) counting as 1.0.
+pub fn feats_similarity(a: &str, b: &str) -> f64 {
+    let set_a: HashSet<&str> = a.split('|').filter(|s| !s.is_empty()).collect();
+    let set_b: HashSet<&str> = b.split('|').filter(|s| !s.is_empty()).collect();
+    if set_a.is_subset(&set_b) || set_b.is_subset(&set_a) {
+        return 1.0;
+    }
+    let intersection = set_a.intersection(&set_b).count() as f64;
+    let union = set_a.union(&set_b).count() as f64;
+    intersection / union
+}
+
+/// Index of the existing form matching `(lemma_id, surface, feats_key)`:
+/// first the exact `find_form`, otherwise the same-lemma form with the
+/// same normalized surface whose feats similarity is highest and at least
+/// `FORM_MERGE_SIMILARITY` (e.g. an incomplete feats set from the LLM).
+pub fn find_form_fuzzy(
+    existing: &[Form],
+    lemma_id: &str,
+    surface: &str,
+    feats_key: &str,
+) -> Option<usize> {
+    if let Some(i) = find_form(existing, lemma_id, surface, feats_key) {
+        return Some(i);
+    }
+    let surface_key = normalize_key(surface);
+    existing
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| f.lemma_id == lemma_id && normalize_key(&f.surface) == surface_key)
+        .map(|(i, f)| (i, feats_similarity(&f.feats_key, feats_key)))
+        .filter(|(_, sim)| *sim >= FORM_MERGE_SIMILARITY)
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(i, _)| i)
+}
+
+/// Whether a grammar error is fully explained by a single word form the
+/// student got wrong: true when a student-side vocabulary use failed
+/// (`spelling_ok` or `usage_ok` is `Some(false)`) and its surface or lemma
+/// shares significant words with the error's pattern/explanation. Such
+/// errors belong to the vocabulary system and must not also create
+/// learning items.
+pub fn vocabulary_owns_error(sentence: &SentenceAnalysis, error: &GrammarError) -> bool {
+    let error_text = format!("{} {}", error.pattern, error.explanation);
+    let error_words = significant_words(&error_text);
+    if error_words.is_empty() {
+        return false;
+    }
+    sentence
+        .used_vocabulary
+        .iter()
+        .filter(|u| u.side == "student")
+        .filter(|u| u.spelling_ok == Some(false) || u.usage_ok == Some(false))
+        .any(|u| {
+            text_contains_any_word(&u.surface, &error_words)
+                || text_contains_any_word(&u.lemma, &error_words)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_feats_key_sorts_and_trims() {
+        assert_eq!(
+            normalize_feats_key("Tense=Pres | Mood=Ind|Number=Sing"),
+            "mood=ind|number=sing|tense=pres"
+        );
+    }
+
+    #[test]
+    fn normalize_feats_key_tolerates_garbage() {
+        assert_eq!(normalize_feats_key(""), "");
+        assert_eq!(normalize_feats_key("|| |"), "");
+        // Malformed segments are kept, not dropped.
+        assert_eq!(normalize_feats_key("bogus|Number=Sing"), "bogus|number=sing");
+    }
+
+    #[test]
+    fn normalize_feats_key_canonicalizes_full_pairs() {
+        assert_eq!(normalize_feats_key("Tense=Present"), "tense=pres");
+        assert_eq!(normalize_feats_key("Tense=Preterite"), "tense=past");
+        assert_eq!(
+            normalize_feats_key(
+                "Mood=Indicative|Number=Singular|Person=First|Gender=Feminine|VerbForm=Finite"
+            ),
+            "gender=fem|mood=ind|number=sing|person=1|verbform=fin"
+        );
+        // Unknown pairs are only lowercased, never guessed.
+        assert_eq!(normalize_feats_key("Tense=Imperfect"), "tense=imperfect");
+    }
+
+    #[test]
+    fn normalize_feats_key_dedups_after_canonicalization() {
+        assert_eq!(
+            normalize_feats_key("Number=Sing|Number=Singular|number=sing"),
+            "number=sing"
+        );
+    }
+
+    #[test]
+    fn normalize_feats_key_is_order_and_case_insensitive() {
+        // "hablo": same feats in a different order and casing produce one key.
+        assert_eq!(
+            normalize_feats_key("Mood=Ind|Number=Sing|Person=1|Tense=Pres"),
+            normalize_feats_key("Tense=Pres | person=1|Number=Sing|MOOD=IND")
+        );
+        // Full UD values canonicalize to the same key as short ones.
+        assert_eq!(
+            normalize_feats_key("Mood=Indicative|Tense=Present|Number=Singular|Person=1"),
+            normalize_feats_key("mood=ind|tense=pres|number=sing|person=1")
+        );
+    }
+
+    #[test]
+    fn normalize_key_keeps_diacritics() {
+        assert_eq!(normalize_key("Año"), "año");
+        assert_ne!(normalize_key("año"), normalize_key("ano"));
+        // NFKC folds compatibility characters.
+        assert_eq!(normalize_key("ﬁnal"), "final");
+    }
+
+    #[test]
+    fn is_content_pos_filters_function_words() {
+        for pos in ["NOUN", "verb", "Adj", "ADV", "PROPN"] {
+            assert!(is_content_pos(pos), "{pos} should be content");
+        }
+        for pos in ["PART", "ADP", "DET", "PRON", "AUX", "CCONJ", "PUNCT"] {
+            assert!(!is_content_pos(pos), "{pos} should be function");
+        }
+        // Empty or unrecognized tags are lazily accepted.
+        assert!(is_content_pos(""));
+        assert!(is_content_pos("NUM"));
+        assert!(is_content_pos("garbage"));
+    }
+
+    #[test]
+    fn derive_status_thresholds() {
+        assert_eq!(derive_status(0.0, false), STATUS_NEW);
+        assert_eq!(derive_status(49.9, false), STATUS_NEW);
+        assert_eq!(derive_status(50.0, false), STATUS_PRACTICING);
+        assert_eq!(derive_status(79.9, false), STATUS_PRACTICING);
+        assert_eq!(derive_status(80.0, false), STATUS_KNOWN);
+        assert_eq!(derive_status(100.0, false), STATUS_KNOWN);
+    }
+
+    #[test]
+    fn derive_status_error_caps_at_practicing() {
+        assert_eq!(derive_status(95.0, true), STATUS_PRACTICING);
+        assert_eq!(derive_status(60.0, true), STATUS_PRACTICING);
+        assert_eq!(derive_status(10.0, true), STATUS_NEW);
+    }
+
+    #[test]
+    fn vocabulary_session_score_values() {
+        assert_eq!(vocabulary_session_score(true, true), 100.0);
+        assert_eq!(vocabulary_session_score(false, true), 30.0);
+        assert_eq!(vocabulary_session_score(true, false), 0.0);
+        assert_eq!(vocabulary_session_score(false, false), 0.0);
+    }
+
+    #[test]
+    fn ids_are_deterministic() {
+        assert_eq!(Lemma::slug_id("comer", "es"), "es-comer");
+        assert_eq!(Lemma::slug_id("Pequeño/Pequeña", "es"), "es-pequeno-pequena");
+        assert_eq!(Form::id("es-comer", "comí"), "es-comer--comi");
+        assert_eq!(Form::id("es-comer", "Comí"), "es-comer--comi");
+    }
+
+    #[test]
+    fn cefr_source_rank_orders_sources() {
+        assert_eq!(cefr_source_rank(Some("manual")), 4);
+        assert_eq!(cefr_source_rank(Some("list")), 4);
+        assert_eq!(cefr_source_rank(Some("topic")), 3);
+        assert_eq!(cefr_source_rank(Some("llm")), 2);
+        assert_eq!(cefr_source_rank(Some("bogus")), 0);
+        assert_eq!(cefr_source_rank(None), 0);
+    }
+
+    #[test]
+    fn should_replace_cefr_requires_strictly_higher_rank() {
+        // llm -> topic replaces.
+        assert!(should_replace_cefr(Some("llm"), "topic"));
+        // topic -> llm does not.
+        assert!(!should_replace_cefr(Some("topic"), "llm"));
+        // Missing source is replaced by any known source.
+        assert!(should_replace_cefr(None, "llm"));
+        // Unknown new source never replaces.
+        assert!(!should_replace_cefr(None, "bogus"));
+        // Equal rank does not replace.
+        assert!(!should_replace_cefr(Some("topic"), "topic"));
+        assert!(!should_replace_cefr(Some("manual"), "list"));
+    }
+
+    #[test]
+    fn find_lemma_matches_case_insensitively() {
+        let existing = vec![Lemma {
+            id: "es-comer".to_string(),
+            lemma: "comer".to_string(),
+            pos: "VERB".to_string(),
+            target_lang: "es".to_string(),
+            ..Default::default()
+        }];
+        assert_eq!(find_lemma(&existing, "es", "Comer", "verb"), Some(0));
+        assert_eq!(find_lemma(&existing, "es", "comer", "NOUN"), None);
+        assert_eq!(find_lemma(&existing, "fr", "comer", "VERB"), None);
+    }
+
+    #[test]
+    fn find_form_dedups_by_feats_key_then_surface() {
+        let existing = vec![
+            Form {
+                id: "es-comer--como".to_string(),
+                lemma_id: "es-comer".to_string(),
+                surface: "como".to_string(),
+                feats_key: "Mood=Ind|Number=Sing|Person=1".to_string(),
+                ..Default::default()
+            },
+            Form {
+                id: "es-comer--comi".to_string(),
+                lemma_id: "es-comer".to_string(),
+                surface: "comí".to_string(),
+                feats_key: String::new(),
+                ..Default::default()
+            },
+        ];
+        // Same lemma and feats_key -> duplicate.
+        assert_eq!(
+            find_form(&existing, "es-comer", "como", "Mood=Ind|Number=Sing|Person=1"),
+            Some(0)
+        );
+        // Different feats_key -> distinct form.
+        assert_eq!(
+            find_form(&existing, "es-comer", "como", "Mood=Ind|Number=Plur|Person=1"),
+            None
+        );
+        // Empty feats_key falls back to the surface match.
+        assert_eq!(find_form(&existing, "es-comer", "Comí", ""), Some(1));
+        assert_eq!(find_form(&existing, "es-comer", "como", ""), Some(0));
+    }
+
+    #[test]
+    fn find_lemma_does_not_merge_diacritics() {
+        let existing = vec![Lemma {
+            id: "es-ano".to_string(),
+            lemma: "ano".to_string(),
+            pos: "NOUN".to_string(),
+            target_lang: "es".to_string(),
+            ..Default::default()
+        }];
+        assert_eq!(find_lemma(&existing, "es", "año", "NOUN"), None);
+        assert_eq!(find_lemma(&existing, "es", "Ano", "noun"), Some(0));
+    }
+
+    #[test]
+    fn feats_similarity_jaccard_with_subset_shortcut() {
+        assert_eq!(feats_similarity("", ""), 1.0);
+        // A subset (e.g. an incomplete feats set: 4 of 5 segments) is a
+        // full match.
+        assert_eq!(
+            feats_similarity(
+                "mood=ind|number=sing|person=1|tense=pres",
+                "mood=ind|number=sing|person=1|tense=pres|verbform=fin"
+            ),
+            1.0
+        );
+        // 8 of 10 union segments -> 0.8, right at the merge threshold.
+        let a = "a=1|b=1|c=1|d=1|e=1|f=1|g=1|h=1|i=1";
+        let b = "a=1|b=1|c=1|d=1|e=1|f=1|g=1|h=1|j=1";
+        assert_eq!(feats_similarity(a, b), 0.8);
+        // 4 of 6 union segments -> 0.667, below the threshold.
+        let a = "mood=ind|number=sing|person=1|tense=pres|verbform=fin";
+        let b = "mood=ind|number=sing|person=1|tense=past|verbform=fin";
+        assert!((feats_similarity(a, b) - 2.0 / 3.0).abs() < 1e-9);
+        // Disjoint sets -> 0.0.
+        assert_eq!(feats_similarity("mood=ind", "mood=sub"), 0.0);
+    }
+
+    #[test]
+    fn find_form_fuzzy_merges_incomplete_feats() {
+        let existing = vec![
+            Form {
+                id: "es-hablar--hablo".to_string(),
+                lemma_id: "es-hablar".to_string(),
+                surface: "hablo".to_string(),
+                feats_key: "mood=ind|number=sing|person=1|tense=pres|verbform=fin".to_string(),
+                ..Default::default()
+            },
+            Form {
+                id: "es-hablar--hablo-1".to_string(),
+                lemma_id: "es-hablar".to_string(),
+                surface: "hablo".to_string(),
+                feats_key: "mood=sub|number=sing|person=1|tense=pres|verbform=fin".to_string(),
+                ..Default::default()
+            },
+        ];
+        // Exact feats_key match wins.
+        assert_eq!(
+            find_form_fuzzy(
+                &existing,
+                "es-hablar",
+                "Hablo",
+                "mood=ind|number=sing|person=1|tense=pres|verbform=fin"
+            ),
+            Some(0)
+        );
+        // Incomplete feats (4 of 5 segments, a subset) merge into the
+        // fuller form.
+        assert_eq!(
+            find_form_fuzzy(
+                &existing,
+                "es-hablar",
+                "hablo",
+                "mood=ind|number=sing|person=1|tense=pres"
+            ),
+            Some(0)
+        );
+        // Different feature sets (past vs present, similarity 0.67) stay
+        // distinct forms.
+        assert_eq!(
+            find_form_fuzzy(
+                &existing,
+                "es-hablar",
+                "hablo",
+                "mood=ind|number=sing|person=1|tense=past|verbform=fin"
+            ),
+            None
+        );
+        // A different lemma never merges.
+        assert_eq!(
+            find_form_fuzzy(
+                &existing,
+                "es-comer",
+                "hablo",
+                "mood=ind|number=sing|person=1|tense=pres|verbform=fin"
+            ),
+            None
+        );
+    }
+
+    fn sentence_with_uses(uses: Vec<crate::session::VocabularyUse>) -> SentenceAnalysis {
+        SentenceAnalysis {
+            sentence_number: 1,
+            student_translation: String::new(),
+            expected_translation: String::new(),
+            acceptable_translations: vec![],
+            semantic_verdict: crate::session::SemanticVerdict::NeedsCorrection,
+            errors: vec![],
+            per_sentence_feedback: vec![],
+            used_vocabulary: uses,
+        }
+    }
+
+    #[test]
+    fn vocabulary_owns_error_when_failed_use_matches() {
+        let sentence = sentence_with_uses(vec![
+            crate::session::VocabularyUse {
+                surface: "pequeño".to_string(),
+                lemma: "pequeño".to_string(),
+                pos: "ADJ".to_string(),
+                side: "student".to_string(),
+                spelling_ok: Some(true),
+                usage_ok: Some(false),
+                ..Default::default()
+            },
+            crate::session::VocabularyUse {
+                surface: "casa".to_string(),
+                lemma: "casa".to_string(),
+                pos: "NOUN".to_string(),
+                side: "target".to_string(),
+                ..Default::default()
+            },
+        ]);
+        let owned = GrammarError {
+            error_type: crate::session::GrammarErrorType::Major,
+            pattern: "pequeño vs pequeña".to_string(),
+            explanation: "La casa es pequeña: the adjective must agree in gender.".to_string(),
+            ..Default::default()
+        };
+        assert!(vocabulary_owns_error(&sentence, &owned));
+    }
+
+    #[test]
+    fn vocabulary_owns_error_rejects_constructions_and_clean_uses() {
+        let sentence = sentence_with_uses(vec![crate::session::VocabularyUse {
+            surface: "caro".to_string(),
+            lemma: "caro".to_string(),
+            pos: "ADJ".to_string(),
+            side: "student".to_string(),
+            spelling_ok: Some(true),
+            usage_ok: Some(false),
+            ..Default::default()
+        }]);
+        // A word-pair confusion about different words is not owned.
+        let construction = GrammarError {
+            error_type: crate::session::GrammarErrorType::Major,
+            pattern: "word order".to_string(),
+            explanation: "Adjectives usually follow the noun in Spanish.".to_string(),
+            ..Default::default()
+        };
+        assert!(!vocabulary_owns_error(&sentence, &construction));
+        // No failed student-side use -> nothing to own.
+        let sentence = sentence_with_uses(vec![crate::session::VocabularyUse {
+            surface: "pequeño".to_string(),
+            lemma: "pequeño".to_string(),
+            side: "student".to_string(),
+            spelling_ok: Some(true),
+            usage_ok: Some(true),
+            ..Default::default()
+        }]);
+        let error = GrammarError {
+            pattern: "pequeño vs pequeña".to_string(),
+            ..Default::default()
+        };
+        assert!(!vocabulary_owns_error(&sentence, &error));
+    }
+}

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -228,7 +228,12 @@ pub fn find_lemma(existing: &[Lemma], target_lang: &str, lemma: &str, pos: &str)
 /// Index of the existing form matching `(lemma_id, feats_key)`. Falls back
 /// to a surface match when `feats_key` is empty, so malformed LLM feats do
 /// not produce duplicate forms.
-pub fn find_form(existing: &[Form], lemma_id: &str, surface: &str, feats_key: &str) -> Option<usize> {
+pub fn find_form(
+    existing: &[Form],
+    lemma_id: &str,
+    surface: &str,
+    feats_key: &str,
+) -> Option<usize> {
     existing.iter().position(|f| {
         f.lemma_id == lemma_id
             && if feats_key.is_empty() {
@@ -320,7 +325,10 @@ mod tests {
         assert_eq!(normalize_feats_key(""), "");
         assert_eq!(normalize_feats_key("|| |"), "");
         // Malformed segments are kept, not dropped.
-        assert_eq!(normalize_feats_key("bogus|Number=Sing"), "bogus|number=sing");
+        assert_eq!(
+            normalize_feats_key("bogus|Number=Sing"),
+            "bogus|number=sing"
+        );
     }
 
     #[test]
@@ -409,7 +417,10 @@ mod tests {
     #[test]
     fn ids_are_deterministic() {
         assert_eq!(Lemma::slug_id("comer", "es"), "es-comer");
-        assert_eq!(Lemma::slug_id("Pequeño/Pequeña", "es"), "es-pequeno-pequena");
+        assert_eq!(
+            Lemma::slug_id("Pequeño/Pequeña", "es"),
+            "es-pequeno-pequena"
+        );
         assert_eq!(Form::id("es-comer", "comí"), "es-comer--comi");
         assert_eq!(Form::id("es-comer", "Comí"), "es-comer--comi");
     }
@@ -473,12 +484,22 @@ mod tests {
         ];
         // Same lemma and feats_key -> duplicate.
         assert_eq!(
-            find_form(&existing, "es-comer", "como", "Mood=Ind|Number=Sing|Person=1"),
+            find_form(
+                &existing,
+                "es-comer",
+                "como",
+                "Mood=Ind|Number=Sing|Person=1"
+            ),
             Some(0)
         );
         // Different feats_key -> distinct form.
         assert_eq!(
-            find_form(&existing, "es-comer", "como", "Mood=Ind|Number=Plur|Person=1"),
+            find_form(
+                &existing,
+                "es-comer",
+                "como",
+                "Mood=Ind|Number=Plur|Person=1"
+            ),
             None
         );
         // Empty feats_key falls back to the surface match.

--- a/crates/db/src/apply.rs
+++ b/crates/db/src/apply.rs
@@ -1,25 +1,31 @@
 //! Applying a finished session's analysis to the database: topic mastery
 //! updates, history records, adaptive alerts and learning items.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use chrono::Utc;
 
 use crate::curriculum::Topic;
+use crate::forms::Form;
 use crate::history::{HistoryTable, SessionSummary};
 use crate::learning_items::{
     LearningItem, is_duplicate_name, is_learning_item_name, significant_words,
     text_contains_any_word,
 };
+use crate::lemmas::Lemma;
 use crate::progress::{ProgressData, ProgressTopic};
+use open_course_core::curriculum::{CEFR_LEVELS, Curriculum, cefr_to_numeric};
 use open_course_core::error::Result;
-
-use open_course_core::session::models::AnalysisResult;
+use open_course_core::session::models::{AnalysisResult, VocabularyUse};
 use open_course_core::session::scoring::{
     adaptive_alpha, average, clamp_score, ema_update, topic_exercise_scores,
 };
 use open_course_core::session::{
     LOW_SESSION_SCORE_THRESHOLD, MASTERY_THRESHOLD, MentorSession, unique_topic_ids,
+};
+use open_course_core::vocabulary::{
+    STATUS_NEW, derive_status, find_form_fuzzy, find_lemma, normalize_feats_key,
+    should_replace_cefr, vocabulary_session_score,
 };
 
 pub async fn apply_analysis(
@@ -142,12 +148,20 @@ pub async fn apply_analysis(
     Ok(final_scores)
 }
 
+/// Returns the final topic masteries plus the ids of every lemma and form
+/// the session touched (created, practiced, or CEFR-updated), so the caller
+/// can emit outbox entries for exactly the rows that changed.
+///
+/// Forced lemmas earn practice credit only through student-side evidence:
+/// `_forced_lemma_ids` is kept for call-site symmetry but a forced lemma
+/// without an observed use is left completely untouched.
 pub async fn apply_analysis_to_db(
-    analysis: &AnalysisResult,
+    analysis: &mut AnalysisResult,
     session: &MentorSession,
     forced_learning_item_ids: &[String],
+    _forced_lemma_ids: &[String],
     db: &crate::Database,
-) -> Result<HashMap<String, f64>> {
+) -> Result<(HashMap<String, f64>, Vec<String>, Vec<String>)> {
     let mut progress = db.progress().read_all().await?;
 
     let mut learning_items: HashMap<String, LearningItem> = db
@@ -241,10 +255,273 @@ pub async fn apply_analysis_to_db(
         db.learning_items().upsert(item).await?;
     }
 
+    // Vocabulary: lemmas and forms mentioned in `used_vocabulary`. Words
+    // from the target sentence (side "target") are only registered as NEW;
+    // words from the student's translation (side "student") carry per-use
+    // assessments and produce scoring evidence. Both sides ensure the
+    // lemma/form exists — student-side evidence needs an entity to attach
+    // to even when the word never appeared in the target sentence.
+    let mut lemmas: Vec<Lemma> = db.lemmas().read_all().await?;
+    let mut forms: Vec<Form> = db.forms().read_all().await?;
+    // Worst-case evidence per entity: the lowest session score across all
+    // observed uses, plus whether any use had an error.
+    let mut lemma_evidence: HashMap<String, (f64, bool)> = HashMap::new();
+    let mut form_evidence: HashMap<String, (f64, bool)> = HashMap::new();
+    let mut created_lemma_ids: Vec<String> = Vec::new();
+    let mut created_form_ids: Vec<String> = Vec::new();
+    // Existing forms whose feats were enriched by a richer incoming variant
+    // through fuzzy-merge; they must be persisted even without evidence.
+    let mut enriched_form_ids: HashSet<String> = HashSet::new();
+    // Lemmas whose CEFR level was upgraded by a higher-ranked source without
+    // any scoring evidence; they still need to be persisted.
+    let mut cefr_updated_lemma_ids: HashSet<String> = HashSet::new();
+
+    for sentence in &analysis.sentences {
+        for vocabulary_use in &sentence.used_vocabulary {
+            if vocabulary_use.lemma.is_empty() {
+                continue;
+            }
+            let cefr = cefr_candidate(
+                session,
+                &existing_curriculum,
+                sentence.sentence_number,
+                vocabulary_use,
+            );
+            let lemma_pos = match find_lemma(
+                &lemmas,
+                &existing_curriculum.target_language,
+                &vocabulary_use.lemma,
+                &vocabulary_use.pos,
+            ) {
+                Some(pos) => {
+                    // Reappearance of a known lemma: a strictly higher-ranked
+                    // source replaces the stored level (topic overrides an
+                    // LLM guess, never the other way round).
+                    if let Some((level, source)) = &cefr
+                        && should_replace_cefr(lemmas[pos].cefr_source.as_deref(), source)
+                    {
+                        lemmas[pos].cefr_level = Some(level.clone());
+                        lemmas[pos].cefr_source = Some(source.to_string());
+                        cefr_updated_lemma_ids.insert(lemmas[pos].id.clone());
+                    }
+                    pos
+                }
+                None => {
+                    let (cefr_level, cefr_source) = match &cefr {
+                        Some((level, source)) => {
+                            (Some(level.clone()), Some(source.to_string()))
+                        }
+                        None => (None, None),
+                    };
+                    let mut lemma = Lemma {
+                        id: Lemma::slug_id(
+                            &vocabulary_use.lemma,
+                            &existing_curriculum.target_language,
+                        ),
+                        lemma: vocabulary_use.lemma.clone(),
+                        pos: vocabulary_use.pos.clone(),
+                        target_lang: existing_curriculum.target_language.clone(),
+                        native_lang: existing_curriculum.native_language.clone(),
+                        status: STATUS_NEW,
+                        cefr_level,
+                        cefr_source,
+                        ..Default::default()
+                    };
+                    // The slug id is taken by a different (lemma, pos):
+                    // disambiguate with a POS suffix.
+                    if lemmas.iter().any(|l| l.id == lemma.id) {
+                        lemma.id =
+                            format!("{}-{}", lemma.id, vocabulary_use.pos.to_lowercase());
+                    }
+                    created_lemma_ids.push(lemma.id.clone());
+                    lemmas.push(lemma);
+                    lemmas.len() - 1
+                }
+            };
+            let lemma_id = lemmas[lemma_pos].id.clone();
+
+            if vocabulary_use.surface.is_empty() {
+                continue;
+            }
+            let feats_key = normalize_feats_key(&vocabulary_use.feats);
+            let form_pos =
+                match find_form_fuzzy(&forms, &lemma_id, &vocabulary_use.surface, &feats_key) {
+                    Some(pos) => {
+                        // Fuzzy hit: the incoming use merges into the existing
+                        // form instead of creating a near-duplicate. When the
+                        // incoming feats set is richer (more segments) than
+                        // the stored one, upgrade feats/feats_key to the
+                        // fuller description and persist the form.
+                        if feats_segment_count(&feats_key)
+                            > feats_segment_count(&forms[pos].feats_key)
+                        {
+                            forms[pos].feats = vocabulary_use.feats.clone();
+                            forms[pos].feats_key = feats_key.clone();
+                            enriched_form_ids.insert(forms[pos].id.clone());
+                        }
+                        Some(pos)
+                    }
+                    None => {
+                        let base_id = Form::id(&lemma_id, &vocabulary_use.surface);
+                        let mut id = base_id.clone();
+                        // feats_key collisions on the same surface get numeric
+                        // suffixes (same pattern as topic_id_from_name).
+                        let mut suffix = 0;
+                        while forms.iter().any(|f| f.id == id) {
+                            suffix += 1;
+                            id = format!("{base_id}-{suffix}");
+                        }
+                        let form = Form {
+                            id,
+                            lemma_id: lemma_id.clone(),
+                            surface: vocabulary_use.surface.clone(),
+                            feats: vocabulary_use.feats.clone(),
+                            feats_key,
+                            status: STATUS_NEW,
+                            ..Default::default()
+                        };
+                        created_form_ids.push(form.id.clone());
+                        forms.push(form);
+                        Some(forms.len() - 1)
+                    }
+                };
+
+            if vocabulary_use.side != "student" {
+                continue;
+            }
+            // A missing assessment (None) is treated conservatively as OK:
+            // the LLM omits the flags when nothing is wrong, so an absent
+            // flag must not penalize the word.
+            let session_score = vocabulary_session_score(
+                vocabulary_use.spelling_ok.unwrap_or(true),
+                vocabulary_use.usage_ok.unwrap_or(true),
+            );
+            let had_error = session_score < 100.0;
+            lemma_evidence
+                .entry(lemma_id.clone())
+                .and_modify(|(score, err)| {
+                    *score = score.min(session_score);
+                    *err = *err || had_error;
+                })
+                .or_insert((session_score, had_error));
+            if let Some(pos) = form_pos {
+                let form_id = forms[pos].id.clone();
+                form_evidence
+                    .entry(form_id)
+                    .and_modify(|(score, err)| {
+                        *score = score.min(session_score);
+                        *err = *err || had_error;
+                    })
+                    .or_insert((session_score, had_error));
+            }
+        }
+    }
+
+    // Scored lemmas: only those with student-side evidence. A forced lemma
+    // the student never used earns no credit — its mastery, counters,
+    // last_seen and status stay untouched and it is not marked touched
+    // (neutral non-use instead of the former soft credit with a perfect
+    // score). Forms likewise score only through evidence.
+    let mut touched_lemma_ids: HashSet<String> = created_lemma_ids.iter().cloned().collect();
+    touched_lemma_ids.extend(cefr_updated_lemma_ids);
+    let mut touched_form_ids: HashSet<String> = created_form_ids.iter().cloned().collect();
+    touched_form_ids.extend(enriched_form_ids);
+
+    for (id, (session_score, had_error)) in &lemma_evidence {
+        if let Some(lemma) = lemmas.iter_mut().find(|l| &l.id == id) {
+            lemma.mastery = ema_update(lemma.mastery, *session_score);
+            lemma.practice_count += 1;
+            if *had_error {
+                lemma.incorrect_uses += 1;
+            } else {
+                lemma.correct_uses += 1;
+            }
+            lemma.last_seen = Some(now.clone());
+            lemma.status = derive_status(lemma.mastery, *had_error);
+            touched_lemma_ids.insert(id.clone());
+        }
+    }
+
+    for (id, (session_score, had_error)) in &form_evidence {
+        if let Some(form) = forms.iter_mut().find(|f| &f.id == id) {
+            form.mastery = ema_update(form.mastery, *session_score);
+            if *had_error {
+                form.incorrect += 1;
+            } else {
+                form.correct += 1;
+            }
+            form.last_seen = Some(now.clone());
+            form.status = derive_status(form.mastery, *had_error);
+            touched_form_ids.insert(id.clone());
+        }
+    }
+
+    // Report the created entities (post-scoring state) so callers can emit
+    // outbox entries and session summaries.
+    analysis.new_lemmas = created_lemma_ids
+        .iter()
+        .filter_map(|id| lemmas.iter().find(|l| &l.id == id).cloned())
+        .collect();
+    analysis.new_forms = created_form_ids
+        .iter()
+        .filter_map(|id| forms.iter().find(|f| &f.id == id).cloned())
+        .collect();
+
+    for lemma in lemmas.iter().filter(|l| touched_lemma_ids.contains(&l.id)) {
+        db.lemmas().upsert(lemma).await?;
+    }
+    for form in forms.iter().filter(|f| touched_form_ids.contains(&f.id)) {
+        db.forms().upsert(form).await?;
+    }
+
     let history = db.history();
     let scores = apply_analysis(analysis, session, &mut progress, &history).await?;
     db.progress().write_all(&progress).await?;
-    Ok(scores)
+    let mut touched_lemmas: Vec<String> = touched_lemma_ids.into_iter().collect();
+    touched_lemmas.sort();
+    let mut touched_forms: Vec<String> = touched_form_ids.into_iter().collect();
+    touched_forms.sort();
+    Ok((scores, touched_lemmas, touched_forms))
+}
+
+/// Number of `key=value` segments in a normalized feats key — used to decide
+/// which of two fuzzy-merged variants carries the richer description.
+fn feats_segment_count(feats_key: &str) -> usize {
+    feats_key.split('|').filter(|s| !s.is_empty()).count()
+}
+
+/// CEFR candidate for a vocabulary use: the minimum valid level among the
+/// curriculum topics targeted by the exercise the sentence belongs to
+/// (source "topic", matching the early-textbook-order guidance given to the
+/// LLM), falling back to the LLM's per-use estimate (source "llm"). Levels
+/// outside `CEFR_LEVELS` are dropped as garbage.
+fn cefr_candidate(
+    session: &MentorSession,
+    curriculum: &Curriculum,
+    sentence_number: i32,
+    vocabulary_use: &VocabularyUse,
+) -> Option<(String, &'static str)> {
+    // sentence_number is 1-based and matches the exercise order (validated
+    // at parse time).
+    if sentence_number >= 1
+        && let Some(exercise) = session.exercises.get((sentence_number - 1) as usize)
+    {
+        let topic_level = exercise
+            .target_topic_ids
+            .iter()
+            .filter_map(|id| curriculum.topics.iter().find(|t| &t.id == id))
+            .filter_map(|t| t.level.as_deref())
+            .filter(|level| CEFR_LEVELS.contains(level))
+            .min_by_key(|level| cefr_to_numeric(level).unwrap_or(i32::MAX));
+        if let Some(level) = topic_level {
+            return Some((level.to_string(), "topic"));
+        }
+    }
+    vocabulary_use
+        .cefr_level
+        .as_deref()
+        .filter(|level| CEFR_LEVELS.contains(level))
+        .map(|level| (level.to_string(), "llm"))
 }
 
 /// Inserts a new learning item, merging fuzzy name duplicates into the

--- a/crates/db/src/apply.rs
+++ b/crates/db/src/apply.rs
@@ -308,9 +308,7 @@ pub async fn apply_analysis_to_db(
                 }
                 None => {
                     let (cefr_level, cefr_source) = match &cefr {
-                        Some((level, source)) => {
-                            (Some(level.clone()), Some(source.to_string()))
-                        }
+                        Some((level, source)) => (Some(level.clone()), Some(source.to_string())),
                         None => (None, None),
                     };
                     let mut lemma = Lemma {
@@ -330,8 +328,7 @@ pub async fn apply_analysis_to_db(
                     // The slug id is taken by a different (lemma, pos):
                     // disambiguate with a POS suffix.
                     if lemmas.iter().any(|l| l.id == lemma.id) {
-                        lemma.id =
-                            format!("{}-{}", lemma.id, vocabulary_use.pos.to_lowercase());
+                        lemma.id = format!("{}-{}", lemma.id, vocabulary_use.pos.to_lowercase());
                     }
                     created_lemma_ids.push(lemma.id.clone());
                     lemmas.push(lemma);

--- a/crates/db/src/forms.rs
+++ b/crates/db/src/forms.rs
@@ -1,0 +1,288 @@
+use std::sync::Arc;
+
+use arrow_array::{Array, Float64Array, Int32Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use futures_util::stream::TryStreamExt;
+use lancedb::Connection;
+use lancedb::database::CreateTableMode;
+use lancedb::query::{ExecutableQuery, QueryBase};
+
+use crate::util::eq_predicate;
+use open_course_core::error::Result;
+
+pub use open_course_core::vocabulary::*;
+
+pub const TABLE_NAME: &str = "forms";
+
+pub(crate) fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("lemma_id", DataType::Utf8, false),
+        Field::new("surface", DataType::Utf8, false),
+        Field::new("feats", DataType::Utf8, false),
+        Field::new("feats_key", DataType::Utf8, false),
+        Field::new("status", DataType::Int32, false),
+        Field::new("mastery", DataType::Float64, false),
+        Field::new("correct", DataType::Int32, false),
+        Field::new("incorrect", DataType::Int32, false),
+        Field::new("last_seen", DataType::Utf8, true),
+        Field::new("updated_at", DataType::Utf8, true),
+        Field::new("deleted_at", DataType::Utf8, true),
+    ]))
+}
+
+#[derive(Clone)]
+pub struct FormsTable {
+    table: lancedb::Table,
+}
+
+impl FormsTable {
+    pub async fn open(connection: &Connection) -> Result<Self> {
+        let table = connection
+            .create_empty_table(TABLE_NAME, schema())
+            .mode(CreateTableMode::exist_ok(|req| req))
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(Self { table })
+    }
+
+    /// Reads all non-deleted forms.
+    pub async fn read_all(&self) -> Result<Vec<Form>> {
+        let records = self
+            .table
+            .query()
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let mut all = Vec::new();
+        for batch in &records {
+            all.extend(forms_from_record_batch(batch)?);
+        }
+        all.retain(|f| f.deleted_at.is_none());
+        Ok(all)
+    }
+
+    /// Insert or replace a form, stamping `updated_at` with the current time.
+    pub async fn upsert(&self, form: &Form) -> Result<()> {
+        let mut form = form.clone();
+        form.updated_at = Some(crate::util::now_rfc3339());
+        self.upsert_with_timestamps(&form).await
+    }
+
+    /// Insert or replace a form exactly as given — used when applying
+    /// synced changes whose timestamps must be preserved.
+    pub async fn upsert_with_timestamps(&self, form: &Form) -> Result<()> {
+        self.table
+            .delete(&eq_predicate("id", &form.id))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let batch = form_to_record_batch(form)?;
+        self.table
+            .add(vec![batch])
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
+    /// Soft-delete: the row stays as a tombstone so sync can propagate the
+    /// deletion; reads filter it out.
+    pub async fn delete_by_id(&self, id: &str) -> Result<()> {
+        let records = self
+            .table
+            .query()
+            .only_if(eq_predicate("id", id))
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let now = crate::util::now_rfc3339();
+        let mut tombstoned = Vec::new();
+        for batch in &records {
+            for mut form in forms_from_record_batch(batch)? {
+                form.deleted_at = Some(now.clone());
+                tombstoned.push(form);
+            }
+        }
+        if tombstoned.is_empty() {
+            return Ok(());
+        }
+        self.table
+            .delete(&eq_predicate("id", id))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        for form in &tombstoned {
+            let batch = form_to_record_batch(form)?;
+            self.table
+                .add(vec![batch])
+                .execute()
+                .await
+                .map_err(crate::error::DbError::from)?;
+        }
+        Ok(())
+    }
+
+    /// Physically removes tombstones older than `older_than` (RFC3339).
+    /// Not called automatically.
+    pub async fn purge_deleted(&self, older_than: &str) -> Result<()> {
+        self.table
+            .delete(&format!(
+                "deleted_at IS NOT NULL AND deleted_at < '{}'",
+                crate::util::sql_escape(older_than)
+            ))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
+    pub async fn reset(&self) -> Result<()> {
+        self.table
+            .delete("id IS NOT NULL")
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+}
+
+pub(crate) fn form_to_record_batch(form: &Form) -> Result<RecordBatch> {
+    let batch = RecordBatch::try_new(
+        schema(),
+        vec![
+            Arc::new(StringArray::from(vec![form.id.as_str()])),
+            Arc::new(StringArray::from(vec![form.lemma_id.as_str()])),
+            Arc::new(StringArray::from(vec![form.surface.as_str()])),
+            Arc::new(StringArray::from(vec![form.feats.as_str()])),
+            Arc::new(StringArray::from(vec![form.feats_key.as_str()])),
+            Arc::new(Int32Array::from(vec![form.status])),
+            Arc::new(Float64Array::from(vec![form.mastery])),
+            Arc::new(Int32Array::from(vec![form.correct])),
+            Arc::new(Int32Array::from(vec![form.incorrect])),
+            Arc::new(StringArray::from(vec![form.last_seen.as_deref()])),
+            Arc::new(StringArray::from(vec![form.updated_at.as_deref()])),
+            Arc::new(StringArray::from(vec![form.deleted_at.as_deref()])),
+        ],
+    )
+    .map_err(crate::error::DbError::from)?;
+    Ok(batch)
+}
+
+pub(crate) fn forms_from_record_batch(batch: &RecordBatch) -> Result<Vec<Form>> {
+    let n = batch.num_rows();
+    let string_col = |name: &str| {
+        batch
+            .column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+    };
+    let int_col = |name: &str| {
+        batch
+            .column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+    };
+    let id_col = string_col("id");
+    let lemma_id_col = string_col("lemma_id");
+    let surface_col = string_col("surface");
+    let feats_col = string_col("feats");
+    let feats_key_col = string_col("feats_key");
+    let status_col = int_col("status");
+    let mastery_col = batch
+        .column_by_name("mastery")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    let correct_col = int_col("correct");
+    let incorrect_col = int_col("incorrect");
+    let last_seen_col = string_col("last_seen");
+    let updated_col = crate::util::optional_string_column(batch, "updated_at");
+    let deleted_col = crate::util::optional_string_column(batch, "deleted_at");
+
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        out.push(Form {
+            id: id_col.value(i).to_string(),
+            lemma_id: lemma_id_col.value(i).to_string(),
+            surface: surface_col.value(i).to_string(),
+            feats: feats_col.value(i).to_string(),
+            feats_key: feats_key_col.value(i).to_string(),
+            status: status_col.value(i),
+            mastery: mastery_col.value(i),
+            correct: correct_col.value(i),
+            incorrect: incorrect_col.value(i),
+            last_seen: if last_seen_col.is_null(i) || last_seen_col.value(i).is_empty() {
+                None
+            } else {
+                Some(last_seen_col.value(i).to_string())
+            },
+            updated_at: crate::util::optional_string_at(updated_col, i),
+            deleted_at: crate::util::optional_string_at(deleted_col, i),
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lancedb::connect;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn upsert_read_delete_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let connection = connect(&dir.path().join("db").to_string_lossy())
+            .execute()
+            .await
+            .unwrap();
+        let table = FormsTable::open(&connection).await.unwrap();
+
+        let form = Form {
+            id: "es-comer--comi".to_string(),
+            lemma_id: "es-comer".to_string(),
+            surface: "comí".to_string(),
+            feats: "Mood=Ind|Tense=Past".to_string(),
+            // Stored keys are normalized (lowercase, canonicalized).
+            feats_key: "mood=ind|tense=past".to_string(),
+            status: STATUS_PRACTICING,
+            mastery: 60.0,
+            correct: 2,
+            incorrect: 1,
+            last_seen: Some("2024-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        };
+        table.upsert(&form).await.unwrap();
+
+        let stored = table.read_all().await.unwrap();
+        assert_eq!(stored.len(), 1);
+        let mut expected = form.clone();
+        expected.updated_at = stored[0].updated_at.clone();
+        assert_eq!(stored[0], expected);
+        // Upsert stamps updated_at.
+        assert!(stored[0].updated_at.is_some());
+
+        // Re-upsert replaces the row instead of duplicating it.
+        table.upsert(&form).await.unwrap();
+        assert_eq!(table.read_all().await.unwrap().len(), 1);
+
+        // Soft-delete hides the row; purge removes the tombstone.
+        table.delete_by_id("es-comer--comi").await.unwrap();
+        assert!(table.read_all().await.unwrap().is_empty());
+        table.purge_deleted("2999-01-01T00:00:00Z").await.unwrap();
+        table.upsert(&form).await.unwrap();
+        assert_eq!(table.read_all().await.unwrap().len(), 1);
+
+        table.reset().await.unwrap();
+        assert!(table.read_all().await.unwrap().is_empty());
+    }
+}

--- a/crates/db/src/lemmas.rs
+++ b/crates/db/src/lemmas.rs
@@ -1,0 +1,477 @@
+use std::sync::Arc;
+
+use arrow_array::{Array, Float64Array, Int32Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use futures_util::stream::TryStreamExt;
+use lancedb::Connection;
+use lancedb::database::CreateTableMode;
+use lancedb::query::{ExecutableQuery, QueryBase};
+
+use crate::util::eq_predicate;
+use open_course_core::curriculum::cefr_to_numeric;
+use open_course_core::error::Result;
+
+pub use open_course_core::vocabulary::*;
+
+pub const TABLE_NAME: &str = "lemmas";
+
+/// Mastery below which a lemma still counts as weak. Mirrors
+/// `core::session::MASTERY_THRESHOLD`; the constant is deliberately
+/// duplicated here to keep the db layer self-contained.
+const LEMMA_MASTERY_THRESHOLD: f64 = 50.0;
+
+pub(crate) fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("lemma", DataType::Utf8, false),
+        Field::new("pos", DataType::Utf8, false),
+        Field::new("target_lang", DataType::Utf8, false),
+        Field::new("native_lang", DataType::Utf8, false),
+        Field::new("translation", DataType::Utf8, false),
+        Field::new("status", DataType::Int32, false),
+        Field::new("mastery", DataType::Float64, false),
+        Field::new("last_seen", DataType::Utf8, true),
+        Field::new("practice_count", DataType::Int32, false),
+        Field::new("correct_uses", DataType::Int32, false),
+        Field::new("incorrect_uses", DataType::Int32, false),
+        Field::new("cefr_level", DataType::Utf8, true),
+        Field::new("cefr_source", DataType::Utf8, true),
+        Field::new("updated_at", DataType::Utf8, true),
+        Field::new("deleted_at", DataType::Utf8, true),
+    ]))
+}
+
+#[derive(Clone)]
+pub struct LemmasTable {
+    table: lancedb::Table,
+}
+
+impl LemmasTable {
+    pub async fn open(connection: &Connection) -> Result<Self> {
+        let table = connection
+            .create_empty_table(TABLE_NAME, schema())
+            .mode(CreateTableMode::exist_ok(|req| req))
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(Self { table })
+    }
+
+    /// Reads all non-deleted lemmas.
+    pub async fn read_all(&self) -> Result<Vec<Lemma>> {
+        let records = self
+            .table
+            .query()
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let mut all = Vec::new();
+        for batch in &records {
+            all.extend(lemmas_from_record_batch(batch)?);
+        }
+        all.retain(|l| l.deleted_at.is_none());
+        Ok(all)
+    }
+
+    /// Insert or replace a lemma, stamping `updated_at` with the current time.
+    pub async fn upsert(&self, lemma: &Lemma) -> Result<()> {
+        let mut lemma = lemma.clone();
+        lemma.updated_at = Some(crate::util::now_rfc3339());
+        self.upsert_with_timestamps(&lemma).await
+    }
+
+    /// Insert or replace a lemma exactly as given — used when applying
+    /// synced changes whose timestamps must be preserved.
+    pub async fn upsert_with_timestamps(&self, lemma: &Lemma) -> Result<()> {
+        self.table
+            .delete(&eq_predicate("id", &lemma.id))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let batch = lemma_to_record_batch(lemma)?;
+        self.table
+            .add(vec![batch])
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
+    /// Soft-delete: the row stays as a tombstone so sync can propagate the
+    /// deletion; reads filter it out.
+    pub async fn delete_by_id(&self, id: &str) -> Result<()> {
+        let records = self
+            .table
+            .query()
+            .only_if(eq_predicate("id", id))
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let now = crate::util::now_rfc3339();
+        let mut tombstoned = Vec::new();
+        for batch in &records {
+            for mut lemma in lemmas_from_record_batch(batch)? {
+                lemma.deleted_at = Some(now.clone());
+                tombstoned.push(lemma);
+            }
+        }
+        if tombstoned.is_empty() {
+            return Ok(());
+        }
+        self.table
+            .delete(&eq_predicate("id", id))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        for lemma in &tombstoned {
+            let batch = lemma_to_record_batch(lemma)?;
+            self.table
+                .add(vec![batch])
+                .execute()
+                .await
+                .map_err(crate::error::DbError::from)?;
+        }
+        Ok(())
+    }
+
+    /// Physically removes tombstones older than `older_than` (RFC3339).
+    /// Not called automatically.
+    pub async fn purge_deleted(&self, older_than: &str) -> Result<()> {
+        self.table
+            .delete(&format!(
+                "deleted_at IS NOT NULL AND deleted_at < '{}'",
+                crate::util::sql_escape(older_than)
+            ))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
+    pub async fn reset(&self) -> Result<()> {
+        self.table
+            .delete("id IS NOT NULL")
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
+    /// Return up to `n` weakest lemmas: lowest mastery first, then least
+    /// recently seen (never-seen first). Only lemmas still being learned
+    /// (status NEW or PRACTICING) with mastery below `LEMMA_MASTERY_THRESHOLD`
+    /// qualify, so the result may be shorter than `n` (no padding).
+    /// Function-word POS tags (ADP, DET, ...) are excluded via
+    /// `is_content_pos` — forced practice targets content words only.
+    ///
+    /// `frontier_cefr` (numeric level of the lowest unfinished curriculum
+    /// level, A1=1..C2=6) softly prioritizes level-appropriate vocabulary:
+    /// lemmas with a CEFR level more than one step above the frontier sort
+    /// after everything else but are never excluded. Lemmas without a level
+    /// (or when `frontier_cefr` is `None`) keep the plain weakness order.
+    pub fn weakest(lemmas: &[Lemma], n: usize, frontier_cefr: Option<i32>) -> Vec<Lemma> {
+        // 0 = at/just above the frontier or unknown level; 1 = further ahead.
+        let level_group = |l: &Lemma| match (frontier_cefr, l.cefr_level.as_deref()) {
+            (Some(frontier), Some(level)) => match cefr_to_numeric(level) {
+                Some(numeric) if numeric > frontier + 1 => 1,
+                _ => 0,
+            },
+            _ => 0,
+        };
+        let mut qualified: Vec<Lemma> = lemmas
+            .iter()
+            .filter(|l| {
+                (l.status == STATUS_NEW || l.status == STATUS_PRACTICING)
+                    && l.mastery < LEMMA_MASTERY_THRESHOLD
+                    && is_content_pos(&l.pos)
+            })
+            .cloned()
+            .collect();
+        qualified.sort_by(|a, b| {
+            let group_cmp = level_group(a).cmp(&level_group(b));
+            if group_cmp != std::cmp::Ordering::Equal {
+                return group_cmp;
+            }
+            let mastery_cmp = a
+                .mastery
+                .partial_cmp(&b.mastery)
+                .unwrap_or(std::cmp::Ordering::Equal);
+            if mastery_cmp != std::cmp::Ordering::Equal {
+                return mastery_cmp;
+            }
+            match (&a.last_seen, &b.last_seen) {
+                (None, Some(_)) => std::cmp::Ordering::Less,
+                (Some(_), None) => std::cmp::Ordering::Greater,
+                (Some(aa), Some(bb)) => aa.cmp(bb),
+                (None, None) => std::cmp::Ordering::Equal,
+            }
+        });
+        qualified.into_iter().take(n).collect()
+    }
+}
+
+pub(crate) fn lemma_to_record_batch(lemma: &Lemma) -> Result<RecordBatch> {
+    let batch = RecordBatch::try_new(
+        schema(),
+        vec![
+            Arc::new(StringArray::from(vec![lemma.id.as_str()])),
+            Arc::new(StringArray::from(vec![lemma.lemma.as_str()])),
+            Arc::new(StringArray::from(vec![lemma.pos.as_str()])),
+            Arc::new(StringArray::from(vec![lemma.target_lang.as_str()])),
+            Arc::new(StringArray::from(vec![lemma.native_lang.as_str()])),
+            Arc::new(StringArray::from(vec![lemma.translation.as_str()])),
+            Arc::new(Int32Array::from(vec![lemma.status])),
+            Arc::new(Float64Array::from(vec![lemma.mastery])),
+            Arc::new(StringArray::from(vec![lemma.last_seen.as_deref()])),
+            Arc::new(Int32Array::from(vec![lemma.practice_count])),
+            Arc::new(Int32Array::from(vec![lemma.correct_uses])),
+            Arc::new(Int32Array::from(vec![lemma.incorrect_uses])),
+            Arc::new(StringArray::from(vec![lemma.cefr_level.as_deref()])),
+            Arc::new(StringArray::from(vec![lemma.cefr_source.as_deref()])),
+            Arc::new(StringArray::from(vec![lemma.updated_at.as_deref()])),
+            Arc::new(StringArray::from(vec![lemma.deleted_at.as_deref()])),
+        ],
+    )
+    .map_err(crate::error::DbError::from)?;
+    Ok(batch)
+}
+
+pub(crate) fn lemmas_from_record_batch(batch: &RecordBatch) -> Result<Vec<Lemma>> {
+    let n = batch.num_rows();
+    let string_col = |name: &str| {
+        batch
+            .column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+    };
+    let int_col = |name: &str| {
+        batch
+            .column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+    };
+    let id_col = string_col("id");
+    let lemma_col = string_col("lemma");
+    let pos_col = string_col("pos");
+    let target_col = string_col("target_lang");
+    let native_col = string_col("native_lang");
+    let translation_col = string_col("translation");
+    let status_col = int_col("status");
+    let mastery_col = batch
+        .column_by_name("mastery")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    let last_seen_col = string_col("last_seen");
+    let practice_count_col = int_col("practice_count");
+    let correct_col = int_col("correct_uses");
+    let incorrect_col = int_col("incorrect_uses");
+    let updated_col = crate::util::optional_string_column(batch, "updated_at");
+    let deleted_col = crate::util::optional_string_column(batch, "deleted_at");
+    // Read tolerantly: dev databases created by intermediate builds may
+    // lack the CEFR columns.
+    let cefr_level_col = crate::util::optional_string_column(batch, "cefr_level");
+    let cefr_source_col = crate::util::optional_string_column(batch, "cefr_source");
+
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        out.push(Lemma {
+            id: id_col.value(i).to_string(),
+            lemma: lemma_col.value(i).to_string(),
+            pos: pos_col.value(i).to_string(),
+            target_lang: target_col.value(i).to_string(),
+            native_lang: native_col.value(i).to_string(),
+            translation: translation_col.value(i).to_string(),
+            status: status_col.value(i),
+            mastery: mastery_col.value(i),
+            last_seen: if last_seen_col.is_null(i) || last_seen_col.value(i).is_empty() {
+                None
+            } else {
+                Some(last_seen_col.value(i).to_string())
+            },
+            practice_count: practice_count_col.value(i),
+            correct_uses: correct_col.value(i),
+            incorrect_uses: incorrect_col.value(i),
+            cefr_level: crate::util::optional_string_at(cefr_level_col, i),
+            cefr_source: crate::util::optional_string_at(cefr_source_col, i),
+            updated_at: crate::util::optional_string_at(updated_col, i),
+            deleted_at: crate::util::optional_string_at(deleted_col, i),
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lancedb::connect;
+    use tempfile::TempDir;
+
+    fn make_lemma(
+        id: &str,
+        status: i32,
+        mastery: f64,
+        last_seen: Option<&str>,
+    ) -> Lemma {
+        Lemma {
+            id: id.to_string(),
+            lemma: id.to_string(),
+            pos: "VERB".to_string(),
+            target_lang: "es".to_string(),
+            native_lang: "ru".to_string(),
+            status,
+            mastery,
+            last_seen: last_seen.map(|s| s.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn weakest_skips_known_and_graduated_lemmas() {
+        let lemmas = vec![
+            make_lemma("a", STATUS_NEW, 30.0, None),
+            make_lemma("b", STATUS_PRACTICING, 50.0, None),
+            make_lemma("c", STATUS_KNOWN, 20.0, None),
+            make_lemma("d", STATUS_PRACTICING, 80.0, None),
+        ];
+        let weak = LemmasTable::weakest(&lemmas, 4, None);
+        assert_eq!(weak.len(), 1);
+        assert_eq!(weak[0].id, "a");
+    }
+
+    #[test]
+    fn weakest_does_not_pad_to_n() {
+        let lemmas = vec![
+            make_lemma("a", STATUS_NEW, 10.0, None),
+            make_lemma("b", STATUS_KNOWN, 90.0, None),
+        ];
+        let weak = LemmasTable::weakest(&lemmas, 5, None);
+        assert_eq!(weak.len(), 1);
+    }
+
+    #[test]
+    fn weakest_orders_by_mastery_then_recency() {
+        let lemmas = vec![
+            make_lemma("recent", STATUS_NEW, 40.0, Some("2024-01-10T00:00:00Z")),
+            make_lemma("never", STATUS_NEW, 40.0, None),
+            make_lemma("older", STATUS_PRACTICING, 40.0, Some("2024-01-01T00:00:00Z")),
+            make_lemma("weakest", STATUS_PRACTICING, 10.0, Some("2024-02-01T00:00:00Z")),
+        ];
+        let weak = LemmasTable::weakest(&lemmas, 4, None);
+        let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, ["weakest", "never", "older", "recent"]);
+    }
+
+    #[test]
+    fn weakest_defers_lemmas_far_above_frontier() {
+        let mut ahead = make_lemma("ahead", STATUS_PRACTICING, 10.0, None);
+        ahead.cefr_level = Some("C1".to_string());
+        let mut at_frontier = make_lemma("at-frontier", STATUS_NEW, 40.0, None);
+        at_frontier.cefr_level = Some("A2".to_string());
+        let mut one_above = make_lemma("one-above", STATUS_NEW, 40.0, None);
+        one_above.cefr_level = Some("B1".to_string());
+        let no_level = make_lemma("no-level", STATUS_NEW, 40.0, None);
+        let lemmas = vec![ahead, at_frontier, one_above, no_level];
+
+        // Frontier A2: the C1 lemma (more than one step up) sorts last but
+        // is still returned.
+        let weak = LemmasTable::weakest(&lemmas, 4, Some(2));
+        let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, ["at-frontier", "one-above", "no-level", "ahead"]);
+
+        // Deferred, not excluded: it is picked once the nearer lemmas no
+        // longer fill the quota.
+        let weak = LemmasTable::weakest(&lemmas, 3, Some(2));
+        let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, ["at-frontier", "one-above", "no-level"]);
+    }
+
+    #[test]
+    fn weakest_ignores_unparseable_cefr_levels() {
+        let mut bogus = make_lemma("bogus", STATUS_PRACTICING, 10.0, None);
+        bogus.cefr_level = Some("A0".to_string());
+        let plain = make_lemma("plain", STATUS_NEW, 40.0, None);
+        let lemmas = vec![bogus, plain];
+
+        // An unparseable level is treated as unknown: plain weakness order.
+        let weak = LemmasTable::weakest(&lemmas, 2, Some(1));
+        let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, ["bogus", "plain"]);
+    }
+
+    #[test]
+    fn weakest_skips_function_word_pos() {
+        let mut adp = make_lemma("adp", STATUS_NEW, 10.0, None);
+        adp.pos = "ADP".to_string();
+        let mut det = make_lemma("det", STATUS_PRACTICING, 20.0, None);
+        // POS matching is case-insensitive.
+        det.pos = "det".to_string();
+        let noun = make_lemma("noun", STATUS_PRACTICING, 30.0, None);
+        // Empty and unrecognized POS tags stay candidates (lazy inclusion).
+        let mut no_pos = make_lemma("no-pos", STATUS_NEW, 40.0, None);
+        no_pos.pos = String::new();
+        let lemmas = vec![adp, det, noun, no_pos];
+
+        let weak = LemmasTable::weakest(&lemmas, 4, None);
+        let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, ["noun", "no-pos"]);
+    }
+
+    #[tokio::test]
+    async fn upsert_read_delete_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let connection = connect(&dir.path().join("db").to_string_lossy())
+            .execute()
+            .await
+            .unwrap();
+        let table = LemmasTable::open(&connection).await.unwrap();
+
+        let lemma = Lemma {
+            id: "es-comer".to_string(),
+            lemma: "comer".to_string(),
+            pos: "VERB".to_string(),
+            target_lang: "es".to_string(),
+            native_lang: "ru".to_string(),
+            translation: "есть".to_string(),
+            status: STATUS_PRACTICING,
+            mastery: 55.0,
+            last_seen: Some("2024-01-01T00:00:00Z".to_string()),
+            practice_count: 3,
+            correct_uses: 2,
+            incorrect_uses: 1,
+            cefr_level: Some("B1".to_string()),
+            cefr_source: Some("topic".to_string()),
+            ..Default::default()
+        };
+        table.upsert(&lemma).await.unwrap();
+
+        let stored = table.read_all().await.unwrap();
+        assert_eq!(stored.len(), 1);
+        let mut expected = lemma.clone();
+        expected.updated_at = stored[0].updated_at.clone();
+        assert_eq!(stored[0], expected);
+        // Upsert stamps updated_at.
+        assert!(stored[0].updated_at.is_some());
+
+        // Re-upsert replaces the row instead of duplicating it.
+        table.upsert(&lemma).await.unwrap();
+        assert_eq!(table.read_all().await.unwrap().len(), 1);
+
+        // Soft-delete hides the row; purge removes the tombstone.
+        table.delete_by_id("es-comer").await.unwrap();
+        assert!(table.read_all().await.unwrap().is_empty());
+        table.purge_deleted("2999-01-01T00:00:00Z").await.unwrap();
+        table.upsert(&lemma).await.unwrap();
+        assert_eq!(table.read_all().await.unwrap().len(), 1);
+
+        table.reset().await.unwrap();
+        assert!(table.read_all().await.unwrap().is_empty());
+    }
+}

--- a/crates/db/src/lemmas.rs
+++ b/crates/db/src/lemmas.rs
@@ -314,12 +314,7 @@ mod tests {
     use lancedb::connect;
     use tempfile::TempDir;
 
-    fn make_lemma(
-        id: &str,
-        status: i32,
-        mastery: f64,
-        last_seen: Option<&str>,
-    ) -> Lemma {
+    fn make_lemma(id: &str, status: i32, mastery: f64, last_seen: Option<&str>) -> Lemma {
         Lemma {
             id: id.to_string(),
             lemma: id.to_string(),
@@ -361,8 +356,18 @@ mod tests {
         let lemmas = vec![
             make_lemma("recent", STATUS_NEW, 40.0, Some("2024-01-10T00:00:00Z")),
             make_lemma("never", STATUS_NEW, 40.0, None),
-            make_lemma("older", STATUS_PRACTICING, 40.0, Some("2024-01-01T00:00:00Z")),
-            make_lemma("weakest", STATUS_PRACTICING, 10.0, Some("2024-02-01T00:00:00Z")),
+            make_lemma(
+                "older",
+                STATUS_PRACTICING,
+                40.0,
+                Some("2024-01-01T00:00:00Z"),
+            ),
+            make_lemma(
+                "weakest",
+                STATUS_PRACTICING,
+                10.0,
+                Some("2024-02-01T00:00:00Z"),
+            ),
         ];
         let weak = LemmasTable::weakest(&lemmas, 4, None);
         let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,8 +1,10 @@
 use lancedb::connect;
 
 use crate::curriculum::{CurriculumTable, TABLE_NAME as CURRICULUM_TABLE};
+use crate::forms::FormsTable;
 use crate::history::HistoryTable;
 use crate::learning_items::LearningItemsTable;
+use crate::lemmas::LemmasTable;
 use crate::metadata::MetadataTable;
 use crate::outbox::OutboxTable;
 use crate::progress::ProgressTable;
@@ -12,8 +14,10 @@ use open_course_core::error::Result;
 pub mod apply;
 pub mod curriculum;
 pub mod error;
+pub mod forms;
 pub mod history;
 pub mod learning_items;
+pub mod lemmas;
 pub mod metadata;
 pub mod migrations;
 pub mod outbox;
@@ -28,6 +32,8 @@ pub struct Database {
     history: HistoryTable,
     reviews: ReviewsTable,
     learning_items: LearningItemsTable,
+    lemmas: LemmasTable,
+    forms: FormsTable,
     metadata: MetadataTable,
     outbox: OutboxTable,
 }
@@ -49,6 +55,8 @@ impl Database {
         let history = HistoryTable::open(&connection).await?;
         let reviews = ReviewsTable::open(&connection).await?;
         let learning_items = LearningItemsTable::open(&connection).await?;
+        let lemmas = LemmasTable::open(&connection).await?;
+        let forms = FormsTable::open(&connection).await?;
         let outbox = OutboxTable::open(&connection).await?;
         Ok(Self {
             curriculum,
@@ -56,6 +64,8 @@ impl Database {
             history,
             reviews,
             learning_items,
+            lemmas,
+            forms,
             metadata,
             outbox,
         })
@@ -89,6 +99,14 @@ impl Database {
 
     pub fn learning_items(&self) -> LearningItemsTable {
         self.learning_items.clone()
+    }
+
+    pub fn lemmas(&self) -> LemmasTable {
+        self.lemmas.clone()
+    }
+
+    pub fn forms(&self) -> FormsTable {
+        self.forms.clone()
     }
 
     pub fn metadata(&self) -> MetadataTable {

--- a/crates/db/src/migrations.rs
+++ b/crates/db/src/migrations.rs
@@ -18,7 +18,7 @@ use crate::metadata::MetadataTable;
 use open_course_core::error::Result;
 
 /// The schema version this build migrates to.
-pub const CURRENT_SCHEMA_VERSION: i32 = 4;
+pub const CURRENT_SCHEMA_VERSION: i32 = 5;
 
 type MigrationFn = fn(&Connection) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
 
@@ -28,6 +28,7 @@ const MIGRATIONS: &[(i32, MigrationFn)] = &[
     (2, |c| Box::pin(migrate_v2_timestamps(c))),
     (3, |c| Box::pin(migrate_v3_session_uuids(c))),
     (4, |c| Box::pin(migrate_v4_outbox(c))),
+    (5, |c| Box::pin(migrate_v5_vocabulary(c))),
 ];
 
 /// Brings the database at `connection` up to `CURRENT_SCHEMA_VERSION`.
@@ -237,6 +238,25 @@ async fn migrate_v4_outbox(connection: &Connection) -> Result<()> {
     if !table_exists(connection, crate::outbox::TABLE_NAME).await {
         connection
             .create_empty_table(crate::outbox::TABLE_NAME, crate::outbox::schema())
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+    }
+    Ok(())
+}
+
+/// v5: the vocabulary tables (lemmas and their inflected forms).
+async fn migrate_v5_vocabulary(connection: &Connection) -> Result<()> {
+    if !table_exists(connection, crate::lemmas::TABLE_NAME).await {
+        connection
+            .create_empty_table(crate::lemmas::TABLE_NAME, crate::lemmas::schema())
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+    }
+    if !table_exists(connection, crate::forms::TABLE_NAME).await {
+        connection
+            .create_empty_table(crate::forms::TABLE_NAME, crate::forms::schema())
             .execute()
             .await
             .map_err(crate::error::DbError::from)?;
@@ -470,6 +490,10 @@ mod tests {
         );
         assert_eq!(db.outbox().len().await.unwrap(), 0);
 
+        // v5 vocabulary tables exist and are empty.
+        assert!(db.lemmas().read_all().await.unwrap().is_empty());
+        assert!(db.forms().read_all().await.unwrap().is_empty());
+
         // Reconnecting is a no-op (migrations are not re-applied destructively).
         let db = Database::connect(&path).await.unwrap();
         let curriculum = db.curriculum().read_all().await.unwrap();
@@ -488,6 +512,8 @@ mod tests {
         );
         assert!(db.curriculum().read_all().await.unwrap().topics.is_empty());
         assert_eq!(db.outbox().len().await.unwrap(), 0);
+        assert!(db.lemmas().read_all().await.unwrap().is_empty());
+        assert!(db.forms().read_all().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/db/src/outbox.rs
+++ b/crates/db/src/outbox.rs
@@ -23,6 +23,8 @@ pub const ENTITY_TOPIC: &str = "topic";
 pub const ENTITY_PROGRESS: &str = "progress";
 pub const ENTITY_SESSION: &str = "session";
 pub const ENTITY_LEARNING_ITEM: &str = "learning_item";
+pub const ENTITY_LEMMA: &str = "lemma";
+pub const ENTITY_FORM: &str = "form";
 pub const ENTITY_METADATA: &str = "metadata";
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/llm/src/analysis.rs
+++ b/crates/llm/src/analysis.rs
@@ -88,6 +88,12 @@ pub async fn finalize_analysis_with_new_topics(
             if error.error_type == open_course_core::session::GrammarErrorType::Spelling {
                 continue;
             }
+            // Single-word errors are owned by vocabulary evidence: the
+            // failed use already scores the lemma/form, so their new topics
+            // must not also become learning items or curriculum topics.
+            if open_course_core::vocabulary::vocabulary_owns_error(sentence, error) {
+                continue;
+            }
             for new_topic in &error.new_topics {
                 if is_abstract_topic_name(&new_topic.name) {
                     log_debug_event(
@@ -234,4 +240,146 @@ pub async fn generate_topic_metadata(
     normalize_topic_defaults(&mut topic, profile);
 
     Ok(topic)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::streaming::LlmStream;
+    use async_trait::async_trait;
+    use open_course_core::session::{
+        GrammarError, GrammarErrorType, NewTopicRef, SentenceAnalysis, VocabularyUse,
+    };
+
+    /// Any LLM call fails the test: these cases must be resolved locally.
+    struct NoopClient;
+
+    #[async_trait]
+    impl LlmClient for NoopClient {
+        async fn prompt(&self, _: &str, _: Option<&str>, _: u32) -> Result<String> {
+            panic!("no LLM call expected");
+        }
+
+        async fn stream_prompt(&self, _: &str, _: Option<&str>, _: u32) -> Result<LlmStream> {
+            panic!("no LLM call expected");
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn profile() -> UserProfile {
+        UserProfile {
+            native_language: "ru".to_string(),
+            target_language: "es".to_string(),
+            age: None,
+            self_assessed_cefr: None,
+        }
+    }
+
+    fn analysis_with(error: GrammarError, used_vocabulary: Vec<VocabularyUse>) -> AnalysisResult {
+        AnalysisResult {
+            session_score: Some(50.0),
+            sentences: vec![SentenceAnalysis {
+                sentence_number: 1,
+                student_translation: "el pequeño casa".to_string(),
+                expected_translation: "la casa pequeña".to_string(),
+                acceptable_translations: vec![],
+                semantic_verdict: open_course_core::session::SemanticVerdict::NeedsCorrection,
+                errors: vec![error],
+                per_sentence_feedback: vec![],
+                used_vocabulary,
+            }],
+            evaluated_topics: vec![],
+            new_topics: vec![],
+            new_learning_items: vec![],
+            new_lemmas: vec![],
+            new_forms: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn vocabulary_owned_error_spawns_no_learning_item() {
+        // The error boils down to the single failed word "pequeño": the
+        // vocabulary system owns it, so its new topic is dropped entirely.
+        let error = GrammarError {
+            error_type: GrammarErrorType::Major,
+            pattern: "pequeño instead of pequeña".to_string(),
+            explanation: "gender agreement of pequeño".to_string(),
+            topic_ids: vec![],
+            new_topics: vec![NewTopicRef {
+                name: "Adjective: Pequeño vs Pequeña".to_string(),
+                description: "gender of pequeño".to_string(),
+                level: None,
+            }],
+        };
+        let failed_use = VocabularyUse {
+            surface: "pequeño".to_string(),
+            lemma: "pequeño".to_string(),
+            pos: "ADJ".to_string(),
+            side: "student".to_string(),
+            usage_ok: Some(false),
+            ..Default::default()
+        };
+        let analysis = analysis_with(error, vec![failed_use]);
+
+        let result = finalize_analysis_with_new_topics(
+            &NoopClient,
+            &profile(),
+            &[],
+            analysis,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.new_learning_items.is_empty());
+        assert!(result.new_topics.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unowned_error_still_creates_learning_item() {
+        // No failed vocabulary use overlaps the error words: the new topic
+        // survives and becomes a learning item without any LLM call.
+        let error = GrammarError {
+            error_type: GrammarErrorType::Major,
+            pattern: "caro where rico was meant".to_string(),
+            explanation: "confused caro with rico".to_string(),
+            topic_ids: vec![],
+            new_topics: vec![NewTopicRef {
+                name: "Adjective: Caro vs Rico".to_string(),
+                description: "expensive vs tasty".to_string(),
+                level: None,
+            }],
+        };
+        let unrelated_use = VocabularyUse {
+            surface: "casa".to_string(),
+            lemma: "casa".to_string(),
+            pos: "NOUN".to_string(),
+            side: "student".to_string(),
+            usage_ok: Some(false),
+            ..Default::default()
+        };
+        let analysis = analysis_with(error, vec![unrelated_use]);
+
+        let result = finalize_analysis_with_new_topics(
+            &NoopClient,
+            &profile(),
+            &[],
+            analysis,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.new_learning_items.len(), 1);
+        assert_eq!(
+            result.new_learning_items[0].name,
+            "Adjective: Caro vs Rico"
+        );
+        assert!(result.new_topics.is_empty());
+    }
 }

--- a/crates/llm/src/analysis.rs
+++ b/crates/llm/src/analysis.rs
@@ -324,16 +324,10 @@ mod tests {
         };
         let analysis = analysis_with(error, vec![failed_use]);
 
-        let result = finalize_analysis_with_new_topics(
-            &NoopClient,
-            &profile(),
-            &[],
-            analysis,
-            None,
-            None,
-        )
-        .await
-        .unwrap();
+        let result =
+            finalize_analysis_with_new_topics(&NoopClient, &profile(), &[], analysis, None, None)
+                .await
+                .unwrap();
 
         assert!(result.new_learning_items.is_empty());
         assert!(result.new_topics.is_empty());
@@ -364,22 +358,13 @@ mod tests {
         };
         let analysis = analysis_with(error, vec![unrelated_use]);
 
-        let result = finalize_analysis_with_new_topics(
-            &NoopClient,
-            &profile(),
-            &[],
-            analysis,
-            None,
-            None,
-        )
-        .await
-        .unwrap();
+        let result =
+            finalize_analysis_with_new_topics(&NoopClient, &profile(), &[], analysis, None, None)
+                .await
+                .unwrap();
 
         assert_eq!(result.new_learning_items.len(), 1);
-        assert_eq!(
-            result.new_learning_items[0].name,
-            "Adjective: Caro vs Rico"
-        );
+        assert_eq!(result.new_learning_items[0].name, "Adjective: Caro vs Rico");
         assert!(result.new_topics.is_empty());
     }
 }

--- a/crates/llm/src/diagnostics.rs
+++ b/crates/llm/src/diagnostics.rs
@@ -294,7 +294,7 @@ async fn run_exercises_check(client: Arc<dyn LlmClient>, profile: &UserProfile) 
     let wrapper = DiagnosticLlmClient::from_arc(client);
     let start = Instant::now();
     let topics = synthetic_topics(profile);
-    let prompt = build_exercise_prompt(profile, &topics[..1], &topics[1..], &topics, &[], 1, 0.75);
+    let prompt = build_exercise_prompt(profile, &topics[..1], &topics[1..], &topics, &[], &[], 1, 0.75);
     let status = match timeout(
         EXERCISES_TIMEOUT,
         generate_exercises(&wrapper, &prompt, None, None::<&Path>),

--- a/crates/llm/src/diagnostics.rs
+++ b/crates/llm/src/diagnostics.rs
@@ -294,7 +294,16 @@ async fn run_exercises_check(client: Arc<dyn LlmClient>, profile: &UserProfile) 
     let wrapper = DiagnosticLlmClient::from_arc(client);
     let start = Instant::now();
     let topics = synthetic_topics(profile);
-    let prompt = build_exercise_prompt(profile, &topics[..1], &topics[1..], &topics, &[], &[], 1, 0.75);
+    let prompt = build_exercise_prompt(
+        profile,
+        &topics[..1],
+        &topics[1..],
+        &topics,
+        &[],
+        &[],
+        1,
+        0.75,
+    );
     let status = match timeout(
         EXERCISES_TIMEOUT,
         generate_exercises(&wrapper, &prompt, None, None::<&Path>),

--- a/crates/service/src/reset.rs
+++ b/crates/service/src/reset.rs
@@ -58,6 +58,11 @@ pub async fn execute_reset(db: &Database, action: ResetAction) -> Result<()> {
             db.curriculum().reset().await?;
             db.reviews().reset().await?;
             db.learning_items().reset().await?;
+            db.lemmas().reset().await?;
+            db.forms().reset().await?;
+            // TODO: also emit tombstoneReset for lemma/form once old clients
+            // are updated — their sync engine wipes all data on a tombstone
+            // for an unknown entity.
             for entity in [
                 ENTITY_PROGRESS,
                 ENTITY_SESSION,

--- a/crates/service/src/session.rs
+++ b/crates/service/src/session.rs
@@ -327,8 +327,7 @@ async fn outbox_after_apply(
     touched_form_ids: &[String],
 ) {
     use open_course_db::outbox::{
-        ENTITY_FORM, ENTITY_LEARNING_ITEM, ENTITY_LEMMA, ENTITY_PROGRESS, ENTITY_SESSION,
-        OP_UPSERT,
+        ENTITY_FORM, ENTITY_LEARNING_ITEM, ENTITY_LEMMA, ENTITY_PROGRESS, ENTITY_SESSION, OP_UPSERT,
     };
 
     if let Ok(history) = db.history().read_all().await
@@ -413,7 +412,8 @@ fn frontier_cefr(topics: &[Topic], progress: &ProgressData) -> Option<i32> {
         .min()
 }
 
-fn user_cefr_numeric(config: &OpenCourseConfig) -> i32 {    cefr_to_numeric(
+fn user_cefr_numeric(config: &OpenCourseConfig) -> i32 {
+    cefr_to_numeric(
         config
             .active_profile()
             .self_assessed_cefr

--- a/crates/service/src/session.rs
+++ b/crates/service/src/session.rs
@@ -11,14 +11,16 @@ use tokio::sync::mpsc;
 use open_course_config::OpenCourseConfig;
 use open_course_core::error::{AppError, Result};
 use open_course_core::session::{
-    AnalysisResult, Exercise, MentorSession, NextSessionTopic, pick_next_session_topic,
-    recent_success_rate, select_side_topics, unique_topic_ids,
+    AnalysisResult, COMPLETED_THRESHOLD, Exercise, MentorSession, NextSessionTopic,
+    pick_next_session_topic, recent_success_rate, select_side_topics, unique_topic_ids,
 };
+use open_course_core::vocabulary::Lemma;
 use open_course_db::Database;
 use open_course_db::apply::apply_analysis_to_db;
 use open_course_db::curriculum::{Topic, cefr_to_numeric};
 use open_course_db::learning_items::{LearningItem, LearningItemsTable, is_learning_item_name};
-use open_course_db::progress::{ProgressTopic, initial_topic_score};
+use open_course_db::lemmas::LemmasTable;
+use open_course_db::progress::{ProgressData, ProgressTopic, initial_topic_score};
 use open_course_llm::factory::create_llm_model;
 use open_course_llm::pipeline::{
     finalize_analysis_with_new_topics, generate_analysis, generate_exercises,
@@ -34,6 +36,7 @@ use crate::outbox_append;
 pub struct ExercisePreparation {
     pub prompt: String,
     pub forced_learning_item_ids: Vec<String>,
+    pub forced_lemma_ids: Vec<String>,
 }
 
 /// Reads progress, learning items and history from the database, picks side
@@ -85,6 +88,22 @@ pub async fn prepare_exercises(
         .map(|li| li.id.clone())
         .collect();
 
+    let lemmas: Vec<Lemma> = db
+        .lemmas()
+        .read_all()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|l| l.target_lang == profile.target_language)
+        .collect();
+    // Soft vocabulary frontier: the lowest CEFR level that still has
+    // unmastered topics (the same notion as the frontier gate in
+    // core::session::topic_selection, which has no public helper). `None`
+    // when no level information is available.
+    let frontier_cefr = frontier_cefr(all_topics, &progress);
+    let forced_vocabulary = LemmasTable::weakest(&lemmas, 5, frontier_cefr);
+    let forced_lemma_ids = forced_vocabulary.iter().map(|l| l.id.clone()).collect();
+
     let history = db.history().read_all().await.unwrap_or_default();
     let success_rate = recent_success_rate(&history, 5);
 
@@ -94,6 +113,7 @@ pub async fn prepare_exercises(
         &side_topics,
         &candidate_topics,
         &forced_learning_items,
+        &forced_vocabulary,
         config.preferences.batch_size,
         success_rate,
     );
@@ -101,6 +121,7 @@ pub async fn prepare_exercises(
     Ok(ExercisePreparation {
         prompt,
         forced_learning_item_ids,
+        forced_lemma_ids,
     })
 }
 
@@ -243,8 +264,9 @@ pub async fn apply_analysis(
     db: &Database,
     config: Option<&OpenCourseConfig>,
     session: &MentorSession,
-    analysis: &AnalysisResult,
+    analysis: &mut AnalysisResult,
     forced_learning_item_ids: &[String],
+    forced_lemma_ids: &[String],
     data_dir: &Path,
 ) -> Result<AppliedAnalysis> {
     if let Some(config) = config {
@@ -265,9 +287,25 @@ pub async fn apply_analysis(
         })
         .unwrap_or_default();
 
-    let scores = apply_analysis_to_db(analysis, session, forced_learning_item_ids, db).await?;
+    let (scores, touched_lemma_ids, touched_form_ids) = apply_analysis_to_db(
+        analysis,
+        session,
+        forced_learning_item_ids,
+        forced_lemma_ids,
+        db,
+    )
+    .await?;
 
-    outbox_after_apply(db, session, analysis, &scores, forced_learning_item_ids).await;
+    outbox_after_apply(
+        db,
+        session,
+        analysis,
+        &scores,
+        forced_learning_item_ids,
+        &touched_lemma_ids,
+        &touched_form_ids,
+    )
+    .await;
 
     Ok(AppliedAnalysis {
         previous_scores,
@@ -276,17 +314,21 @@ pub async fn apply_analysis(
 }
 
 /// Best-effort outbox entries for everything the session wrote: the session
-/// summary, the progress entries it touched, and the practiced learning
-/// items.
+/// summary, the progress entries it touched, the practiced learning items,
+/// and every lemma/form the apply step reports as touched (created,
+/// practiced, or CEFR-updated).
 async fn outbox_after_apply(
     db: &Database,
     session: &MentorSession,
     analysis: &AnalysisResult,
     scores: &HashMap<String, f64>,
     forced_learning_item_ids: &[String],
+    touched_lemma_ids: &[String],
+    touched_form_ids: &[String],
 ) {
     use open_course_db::outbox::{
-        ENTITY_LEARNING_ITEM, ENTITY_PROGRESS, ENTITY_SESSION, OP_UPSERT,
+        ENTITY_FORM, ENTITY_LEARNING_ITEM, ENTITY_LEMMA, ENTITY_PROGRESS, ENTITY_SESSION,
+        OP_UPSERT,
     };
 
     if let Ok(history) = db.history().read_all().await
@@ -322,10 +364,56 @@ async fn outbox_after_apply(
             }
         }
     }
+
+    if !touched_lemma_ids.is_empty()
+        && let Ok(lemmas) = db.lemmas().read_all().await
+    {
+        let touched: HashSet<&str> = touched_lemma_ids.iter().map(String::as_str).collect();
+        for lemma in &lemmas {
+            if touched.contains(lemma.id.as_str())
+                && let Ok(payload) = serde_json::to_string(lemma)
+            {
+                outbox_append(db, OP_UPSERT, ENTITY_LEMMA, &lemma.id, &payload).await;
+            }
+        }
+    }
+
+    if !touched_form_ids.is_empty()
+        && let Ok(forms) = db.forms().read_all().await
+    {
+        let touched: HashSet<&str> = touched_form_ids.iter().map(String::as_str).collect();
+        for form in &forms {
+            if touched.contains(form.id.as_str())
+                && let Ok(payload) = serde_json::to_string(form)
+            {
+                outbox_append(db, OP_UPSERT, ENTITY_FORM, &form.id, &payload).await;
+            }
+        }
+    }
 }
 
-fn user_cefr_numeric(config: &OpenCourseConfig) -> i32 {
-    cefr_to_numeric(
+/// Numeric CEFR (A1=1..C2=6) of the lowest curriculum level that still has
+/// unmastered topics (mastery below `COMPLETED_THRESHOLD`; topics without a
+/// progress record count as unmastered). `None` when no unfinished topic
+/// carries level information.
+fn frontier_cefr(topics: &[Topic], progress: &ProgressData) -> Option<i32> {
+    let mastery_of = |topic_id: &str| -> f64 {
+        progress
+            .topics
+            .iter()
+            .find(|t| t.topic_id == topic_id)
+            .map(|t| t.mastery)
+            .unwrap_or(0.0)
+    };
+    topics
+        .iter()
+        .filter(|t| mastery_of(&t.id) < COMPLETED_THRESHOLD)
+        .map(|t| t.cefr_numeric())
+        .filter(|n| *n > 0)
+        .min()
+}
+
+fn user_cefr_numeric(config: &OpenCourseConfig) -> i32 {    cefr_to_numeric(
         config
             .active_profile()
             .self_assessed_cefr

--- a/crates/sync/src/bind.rs
+++ b/crates/sync/src/bind.rs
@@ -9,7 +9,8 @@ use std::collections::HashSet;
 
 use open_course_db::Database;
 use open_course_db::outbox::{
-    ENTITY_LEARNING_ITEM, ENTITY_PROGRESS, ENTITY_SESSION, ENTITY_TOPIC, OP_UPSERT,
+    ENTITY_FORM, ENTITY_LEARNING_ITEM, ENTITY_LEMMA, ENTITY_PROGRESS, ENTITY_SESSION, ENTITY_TOPIC,
+    OP_UPSERT,
 };
 
 /// Enqueues every local row as an upsert: the first upload of a pair whose
@@ -41,6 +42,18 @@ pub async fn backfill_outbox(db: &Database, include_topics: bool) -> Result<(), 
         let payload = serde_json::to_string(item)?;
         db.outbox()
             .append(OP_UPSERT, ENTITY_LEARNING_ITEM, &item.id, &payload)
+            .await?;
+    }
+    for lemma in &db.lemmas().read_all().await? {
+        let payload = serde_json::to_string(lemma)?;
+        db.outbox()
+            .append(OP_UPSERT, ENTITY_LEMMA, &lemma.id, &payload)
+            .await?;
+    }
+    for form in &db.forms().read_all().await? {
+        let payload = serde_json::to_string(form)?;
+        db.outbox()
+            .append(OP_UPSERT, ENTITY_FORM, &form.id, &payload)
             .await?;
     }
     Ok(())

--- a/crates/sync/src/engine.rs
+++ b/crates/sync/src/engine.rs
@@ -8,8 +8,8 @@ use crate::client::{SyncClient, check_status};
 use crate::error::{PushError, SyncError};
 use crate::protocol::{
     Change, ConflictBody, PullResponse, PushRequest, PushResponse, entity_is_form,
-    entity_is_learning_item, entity_is_lemma, entity_to_wire, op_is_delete,
-    op_is_tombstone_reset, op_is_upsert, op_to_wire,
+    entity_is_learning_item, entity_is_lemma, entity_to_wire, op_is_delete, op_is_tombstone_reset,
+    op_is_upsert, op_to_wire,
 };
 
 /// How far past the current time a local `updated_at` may be before it is
@@ -317,12 +317,8 @@ async fn apply_delete(db: &Database, change: &Change) -> Result<(), SyncError> {
         entity if entity_is_learning_item(entity) => {
             db.learning_items().delete_by_id(&change.entity_id).await?
         }
-        entity if entity_is_lemma(entity) => {
-            db.lemmas().delete_by_id(&change.entity_id).await?
-        }
-        entity if entity_is_form(entity) => {
-            db.forms().delete_by_id(&change.entity_id).await?
-        }
+        entity if entity_is_lemma(entity) => db.lemmas().delete_by_id(&change.entity_id).await?,
+        entity if entity_is_form(entity) => db.forms().delete_by_id(&change.entity_id).await?,
         // Sessions are append-only and never deleted; metadata keys have no
         // delete operation.
         _ => {}

--- a/crates/sync/src/engine.rs
+++ b/crates/sync/src/engine.rs
@@ -7,8 +7,9 @@ use open_course_db::outbox::OutboxEntry;
 use crate::client::{SyncClient, check_status};
 use crate::error::{PushError, SyncError};
 use crate::protocol::{
-    Change, ConflictBody, PullResponse, PushRequest, PushResponse, entity_is_learning_item,
-    entity_to_wire, op_is_delete, op_is_tombstone_reset, op_is_upsert, op_to_wire,
+    Change, ConflictBody, PullResponse, PushRequest, PushResponse, entity_is_form,
+    entity_is_learning_item, entity_is_lemma, entity_to_wire, op_is_delete,
+    op_is_tombstone_reset, op_is_upsert, op_to_wire,
 };
 
 /// How far past the current time a local `updated_at` may be before it is
@@ -160,6 +161,8 @@ async fn reset_all(db: &Database) -> Result<(), SyncError> {
     db.progress().reset().await?;
     db.history().reset().await?;
     db.learning_items().reset().await?;
+    db.lemmas().reset().await?;
+    db.forms().reset().await?;
     Ok(())
 }
 
@@ -254,6 +257,34 @@ async fn apply_upsert(db: &Database, change: &Change) -> Result<(), SyncError> {
                     .await?;
             }
         }
+        entity if entity_is_lemma(entity) => {
+            let incoming: open_course_core::vocabulary::Lemma =
+                serde_json::from_value(payload.clone())?;
+            let local = db
+                .lemmas()
+                .read_all()
+                .await?
+                .into_iter()
+                .find(|l| l.id == change.entity_id);
+            let local_updated = local.as_ref().and_then(|l| l.updated_at.as_deref());
+            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
+                db.lemmas().upsert_with_timestamps(&incoming).await?;
+            }
+        }
+        entity if entity_is_form(entity) => {
+            let incoming: open_course_core::vocabulary::Form =
+                serde_json::from_value(payload.clone())?;
+            let local = db
+                .forms()
+                .read_all()
+                .await?
+                .into_iter()
+                .find(|f| f.id == change.entity_id);
+            let local_updated = local.as_ref().and_then(|f| f.updated_at.as_deref());
+            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
+                db.forms().upsert_with_timestamps(&incoming).await?;
+            }
+        }
         "metadata" => {
             // Metadata payload shape: { "key": ..., "value": ... }.
             let key = payload
@@ -266,8 +297,10 @@ async fn apply_upsert(db: &Database, change: &Change) -> Result<(), SyncError> {
                 .unwrap_or_default();
             db.metadata().set(key, value).await?;
         }
-        other => {
-            return Err(SyncError::Protocol(format!("unknown entity: {other}")));
+        _ => {
+            // Forward compatibility: an entity introduced by a newer client
+            // is skipped instead of failing the whole pull, so one unknown
+            // entity cannot wedge sync forever (the cursor still advances).
         }
     }
     Ok(())
@@ -283,6 +316,12 @@ async fn apply_delete(db: &Database, change: &Change) -> Result<(), SyncError> {
         "progress" => db.progress().delete_by_topic_id(&change.entity_id).await?,
         entity if entity_is_learning_item(entity) => {
             db.learning_items().delete_by_id(&change.entity_id).await?
+        }
+        entity if entity_is_lemma(entity) => {
+            db.lemmas().delete_by_id(&change.entity_id).await?
+        }
+        entity if entity_is_form(entity) => {
+            db.forms().delete_by_id(&change.entity_id).await?
         }
         // Sessions are append-only and never deleted; metadata keys have no
         // delete operation.
@@ -301,9 +340,15 @@ async fn apply_tombstone_reset(db: &Database, change: &Change) -> Result<(), Syn
         "progress" => db.progress().reset().await?,
         "session" => db.history().reset().await?,
         entity if entity_is_learning_item(entity) => db.learning_items().reset().await?,
-        // A reset of everything else (or an explicit "*" entity) wipes all
-        // synced tables.
-        _ => reset_all(db).await?,
+        entity if entity_is_lemma(entity) => db.lemmas().reset().await?,
+        entity if entity_is_form(entity) => db.forms().reset().await?,
+        // An explicit "*" entity still wipes all synced tables.
+        "*" => reset_all(db).await?,
+        // Forward compatibility: a tombstone reset for an entity this client
+        // does not know is a no-op — resetting everything here would wipe
+        // unrelated local data on every new entity rollout. The reset
+        // marker is not recorded either: nothing was actually reset.
+        _ => return Ok(()),
     }
     db.metadata()
         .set(open_course_db::metadata::KEY_RESET_AT, &reset_at)

--- a/crates/sync/tests/contract.rs
+++ b/crates/sync/tests/contract.rs
@@ -1352,7 +1352,6 @@ async fn backfill_is_safe_to_repeat() {
     );
 }
 
-
 // ---------------------------------------------------------------------------
 // Vocabulary: lemma and form sync (single-word entities, no wire mapping)
 // ---------------------------------------------------------------------------
@@ -1395,7 +1394,11 @@ async fn pull_applies_lemma_and_form_upserts_with_lww() {
         .await
         .unwrap();
     let stale_lemma = lemma("es-hablar", 10.0, Some("2025-01-01T00:00:00Z"));
-    let new_form = form("es-hablar--hablo", "es-hablar", Some("2025-01-01T00:00:00Z"));
+    let new_form = form(
+        "es-hablar--hablo",
+        "es-hablar",
+        Some("2025-01-01T00:00:00Z"),
+    );
     seed_changes(
         &state,
         vec![
@@ -1430,10 +1433,7 @@ async fn pull_applies_lemma_and_form_upserts_with_lww() {
     let forms = db.forms().read_all().await.unwrap();
     assert_eq!(forms.len(), 1);
     assert_eq!(forms[0].surface, "hablo");
-    assert_eq!(
-        forms[0].updated_at.as_deref(),
-        Some("2025-01-01T00:00:00Z")
-    );
+    assert_eq!(forms[0].updated_at.as_deref(), Some("2025-01-01T00:00:00Z"));
 }
 
 #[tokio::test]
@@ -1598,8 +1598,7 @@ async fn roundtrip_lemma_between_two_clients() {
         .into_iter()
         .find(|l| l.id == "es-hablar")
         .unwrap();
-    db_a
-        .outbox()
+    db_a.outbox()
         .append(
             OP_UPSERT,
             ENTITY_LEMMA,

--- a/crates/sync/tests/contract.rs
+++ b/crates/sync/tests/contract.rs
@@ -1351,3 +1351,269 @@ async fn backfill_is_safe_to_repeat() {
         "no duplicate topics after a repeated backfill"
     );
 }
+
+
+// ---------------------------------------------------------------------------
+// Vocabulary: lemma and form sync (single-word entities, no wire mapping)
+// ---------------------------------------------------------------------------
+
+use open_course_core::vocabulary::{Form, Lemma};
+use open_course_db::outbox::ENTITY_LEMMA;
+
+fn lemma(id: &str, mastery: f64, updated_at: Option<&str>) -> Lemma {
+    Lemma {
+        id: id.to_string(),
+        lemma: "hablar".to_string(),
+        pos: "VERB".to_string(),
+        target_lang: "es".to_string(),
+        native_lang: "ru".to_string(),
+        mastery,
+        updated_at: updated_at.map(|s| s.to_string()),
+        ..Default::default()
+    }
+}
+
+fn form(id: &str, lemma_id: &str, updated_at: Option<&str>) -> Form {
+    Form {
+        id: id.to_string(),
+        lemma_id: lemma_id.to_string(),
+        surface: "hablo".to_string(),
+        feats: "Mood=Ind|Number=Sing|Person=1".to_string(),
+        feats_key: "Mood=Ind|Number=Sing|Person=1".to_string(),
+        updated_at: updated_at.map(|s| s.to_string()),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn pull_applies_lemma_and_form_upserts_with_lww() {
+    let (state, base) = start_mock().await;
+    let (_dir, db) = temp_db().await;
+    // A newer local lemma must survive a stale incoming upsert.
+    db.lemmas()
+        .upsert_with_timestamps(&lemma("es-hablar", 66.0, Some("2025-06-01T00:00:00Z")))
+        .await
+        .unwrap();
+    let stale_lemma = lemma("es-hablar", 10.0, Some("2025-01-01T00:00:00Z"));
+    let new_form = form("es-hablar--hablo", "es-hablar", Some("2025-01-01T00:00:00Z"));
+    seed_changes(
+        &state,
+        vec![
+            Change {
+                seq: 1,
+                op: "upsert".to_string(),
+                entity: "lemma".to_string(),
+                entity_id: stale_lemma.id.clone(),
+                payload: Some(serde_json::to_value(&stale_lemma).unwrap()),
+                updated_at: stale_lemma.updated_at.clone(),
+            },
+            Change {
+                seq: 2,
+                op: "upsert".to_string(),
+                entity: "form".to_string(),
+                entity_id: new_form.id.clone(),
+                payload: Some(serde_json::to_value(&new_form).unwrap()),
+                updated_at: new_form.updated_at.clone(),
+            },
+        ],
+    );
+
+    let revision = client(&base).pull(&db, "ru-es").await.unwrap();
+    assert_eq!(revision, 2);
+    assert_eq!(db.metadata().last_pulled_seq().await.unwrap(), 2);
+
+    // LWW: the newer local lemma wins; the incoming form is inserted with
+    // the server's timestamps preserved.
+    let lemmas = db.lemmas().read_all().await.unwrap();
+    assert_eq!(lemmas.len(), 1);
+    assert_eq!(lemmas[0].mastery, 66.0);
+    let forms = db.forms().read_all().await.unwrap();
+    assert_eq!(forms.len(), 1);
+    assert_eq!(forms[0].surface, "hablo");
+    assert_eq!(
+        forms[0].updated_at.as_deref(),
+        Some("2025-01-01T00:00:00Z")
+    );
+}
+
+#[tokio::test]
+async fn pull_applies_lemma_and_form_delete_and_tombstone_reset() {
+    let (state, base) = start_mock().await;
+    let (_dir, db) = temp_db().await;
+    db.lemmas()
+        .upsert_with_timestamps(&lemma("es-hablar", 0.0, Some("2025-01-01T00:00:00Z")))
+        .await
+        .unwrap();
+    db.lemmas()
+        .upsert_with_timestamps(&lemma("es-comer", 0.0, Some("2025-01-01T00:00:00Z")))
+        .await
+        .unwrap();
+    db.forms()
+        .upsert_with_timestamps(&form(
+            "es-hablar--hablo",
+            "es-hablar",
+            Some("2025-01-01T00:00:00Z"),
+        ))
+        .await
+        .unwrap();
+
+    seed_changes(
+        &state,
+        vec![
+            Change {
+                seq: 1,
+                op: "delete".to_string(),
+                entity: "lemma".to_string(),
+                entity_id: "es-hablar".to_string(),
+                payload: None,
+                updated_at: Some("2025-02-01T00:00:00Z".to_string()),
+            },
+            Change {
+                seq: 2,
+                op: "tombstoneReset".to_string(),
+                entity: "form".to_string(),
+                entity_id: "*".to_string(),
+                payload: None,
+                updated_at: Some("2025-02-02T00:00:00Z".to_string()),
+            },
+        ],
+    );
+
+    client(&base).pull(&db, "ru-es").await.unwrap();
+    let lemmas = db.lemmas().read_all().await.unwrap();
+    assert_eq!(lemmas.len(), 1);
+    assert_eq!(lemmas[0].id, "es-comer");
+    assert!(db.forms().read_all().await.unwrap().is_empty());
+    assert_eq!(
+        db.metadata()
+            .get(open_course_db::metadata::KEY_RESET_AT)
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("2025-02-02T00:00:00Z")
+    );
+}
+
+#[tokio::test]
+async fn pull_unknown_entity_is_skipped_and_cursor_advances() {
+    let (state, base) = start_mock().await;
+    let (_dir, db) = temp_db().await;
+    db.curriculum()
+        .upsert_with_timestamps(&topic("t1", "Greetings", Some("2025-01-01T00:00:00Z")))
+        .await
+        .unwrap();
+
+    // An entity from a future client version: the upsert is skipped (not a
+    // protocol error) and its tombstone reset must NOT wipe local tables.
+    seed_changes(
+        &state,
+        vec![
+            Change {
+                seq: 1,
+                op: "upsert".to_string(),
+                entity: "futureEntity".to_string(),
+                entity_id: "f1".to_string(),
+                payload: Some(serde_json::json!({ "id": "f1" })),
+                updated_at: Some("2025-02-01T00:00:00Z".to_string()),
+            },
+            Change {
+                seq: 2,
+                op: "tombstoneReset".to_string(),
+                entity: "futureEntity".to_string(),
+                entity_id: "*".to_string(),
+                payload: None,
+                updated_at: Some("2025-02-02T00:00:00Z".to_string()),
+            },
+        ],
+    );
+
+    let revision = client(&base).pull(&db, "ru-es").await.unwrap();
+    assert_eq!(revision, 2);
+    assert_eq!(db.metadata().last_pulled_seq().await.unwrap(), 2);
+    assert_eq!(
+        db.curriculum().read_all().await.unwrap().topics.len(),
+        1,
+        "an unknown tombstone reset must not wipe synced tables"
+    );
+    assert!(
+        db.metadata()
+            .get(open_course_db::metadata::KEY_RESET_AT)
+            .await
+            .unwrap()
+            .is_none(),
+        "no reset marker is recorded for a no-op reset"
+    );
+}
+
+#[tokio::test]
+async fn backfill_uploads_pre_sync_vocabulary_on_fresh_bind() {
+    let (state, base) = start_mock().await;
+    let (_dir, db) = temp_db().await;
+
+    db.lemmas()
+        .upsert_with_timestamps(&lemma("es-hablar", 30.0, Some("2025-01-01T00:00:00Z")))
+        .await
+        .unwrap();
+    db.forms()
+        .upsert_with_timestamps(&form(
+            "es-hablar--hablo",
+            "es-hablar",
+            Some("2025-01-01T00:00:00Z"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(db.outbox().len().await.unwrap(), 0, "pre-sync data only");
+
+    backfill_outbox(&db, false).await.unwrap();
+    client(&base).push(&db, "ru-es").await.unwrap();
+
+    {
+        let st = state.lock().unwrap();
+        for entity in ["lemma", "form"] {
+            assert!(
+                st.changes.iter().any(|c| c.entity == entity),
+                "backfilled {entity} reached the server"
+            );
+        }
+    }
+    assert_eq!(db.outbox().len().await.unwrap(), 0, "outbox drained");
+}
+
+#[tokio::test]
+async fn roundtrip_lemma_between_two_clients() {
+    let (_state, base) = start_mock().await;
+    let (_dir_a, db_a) = temp_db().await;
+    let (_dir_b, db_b) = temp_db().await;
+
+    // A upserts a lemma and pushes it through the outbox.
+    db_a.lemmas()
+        .upsert(&lemma("es-hablar", 42.0, None))
+        .await
+        .unwrap();
+    let stamped = db_a
+        .lemmas()
+        .read_all()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|l| l.id == "es-hablar")
+        .unwrap();
+    db_a
+        .outbox()
+        .append(
+            OP_UPSERT,
+            ENTITY_LEMMA,
+            &stamped.id,
+            &serde_json::to_string(&stamped).unwrap(),
+        )
+        .await
+        .unwrap();
+    client(&base).push(&db_a, "ru-es").await.unwrap();
+
+    // B pulls it verbatim (single-word entity: no wire mapping).
+    client(&base).pull(&db_b, "ru-es").await.unwrap();
+    let b_lemmas = db_b.lemmas().read_all().await.unwrap();
+    assert_eq!(b_lemmas.len(), 1);
+    assert_eq!(b_lemmas[0].mastery, 42.0);
+    assert_eq!(b_lemmas[0].updated_at, stamped.updated_at);
+}


### PR DESCRIPTION
## Summary

Adds a third progress system next to topics and learning items: **lemmas** (dictionary headwords) and **inflected forms** described with Universal Dependencies morphology. Language-agnostic by design — the LLM does the morphology, no conjugation rules in code.

## What's inside

**Core**
- `vocabulary` module: `Lemma`/`Form` with deterministic slug ids, normalized `feats_key` (UD feature canonicalization: case, order, synonyms like `Present→Pres`), fuzzy form matching (Jaccard/subset merge at 0.8, richer feats win), CEFR source ranking (`topic > llm`, never overwrite a stronger source), and an error-ownership heuristic — single-word errors belong to vocabulary evidence instead of creating learning items
- Session contract: per-sentence `usedVocabulary` (surface, lemma, pos, UD feats, spelling/usage assessment, LLM CEFR estimate)
- Prompts: forced-vocabulary block (include-if-natural, skip rather than distort); batch analysis asks for full UD feature sets and stops reporting single-word errors as new topics

**DB / service / sync**
- `lemmas`/`forms` LanceDB tables (schema v5), apply step: ensure from target-side uses, EMA scoring from student-side evidence, CEFR from topic of appearance, neutral credit for unused forced lemmas, content-POS filter for forced candidates
- Sync: `lemma`/`form` entities end to end (outbox, push/pull LWW, tombstones, backfill)
- **Forward compatibility**: unknown entities are skipped on pull instead of failing sync forever; unknown tombstone resets no longer wipe all local data

## Deployment note

The companion server PR must be deployed **before** a CLI release ships these entities (server rejects unknown entity strings with 400).

## Testing

Full workspace suite green (unit + integration + sync contract tests), clippy clean.