### PR TITLE
feat: session word warm-up before exercises

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/src/app/llm_results.rs
+++ b/crates/cli/src/app/llm_results.rs
@@ -9,7 +9,7 @@ use crate::ui::views::{ReportState, session};
 use crate::ui::widgets::Toast;
 use open_course_core::error::Result;
 use open_course_core::session::{
-    AnalysisResult, EvaluatedTopic, Exercise, MASTERY_THRESHOLD, create_session,
+    AnalysisResult, EvaluatedTopic, GeneratedSession, MASTERY_THRESHOLD, create_session,
 };
 use open_course_db::curriculum::{Curriculum, Topic};
 use open_course_llm::diagnostics::CheckResult;
@@ -151,17 +151,24 @@ fn handle_diagnostic_update(state: &mut AppState, check: CheckResult) {
     }
 }
 
-fn handle_exercises(state: &mut AppState, res: Result<Vec<Exercise>>) {
+fn handle_exercises(state: &mut AppState, res: Result<GeneratedSession>) {
     clear_loading(state);
     match res {
-        Ok(exercises) => {
+        Ok(generated) => {
             let batch_size = state
                 .config
                 .as_ref()
                 .map(|c| c.preferences.batch_size as usize)
-                .unwrap_or(exercises.len());
-            state.session.mentor_session = Some(create_session(exercises, batch_size));
-            state.session.mode = session::Mode::Practicing;
+                .unwrap_or(generated.exercises.len());
+            state.session.mentor_session = Some(create_session(generated.exercises, batch_size));
+            state.session.warmup_items = generated.warmup;
+            state.session.warmup_index = 0;
+            state.session.warmup_revealed = false;
+            state.session.mode = if state.session.warmup_items.is_empty() {
+                session::Mode::Practicing
+            } else {
+                session::Mode::WarmUp
+            };
             state.session.input.clear();
             state.session.cursor = 0;
         }

--- a/crates/cli/src/ui/help.rs
+++ b/crates/cli/src/ui/help.rs
@@ -177,6 +177,16 @@ fn session_groups(state: &AppState, labels: ReportLabels, common: CommonLabels) 
             ),
             group(common.group_exit, vec![entry("Esc", labels.back)]),
         ],
+        SessionMode::WarmUp => vec![
+            group(
+                common.group_actions,
+                vec![
+                    entry("Enter", labels.show_translation),
+                    entry("s", labels.skip_warmup),
+                ],
+            ),
+            group(common.group_exit, vec![entry("Esc", labels.back)]),
+        ],
         SessionMode::Practicing => vec![
             group(
                 common.group_actions,

--- a/crates/cli/src/ui/labels.rs
+++ b/crates/cli/src/ui/labels.rs
@@ -3,6 +3,9 @@ use open_course_core::language::normalize_language_code;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ReportLabels {
     pub translate: &'static str,
+    pub warmup_title: &'static str,
+    pub show_translation: &'static str,
+    pub skip_warmup: &'static str,
     pub loading_exercises: &'static str,
     pub loading_analysis: &'static str,
     pub loading_curriculum: &'static str,
@@ -111,6 +114,9 @@ pub struct DocsLabels {
 
 const EN_REPORT: ReportLabels = ReportLabels {
     translate: "Translate",
+    warmup_title: "Warm-up",
+    show_translation: "show translation",
+    skip_warmup: "skip warm-up",
     loading_exercises: "Generating exercises...",
     loading_analysis: "Analyzing answers...",
     loading_curriculum: "Generating curriculum...",
@@ -206,6 +212,9 @@ const EN_REPORT: ReportLabels = ReportLabels {
 
 const RU_REPORT: ReportLabels = ReportLabels {
     translate: "Перевод",
+    warmup_title: "Разминка",
+    show_translation: "показать перевод",
+    skip_warmup: "пропустить разминку",
     loading_exercises: "Генерация упражнений...",
     loading_analysis: "Анализ ответов...",
     loading_curriculum: "Генерация программы...",

--- a/crates/cli/src/ui/views/session.rs
+++ b/crates/cli/src/ui/views/session.rs
@@ -13,7 +13,7 @@ use crate::ui::views::utils::{
 };
 use crate::ui::widgets::{Card, build_footer_wrapped};
 use open_course_core::error::{AppError, Result};
-use open_course_core::session::{MentorSession, NextSessionTopic};
+use open_course_core::session::{MentorSession, NextSessionTopic, WarmupItem};
 use open_course_db::curriculum::Topic;
 use open_course_llm::pipeline::log_debug_event;
 
@@ -21,6 +21,7 @@ use open_course_llm::pipeline::log_debug_event;
 pub enum Mode {
     #[default]
     TopicSelection,
+    WarmUp,
     Practicing,
 }
 
@@ -38,6 +39,12 @@ pub struct SessionState {
     pub target_topic_id: Option<String>,
     pub learning_item_ids: Vec<String>,
     pub lemma_ids: Vec<String>,
+    /// Warm-up cards shown before the exercises; empty when the session has
+    /// no teachable forced vocabulary.
+    pub warmup_items: Vec<WarmupItem>,
+    pub warmup_index: usize,
+    /// Whether the current warm-up card's translation is visible.
+    pub warmup_revealed: bool,
 }
 
 impl SessionState {
@@ -107,6 +114,21 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
             ],
             width,
         ),
+        Mode::WarmUp => {
+            let enter_action = if state.session.warmup_revealed {
+                common.next
+            } else {
+                labels.show_translation
+            };
+            build_footer_wrapped(
+                &[
+                    ("Enter", enter_action),
+                    ("s", labels.skip_warmup),
+                    ("Esc", labels.back),
+                ],
+                width,
+            )
+        }
         Mode::Practicing => {
             build_footer_wrapped(&[("Enter", labels.submit), ("Esc", labels.back)], width)
         }
@@ -156,6 +178,51 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                 chunks[2],
             );
         }
+        Mode::WarmUp => {
+            let total = state.session.warmup_items.len();
+            let idx = state.session.warmup_index.min(total.saturating_sub(1));
+            let title = format!("{} {}/{}", labels.warmup_title, idx + 1, total);
+
+            let mut card = Card::new(title);
+            if let Some(item) = state.session.warmup_items.get(idx) {
+                let mut word_spans = vec![Span::styled(
+                    item.lemma.clone(),
+                    Style::default().add_modifier(Modifier::BOLD),
+                )];
+                let badges: Vec<&str> = [item.pos.as_deref(), item.cefr_level.as_deref()]
+                    .into_iter()
+                    .flatten()
+                    .collect();
+                if !badges.is_empty() {
+                    word_spans.push(Span::styled(
+                        format!("  {}", badges.join(" · ")),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+                card = card.line(Line::from(word_spans));
+
+                if state.session.warmup_revealed {
+                    card = card.line(Line::from(item.translation.clone()));
+                    if let Some(example) = item.example.as_ref() {
+                        card = card.line(Line::from(Span::styled(
+                            example.clone(),
+                            Style::default().fg(colors::YELLOW),
+                        )));
+                    }
+                } else {
+                    card = card.line(Line::from(Span::styled(
+                        format!("Enter: {}", labels.show_translation),
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                }
+            }
+            frame.render_widget(card, chunks[0]);
+
+            frame.render_widget(
+                Paragraph::new(footer_text.clone()).style(Style::default().fg(Color::DarkGray)),
+                chunks[2],
+            );
+        }
         Mode::Practicing => {
             let title;
             let prompt = if let Some(session) = state.session.mentor_session.as_ref() {
@@ -196,8 +263,40 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
 pub async fn handle_key(state: &mut AppState, code: KeyCode) -> Result<()> {
     match state.session.mode {
         Mode::TopicSelection => handle_topic_selection(state, code).await,
+        Mode::WarmUp => handle_warmup(state, code).await,
         Mode::Practicing => handle_practicing(state, code).await,
     }
+}
+
+/// Warm-up phase: forward-only flashcards. Enter (or Space) reveals the
+/// translation, then advances to the next card; after the last card the
+/// session moves on to the exercises. `s` skips the rest of the warm-up.
+async fn handle_warmup(state: &mut AppState, code: KeyCode) -> Result<()> {
+    match code {
+        KeyCode::Esc => {
+            if state.session.loading {
+                state.cancelled = true;
+            }
+            reset_session(&mut state.session);
+            state.view = View::Dashboard;
+        }
+        KeyCode::Char('s') => {
+            state.session.mode = Mode::Practicing;
+        }
+        KeyCode::Enter | KeyCode::Char(' ') => {
+            if !state.session.warmup_revealed {
+                state.session.warmup_revealed = true;
+            } else {
+                state.session.warmup_index += 1;
+                state.session.warmup_revealed = false;
+                if state.session.warmup_index >= state.session.warmup_items.len() {
+                    state.session.mode = Mode::Practicing;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 async fn handle_topic_selection(state: &mut AppState, code: KeyCode) -> Result<()> {
@@ -430,10 +529,12 @@ pub(crate) async fn start_exercises_for_topic(
     let data_dir = state.data_dir.clone();
     let tx = state.llm_tx.clone();
     let prompt = preparation.prompt;
+    let forced_lemmas = preparation.forced_lemmas;
     tokio::spawn(async move {
         let result = open_course_service::session::generate_session_exercises(
             &config,
             &prompt,
+            &forced_lemmas,
             &tx,
             Some(data_dir.as_path()),
         )
@@ -529,6 +630,9 @@ pub(crate) fn reset_session(session: &mut SessionState) {
     session.loading_title = None;
     session.pending_new_topic = false;
     session.target_topic_id = None;
+    session.warmup_items.clear();
+    session.warmup_index = 0;
+    session.warmup_revealed = false;
 }
 
 #[cfg(test)]

--- a/crates/cli/tests/debug_exercises.rs
+++ b/crates/cli/tests/debug_exercises.rs
@@ -63,11 +63,12 @@ async fn debug_generate_exercises() {
     println!("\n========== PROMPT ==========\n{prompt}\n===========================\n");
 
     match generate_exercises(model.as_ref(), &prompt, None, Some(&data_dir)).await {
-        Ok(exercises) => {
-            println!("Generated {} exercises:", exercises.len());
-            for ex in exercises {
+        Ok(parsed) => {
+            println!("Generated {} exercises:", parsed.exercises.len());
+            for ex in &parsed.exercises {
                 println!("{ex:?}");
             }
+            println!("Warm-up items: {}", parsed.warmup.len());
         }
         Err(e) => {
             eprintln!("ERROR: {e}");

--- a/crates/cli/tests/prompts_test.rs
+++ b/crates/cli/tests/prompts_test.rs
@@ -112,6 +112,9 @@ fn exercise_prompt_includes_forced_vocabulary() {
     assert!(prompt.contains("words need extra practice"));
     assert!(prompt.contains("- colleague (коллега)"));
     assert!(prompt.contains("- resilient"));
+    // Forced vocabulary also triggers the warm-up contract.
+    assert!(prompt.contains("\"warmup\""));
+    assert!(prompt.contains("one entry per word listed above"));
 }
 
 #[test]

--- a/crates/core/src/llm/parse.rs
+++ b/crates/core/src/llm/parse.rs
@@ -10,6 +10,28 @@ use crate::session::{AnalysisResult, Exercise, SentenceAnalysis};
 #[serde(rename_all = "camelCase")]
 pub struct Exercises {
     pub exercises: Vec<Exercise>,
+    /// Warm-up cards for the session's forced vocabulary, one per forced
+    /// lemma. Optional: older prompts and bare-array responses have none.
+    #[serde(default)]
+    pub warmup: Vec<RawWarmupItem>,
+}
+
+/// Warm-up entry as returned by the LLM, before it is matched against the
+/// session's forced lemmas. Every field is optional so a partial entry never
+/// breaks parsing of the whole response.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RawWarmupItem {
+    #[serde(default)]
+    pub lemma: String,
+    #[serde(default)]
+    pub pos: Option<String>,
+    #[serde(default)]
+    pub cefr_level: Option<String>,
+    #[serde(default)]
+    pub translation: Option<String>,
+    #[serde(default)]
+    pub example: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -23,6 +45,16 @@ pub fn parse_exercises(
     content_chars: usize,
     reasoning_chars: usize,
 ) -> Result<Vec<Exercise>> {
+    parse_session_exercises(cleaned, content_chars, reasoning_chars).map(|w| w.exercises)
+}
+
+/// Same as `parse_exercises`, but keeps the whole wrapper object so the
+/// caller can use the optional `warmup` array alongside the exercises.
+pub fn parse_session_exercises(
+    cleaned: &str,
+    content_chars: usize,
+    reasoning_chars: usize,
+) -> Result<Exercises> {
     if cleaned.trim().is_empty() {
         return Err(AppError::Llm(format!(
             "empty response (content {content_chars} chars, reasoning {reasoning_chars} chars)"
@@ -35,13 +67,16 @@ pub fn parse_exercises(
                 "parsed JSON contains no exercises".to_string(),
             ));
         }
-        return Ok(wrapper.exercises);
+        return Ok(wrapper);
     }
     if let Ok(vec) = from_str::<Vec<Exercise>>(cleaned) {
         if vec.is_empty() {
             return Err(AppError::Llm("parsed JSON array is empty".to_string()));
         }
-        return Ok(vec);
+        return Ok(Exercises {
+            exercises: vec,
+            warmup: vec![],
+        });
     }
 
     Err(AppError::Llm(
@@ -489,6 +524,46 @@ mod tests {
     fn parse_exercises_rejects_empty_array() {
         let err = parse_exercises("[]", 0, 0).unwrap_err();
         assert_eq!(err.to_string(), "LLM error: parsed JSON array is empty");
+    }
+
+    // --- warmup parsing ---
+
+    #[test]
+    fn parse_session_exercises_defaults_warmup_when_absent() {
+        let cleaned = format!(r#"{{"exercises": [{}]}}"#, exercise_json("ex1"));
+        let result = parse_session_exercises(&cleaned, 0, 0).unwrap();
+        assert_eq!(result.exercises.len(), 1);
+        assert!(result.warmup.is_empty());
+    }
+
+    #[test]
+    fn parse_session_exercises_parses_warmup() {
+        let cleaned = format!(
+            r#"{{"exercises": [{}], "warmup": [
+                {{"lemma": "comer", "pos": "VERB", "cefrLevel": "A1", "translation": "есть", "example": "Como pan."}},
+                {{"lemma": "pequeño"}}
+            ]}}"#,
+            exercise_json("ex1")
+        );
+        let result = parse_session_exercises(&cleaned, 0, 0).unwrap();
+        assert_eq!(result.warmup.len(), 2);
+        assert_eq!(result.warmup[0].lemma, "comer");
+        assert_eq!(result.warmup[0].pos.as_deref(), Some("VERB"));
+        assert_eq!(result.warmup[0].cefr_level.as_deref(), Some("A1"));
+        assert_eq!(result.warmup[0].translation.as_deref(), Some("есть"));
+        assert_eq!(result.warmup[0].example.as_deref(), Some("Como pan."));
+        // Partial entries parse too: missing fields fall back to defaults.
+        assert_eq!(result.warmup[1].lemma, "pequeño");
+        assert_eq!(result.warmup[1].translation, None);
+        assert_eq!(result.warmup[1].example, None);
+    }
+
+    #[test]
+    fn parse_session_exercises_bare_array_has_empty_warmup() {
+        let cleaned = format!("[{}]", exercise_json("ex1"));
+        let result = parse_session_exercises(&cleaned, 0, 0).unwrap();
+        assert_eq!(result.exercises.len(), 1);
+        assert!(result.warmup.is_empty());
     }
 
     // --- parse_analysis ---

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -156,7 +156,15 @@ pub fn build_exercise_prompt(
             .collect::<Vec<_>>()
             .join("\n");
         format!(
-            "\nThe following words need extra practice. Include each of these words if it fits naturally, distributing them across different exercises and without distorting the target topics; skip a word rather than distort the sentence:\n{words}\n"
+            "\nThe following words need extra practice. Include each of these words if it fits naturally, distributing them across different exercises and without distorting the target topics; skip a word rather than distort the sentence:\n{words}\n\
+            \nIn addition to the exercises, return a top-level \"warmup\" array with one entry per word listed above, in the same order, each with these fields:\n\
+            - lemma: the word exactly as listed above\n\
+            - pos: part of speech (Universal Dependencies tag)\n\
+            - cefrLevel: approximate CEFR level (\"A1\"–\"C2\")\n\
+            - translation: the translation in {native}\n\
+            - example: one short example sentence in {target} using the word; it must NOT appear in any exercise\n",
+            native = profile.native_language,
+            target = profile.target_language,
         )
     };
 
@@ -187,9 +195,14 @@ For each exercise output a JSON object with these fields:
 - expectedPatterns: grammar patterns the student should use
 - hint: optional short hint
 
-Output a JSON object with a single key \"exercises\" containing an array of the exercise objects.",
+Output a JSON object with the key \"exercises\" containing an array of the exercise objects.{warmup_output_note}",
         native = profile.native_language,
-        target = profile.target_language
+        target = profile.target_language,
+        warmup_output_note = if forced_vocabulary.is_empty() {
+            ""
+        } else {
+            " Also include the requested \"warmup\" array."
+        }
     )
 }
 
@@ -645,12 +658,21 @@ mod tests {
         // Forced words are included only when they fit naturally.
         assert!(prompt.contains("if it fits naturally"));
         assert!(prompt.contains("skip a word rather than distort the sentence"));
+        // The warm-up contract is requested per forced word.
+        assert!(prompt.contains("\"warmup\""));
+        assert!(prompt.contains("one entry per word listed above"));
+        assert!(prompt.contains("the word exactly as listed above"));
+        assert!(prompt.contains("cefrLevel"));
+        assert!(prompt.contains("the translation in Russian"));
+        assert!(prompt.contains("example sentence in Spanish"));
+        assert!(prompt.contains("must NOT appear in any exercise"));
     }
 
     #[test]
     fn exercise_prompt_omits_forced_vocabulary_block_when_empty() {
         let prompt = build_exercise_prompt(&profile(), &[], &[], &[], &[], &[], 3, 0.8);
         assert!(!prompt.contains("need extra practice"));
+        assert!(!prompt.contains("\"warmup\""));
     }
 
     #[test]

--- a/crates/core/src/session/mod.rs
+++ b/crates/core/src/session/mod.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 pub use models::{
     AnalysisResult, EvaluatedTopic, Exercise, FeedbackComment, GrammarError, GrammarErrorType,
-    NewTopicRef, SemanticVerdict, SentenceAnalysis, VocabularyUse,
+    NewTopicRef, SemanticVerdict, SentenceAnalysis, VocabularyUse, WarmupItem,
 };
 pub use scoring::{
     average, clamp_score, collect_topic_errors, count_topic_occurrences, error_based_score,
@@ -23,6 +23,15 @@ pub const MASTERY_THRESHOLD: f64 = 50.0;
 pub const COMPLETED_THRESHOLD: f64 = 80.0;
 /// Average target score below which a session raises a low-score alert.
 pub const LOW_SESSION_SCORE_THRESHOLD: f64 = 60.0;
+
+/// The exercises and warm-up cards generated for one study session. The
+/// warm-up is derived from the session's forced vocabulary and is shown
+/// before the exercises; neither part is persisted as-is.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeneratedSession {
+    pub exercises: Vec<Exercise>,
+    pub warmup: Vec<WarmupItem>,
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MentorSession {

--- a/crates/core/src/session/models.rs
+++ b/crates/core/src/session/models.rs
@@ -53,6 +53,32 @@ where
     deserializer.deserialize_any(StringOrVec)
 }
 
+/// One warm-up card shown before the session's exercises: a forced
+/// vocabulary lemma with its translation and an optional example sentence.
+/// Filled by matching the LLM's `warmup` output against the session's
+/// forced lemmas (see `vocabulary::match_warmup_items`); never persisted.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct WarmupItem {
+    /// Id of the lemma this card was built from.
+    #[serde(default)]
+    pub lemma_id: Option<String>,
+    pub lemma: String,
+    /// Universal Dependencies part-of-speech tag ("NOUN", "VERB", ...).
+    #[serde(default)]
+    pub pos: Option<String>,
+    /// Approximate CEFR level ("A1"–"C2").
+    #[serde(default)]
+    pub cefr_level: Option<String>,
+    /// Translation in the learner's native language.
+    #[serde(default)]
+    pub translation: String,
+    /// Short example sentence in the target language.
+    #[serde(default)]
+    pub example: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -164,6 +164,82 @@ pub fn normalize_key(s: &str) -> String {
     s.nfkc().collect::<String>().to_lowercase()
 }
 
+/// Maximum number of warm-up cards shown before a session's exercises.
+pub const MAX_WARMUP_ITEMS: usize = 8;
+
+/// `Some(value)` trimmed when non-empty, `None` otherwise. The LLM sometimes
+/// emits empty strings instead of omitting an optional field.
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.and_then(|v| {
+        let trimmed = v.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+/// Builds warm-up cards for a session's forced lemmas from the LLM's raw
+/// `warmup` output. Cards follow the forced-lemma order and are capped at
+/// `MAX_WARMUP_ITEMS`. A raw entry whose lemma matches (via `normalize_key`)
+/// supplies the translation and example; unmatched forced lemmas fall back
+/// to the stored translation with no example. Lemmas without any translation
+/// are skipped (there is nothing to teach), and raw entries matching no
+/// forced lemma are dropped.
+pub fn match_warmup_items(
+    forced: &[Lemma],
+    raw: Vec<crate::llm::parse::RawWarmupItem>,
+) -> Vec<crate::session::WarmupItem> {
+    use std::collections::HashMap;
+
+    let mut by_key: HashMap<String, crate::llm::parse::RawWarmupItem> = HashMap::new();
+    for item in raw {
+        let key = normalize_key(item.lemma.trim());
+        if key.is_empty() {
+            continue;
+        }
+        by_key.entry(key).or_insert(item);
+    }
+
+    forced
+        .iter()
+        .take(MAX_WARMUP_ITEMS)
+        .filter_map(|lemma| {
+            let key = normalize_key(&lemma.lemma);
+            let item = match by_key.get(&key) {
+                Some(raw) => {
+                    let translation = non_empty(raw.translation.clone())
+                        .unwrap_or_else(|| lemma.translation.clone());
+                    crate::session::WarmupItem {
+                        lemma_id: Some(lemma.id.clone()),
+                        lemma: lemma.lemma.clone(),
+                        pos: non_empty(raw.pos.clone())
+                            .or_else(|| non_empty(Some(lemma.pos.clone()))),
+                        cefr_level: non_empty(raw.cefr_level.clone())
+                            .or_else(|| lemma.cefr_level.clone()),
+                        translation,
+                        example: non_empty(raw.example.clone()),
+                    }
+                }
+                None => crate::session::WarmupItem {
+                    lemma_id: Some(lemma.id.clone()),
+                    lemma: lemma.lemma.clone(),
+                    pos: non_empty(Some(lemma.pos.clone())),
+                    cefr_level: lemma.cefr_level.clone(),
+                    translation: lemma.translation.clone(),
+                    example: None,
+                },
+            };
+            if item.translation.is_empty() {
+                None
+            } else {
+                Some(item)
+            }
+        })
+        .collect()
+}
+
 /// Priority rank of a CEFR source: user-curated data ("manual"/"list") is 4,
 /// curriculum topics ("topic") 3, LLM estimates ("llm") 2, and anything else
 /// or `None` is 0.
@@ -681,5 +757,118 @@ mod tests {
             ..Default::default()
         };
         assert!(!vocabulary_owns_error(&sentence, &error));
+    }
+
+    // --- match_warmup_items ---
+
+    fn forced_lemma(id: &str, lemma: &str, translation: &str) -> Lemma {
+        Lemma {
+            id: id.to_string(),
+            lemma: lemma.to_string(),
+            pos: "VERB".to_string(),
+            translation: translation.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn raw_warmup(
+        lemma: &str,
+        translation: Option<&str>,
+        example: Option<&str>,
+    ) -> crate::llm::parse::RawWarmupItem {
+        crate::llm::parse::RawWarmupItem {
+            lemma: lemma.to_string(),
+            pos: None,
+            cefr_level: None,
+            translation: translation.map(|s| s.to_string()),
+            example: example.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn warmup_match_uses_llm_translation_and_example() {
+        let forced = vec![forced_lemma("es-comer", "comer", "есть")];
+        let raw = vec![raw_warmup("Comer", Some("кушать"), Some("Como pan."))];
+        let items = match_warmup_items(&forced, raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma_id.as_deref(), Some("es-comer"));
+        // The display form comes from the stored lemma, not the LLM casing.
+        assert_eq!(items[0].lemma, "comer");
+        assert_eq!(items[0].translation, "кушать");
+        assert_eq!(items[0].example.as_deref(), Some("Como pan."));
+        assert_eq!(items[0].pos.as_deref(), Some("VERB"));
+    }
+
+    #[test]
+    fn warmup_match_falls_back_to_stored_translation() {
+        let forced = vec![forced_lemma("es-comer", "comer", "есть")];
+        let raw = vec![raw_warmup("comer", None, None)];
+        let items = match_warmup_items(&forced, raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].translation, "есть");
+        assert_eq!(items[0].example, None);
+    }
+
+    #[test]
+    fn warmup_unmatched_lemma_uses_stored_data() {
+        let forced = vec![{
+            let mut l = forced_lemma("es-comer", "comer", "есть");
+            l.cefr_level = Some("A2".to_string());
+            l
+        }];
+        let items = match_warmup_items(&forced, vec![]);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].translation, "есть");
+        assert_eq!(items[0].cefr_level.as_deref(), Some("A2"));
+        assert_eq!(items[0].example, None);
+    }
+
+    #[test]
+    fn warmup_skips_lemmas_without_translation() {
+        // Unmatched and no stored translation: nothing to teach.
+        let forced = vec![
+            forced_lemma("es-comer", "comer", "есть"),
+            forced_lemma("es-ser", "ser", ""),
+        ];
+        let items = match_warmup_items(&forced, vec![]);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma, "comer");
+
+        // Matched but the LLM returned an empty translation and the stored
+        // one is empty too: skipped as well.
+        let forced = vec![forced_lemma("es-ser", "ser", "")];
+        let raw = vec![raw_warmup("ser", Some(""), Some("Soy yo."))];
+        assert!(match_warmup_items(&forced, raw).is_empty());
+    }
+
+    #[test]
+    fn warmup_drops_raw_items_matching_no_forced_lemma() {
+        let forced = vec![forced_lemma("es-comer", "comer", "есть")];
+        let raw = vec![
+            raw_warmup("comer", None, None),
+            raw_warmup("unrelated", Some("x"), None),
+            // Empty lemmas never match anything.
+            raw_warmup("", Some("y"), None),
+        ];
+        let items = match_warmup_items(&forced, raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma, "comer");
+    }
+
+    #[test]
+    fn warmup_preserves_forced_order_and_caps_at_eight() {
+        let forced: Vec<Lemma> = (0..10)
+            .map(|i| forced_lemma(&format!("es-w{i}"), &format!("w{i}"), "t"))
+            .collect();
+        // Raw order is the reverse of the forced order; output must still
+        // follow the forced order.
+        let raw: Vec<_> = (0..10)
+            .rev()
+            .map(|i| raw_warmup(&format!("w{i}"), None, None))
+            .collect();
+        let items = match_warmup_items(&forced, raw);
+        assert_eq!(items.len(), MAX_WARMUP_ITEMS);
+        let lemmas: Vec<&str> = items.iter().map(|i| i.lemma.as_str()).collect();
+        assert_eq!(lemmas, ["w0", "w1", "w2", "w3", "w4", "w5", "w6", "w7"]);
     }
 }

--- a/crates/llm/src/diagnostics.rs
+++ b/crates/llm/src/diagnostics.rs
@@ -310,11 +310,14 @@ async fn run_exercises_check(client: Arc<dyn LlmClient>, profile: &UserProfile) 
     )
     .await
     {
-        Ok(Ok(exercises)) => {
-            if !exercises.is_empty() {
+        Ok(Ok(parsed)) => {
+            if !parsed.exercises.is_empty() {
                 CheckStatus::Passed
             } else {
-                CheckStatus::Failed(format!("expected 1 exercise, got {}", exercises.len()))
+                CheckStatus::Failed(format!(
+                    "expected 1 exercise, got {}",
+                    parsed.exercises.len()
+                ))
             }
         }
         Ok(Err(e)) => CheckStatus::Failed(e.to_string()),

--- a/crates/llm/src/result.rs
+++ b/crates/llm/src/result.rs
@@ -2,14 +2,14 @@
 
 use open_course_core::curriculum::{Curriculum, Topic};
 use open_course_core::error::Result;
-use open_course_core::session::{AnalysisResult, Exercise};
+use open_course_core::session::{AnalysisResult, GeneratedSession};
 
 use crate::diagnostics::CheckResult;
 use crate::model_listing::ModelInfo;
 
 #[derive(Debug)]
 pub enum LlmResult {
-    Exercises(Result<Vec<Exercise>>),
+    Exercises(Result<GeneratedSession>),
     Analysis(Result<AnalysisResult>),
     Curriculum(Result<Curriculum>),
     CurriculumExtension(Result<Vec<Topic>>),

--- a/crates/llm/src/retry.rs
+++ b/crates/llm/src/retry.rs
@@ -7,11 +7,11 @@ use crate::client::{LlmClient, extract_typed};
 use crate::debug_log::{log_debug_event, log_failed_response, log_raw_response};
 use crate::parse::{
     Exercises, analysis_parse_errors, build_parse_error, clean_json_response,
-    exercise_parse_errors, parse_analysis, parse_exercises, validate_analysis_sentences,
+    exercise_parse_errors, parse_analysis, parse_session_exercises, validate_analysis_sentences,
 };
 use crate::transport::{LlmResponse, stream_or_prompt, with_timeout_secs};
 use open_course_core::error::Result;
-use open_course_core::session::{AnalysisResult, Exercise};
+use open_course_core::session::AnalysisResult;
 
 const MAX_TOKENS_EXERCISES: u32 = 8192;
 const MAX_TOKENS_ANALYSIS: u32 = 16384;
@@ -178,7 +178,7 @@ pub async fn generate_exercises(
     prompt: &str,
     stream_tx: Option<&mpsc::Sender<LlmResult>>,
     data_dir: Option<&Path>,
-) -> Result<Vec<Exercise>> {
+) -> Result<Exercises> {
     let config = RetryConfig {
         system: "You are a language tutor. Return ONLY valid JSON matching the requested schema. Do not wrap in markdown, do not add explanations, do not add commentary.",
         stricter_system: "You are a language tutor. Your response must be a single valid JSON object and nothing else. No markdown code fences, no explanations, no commentary.",
@@ -196,13 +196,13 @@ pub async fn generate_exercises(
         client,
         prompt,
         config,
-        parse_exercises,
+        parse_session_exercises,
         || async move {
             let wrapper = extract_typed::<Exercises>(client, prompt, MAX_TOKENS_EXERCISES).await?;
             Ok(if wrapper.exercises.is_empty() {
                 None
             } else {
-                Some(wrapper.exercises)
+                Some(wrapper)
             })
         },
         exercise_parse_errors,

--- a/crates/service/src/session.rs
+++ b/crates/service/src/session.rs
@@ -11,10 +11,11 @@ use tokio::sync::mpsc;
 use open_course_config::OpenCourseConfig;
 use open_course_core::error::{AppError, Result};
 use open_course_core::session::{
-    AnalysisResult, COMPLETED_THRESHOLD, Exercise, MentorSession, NextSessionTopic,
-    pick_next_session_topic, recent_success_rate, select_side_topics, unique_topic_ids,
+    AnalysisResult, COMPLETED_THRESHOLD, Exercise, GeneratedSession, MentorSession,
+    NextSessionTopic, pick_next_session_topic, recent_success_rate, select_side_topics,
+    unique_topic_ids,
 };
-use open_course_core::vocabulary::Lemma;
+use open_course_core::vocabulary::{Lemma, match_warmup_items};
 use open_course_db::Database;
 use open_course_db::apply::apply_analysis_to_db;
 use open_course_db::curriculum::{Topic, cefr_to_numeric};
@@ -37,6 +38,9 @@ pub struct ExercisePreparation {
     pub prompt: String,
     pub forced_learning_item_ids: Vec<String>,
     pub forced_lemma_ids: Vec<String>,
+    /// The full forced-vocabulary lemmas behind `forced_lemma_ids`, kept for
+    /// the warm-up phase shown before the exercises.
+    pub forced_lemmas: Vec<Lemma>,
 }
 
 /// Reads progress, learning items and history from the database, picks side
@@ -122,18 +126,26 @@ pub async fn prepare_exercises(
         prompt,
         forced_learning_item_ids,
         forced_lemma_ids,
+        forced_lemmas: forced_vocabulary,
     })
 }
 
-/// Runs the exercise-generation LLM call for a prepared prompt.
+/// Runs the exercise-generation LLM call for a prepared prompt and matches
+/// the returned warm-up entries against the session's forced lemmas.
 pub async fn generate_session_exercises(
     config: &OpenCourseConfig,
     prompt: &str,
+    forced_lemmas: &[Lemma],
     tx: &mpsc::Sender<LlmResult>,
     data_dir: Option<&Path>,
-) -> Result<Vec<Exercise>> {
+) -> Result<GeneratedSession> {
     let model = create_llm_model(config)?;
-    generate_exercises(model.as_ref(), prompt, Some(tx), data_dir).await
+    let parsed = generate_exercises(model.as_ref(), prompt, Some(tx), data_dir).await?;
+    let warmup = match_warmup_items(forced_lemmas, parsed.warmup);
+    Ok(GeneratedSession {
+        exercises: parsed.exercises,
+        warmup,
+    })
 }
 
 /// Picks what to practice next: a due review topic, a fresh topic, or a


### PR DESCRIPTION
## What

Adds a warm-up phase at the start of a study session (CLI TUI): the session's forced vocabulary (the weakest lemmas already selected for the session) is shown as flip cards — word hidden → `Enter` reveals translation + a short example → `Enter` advances. `s` skips the whole warm-up, `Esc` aborts as before. Forward-only, no scoring, nothing persisted.

## How

- **core**: `WarmupItem` model; the exercise-generation prompt now also asks for a top-level `warmup` array (one entry per forced lemma: lemma, pos, cefrLevel, translation, example not appearing in any exercise). Parsing is purely additive — `parse_exercises` keeps its signature (server compatibility), new `parse_session_exercises` returns the wrapper.
- **core**: `match_warmup_items` ties LLM warmup entries back to the forced lemmas (normalized match, translation fallback, items without any translation skipped, capped at 8).
- **service**: `ExercisePreparation` keeps the forced lemmas; `generate_session_exercises` returns `GeneratedSession { exercises, warmup }`.
- **cli**: new `Mode::WarmUp` card view; when the warm-up list is empty the session goes straight to exercises (unchanged behaviour).

## Verification

- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` workspace green (new parse/matcher/prompt tests included)

Server and web counterparts land in separate PRs; the server consumes `warmup` from the same generation call after this is released.