### PR TITLE
fix(vocabulary): first session contact moves words new->practicing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -301,13 +301,18 @@ pub fn should_replace_cefr(existing_source: Option<&str>, new_source: &str) -> b
     cefr_source_rank(Some(new_source)) > cefr_source_rank(existing_source)
 }
 
-/// Vocabulary status derived from mastery: 0 below 50, 1 from 50, 2 from 80.
-/// An observed error caps the status at `STATUS_PRACTICING`: one mistake
-/// means the word is not fully known yet.
-pub fn derive_status(mastery: f64, had_error: bool) -> i32 {
+/// Vocabulary status derived from mastery and practice history: 0 when the
+/// word has never been practiced, 1 from a mastery of 50 or once the word has
+/// been contacted at least once (`practiced`), 2 from a mastery of 80.
+///
+/// `new` = never appeared in the student's output; `practicing` = has been
+/// seen/used (even with an error) but not yet mastered; `known` = mastered.
+/// An observed error caps the status at `STATUS_PRACTICING`: a mistake means
+/// the word is not fully known yet, regardless of mastery.
+pub fn derive_status(mastery: f64, had_error: bool, practiced: bool) -> i32 {
     let base = if mastery >= COMPLETED_THRESHOLD {
         STATUS_KNOWN
-    } else if mastery >= MASTERY_THRESHOLD {
+    } else if mastery >= MASTERY_THRESHOLD || practiced {
         STATUS_PRACTICING
     } else {
         STATUS_NEW
@@ -509,19 +514,24 @@ mod tests {
 
     #[test]
     fn derive_status_thresholds() {
-        assert_eq!(derive_status(0.0, false), STATUS_NEW);
-        assert_eq!(derive_status(49.9, false), STATUS_NEW);
-        assert_eq!(derive_status(50.0, false), STATUS_PRACTICING);
-        assert_eq!(derive_status(79.9, false), STATUS_PRACTICING);
-        assert_eq!(derive_status(80.0, false), STATUS_KNOWN);
-        assert_eq!(derive_status(100.0, false), STATUS_KNOWN);
+        assert_eq!(derive_status(0.0, false, false), STATUS_NEW);
+        assert_eq!(derive_status(49.9, false, false), STATUS_NEW);
+        assert_eq!(derive_status(50.0, false, false), STATUS_PRACTICING);
+        assert_eq!(derive_status(79.9, false, false), STATUS_PRACTICING);
+        assert_eq!(derive_status(80.0, false, false), STATUS_KNOWN);
+        assert_eq!(derive_status(100.0, false, false), STATUS_KNOWN);
+
+        assert_eq!(derive_status(34.0, false, true), STATUS_PRACTICING);
+        assert_eq!(derive_status(0.0, false, true), STATUS_PRACTICING);
     }
 
     #[test]
     fn derive_status_error_caps_at_practicing() {
-        assert_eq!(derive_status(95.0, true), STATUS_PRACTICING);
-        assert_eq!(derive_status(60.0, true), STATUS_PRACTICING);
-        assert_eq!(derive_status(10.0, true), STATUS_NEW);
+        assert_eq!(derive_status(95.0, true, false), STATUS_PRACTICING);
+        assert_eq!(derive_status(60.0, true, false), STATUS_PRACTICING);
+        assert_eq!(derive_status(34.0, true, true), STATUS_PRACTICING);
+        assert_eq!(derive_status(0.0, true, true), STATUS_PRACTICING);
+        assert_eq!(derive_status(10.0, true, false), STATUS_NEW);
     }
 
     #[test]

--- a/crates/db/src/apply.rs
+++ b/crates/db/src/apply.rs
@@ -434,7 +434,7 @@ pub async fn apply_analysis_to_db(
                 lemma.correct_uses += 1;
             }
             lemma.last_seen = Some(now.clone());
-            lemma.status = derive_status(lemma.mastery, *had_error);
+            lemma.status = derive_status(lemma.mastery, *had_error, lemma.practice_count > 0);
             touched_lemma_ids.insert(id.clone());
         }
     }
@@ -448,7 +448,8 @@ pub async fn apply_analysis_to_db(
                 form.correct += 1;
             }
             form.last_seen = Some(now.clone());
-            form.status = derive_status(form.mastery, *had_error);
+            form.status =
+                derive_status(form.mastery, *had_error, form.correct + form.incorrect > 0);
             touched_form_ids.insert(id.clone());
         }
     }


### PR DESCRIPTION
## Summary

Evaluated words (student-side use observed in a session) stayed at status `new` after the first clean contact, because `ema_update(0, 100) = 34` is below the `MASTERY_THRESHOLD(50)`. The dashboard showed `New: 108` even though those words were already evaluated/used correctly — they needed a *second* clean session to flip to `practicing`.

## Fix

`derive_status` now takes a `practiced` flag: any word that has been contacted at least once (`practice_count > 0`, or for forms `correct + incorrect > 0`) becomes `practicing` right away after a first use — regardless of the (still-correctly-low) EMA mastery. `known` still requires mastery ≥ 80, and an observed error still caps at `practicing` (preserved).

New lifecycle semantics:
- `new` = never appeared in the student's output
- `practicing` = contacted at least once, not yet mastered
- `known` = mastery ≥ 80

This is shared core used by both the CLI and the server.

## Files
- `crates/core/src/vocabulary.rs` — `derive_status` gains `practiced: bool`, updated doc + unit tests
- `crates/db/src/apply.rs` — pass practice/evidence flags at the two scoring call sites
- No migration — existing rows self-correct on next practice

## Verification
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo fmt --check` ✓
- `cargo test --all-features` — 306 tests ✓
