### PR TITLE
feat(vocabulary): preview new words and rotate forced review vocabulary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4610,6 +4610,7 @@ dependencies = [
  "futures-util",
  "lancedb",
  "open-course-core",
+ "rand 0.9.5",
  "serde_json",
  "tempfile",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ time = "0.3"
 unicode-normalization = "0.1"
 regex = "1"
 uuid = { version = "1", features = ["v7"] }
+rand = "0.9"
 
 # Dev
 tempfile = "3"

--- a/crates/cli/src/ui/views/session.rs
+++ b/crates/cli/src/ui/views/session.rs
@@ -13,7 +13,7 @@ use crate::ui::views::utils::{
 };
 use crate::ui::widgets::{Card, build_footer_wrapped};
 use open_course_core::error::{AppError, Result};
-use open_course_core::session::{MentorSession, NextSessionTopic, WarmupItem};
+use open_course_core::session::{MentorSession, NextSessionTopic, WarmupItem, WarmupKind};
 use open_course_db::curriculum::Topic;
 use open_course_llm::pipeline::log_debug_event;
 
@@ -189,10 +189,12 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                     item.lemma.clone(),
                     Style::default().add_modifier(Modifier::BOLD),
                 )];
-                let badges: Vec<&str> = [item.pos.as_deref(), item.cefr_level.as_deref()]
-                    .into_iter()
-                    .flatten()
-                    .collect();
+                let new_badge = (item.kind == WarmupKind::New).then_some("NEW");
+                let badges: Vec<&str> =
+                    [new_badge, item.pos.as_deref(), item.cefr_level.as_deref()]
+                        .into_iter()
+                        .flatten()
+                        .collect();
                 if !badges.is_empty() {
                     word_spans.push(Span::styled(
                         format!("  {}", badges.join(" · ")),
@@ -531,12 +533,14 @@ pub(crate) async fn start_exercises_for_topic(
     let prompt = preparation.prompt;
     let forced_lemmas = preparation.forced_lemmas;
     let forced_forms = preparation.forced_forms;
+    let existing_lemmas = preparation.existing_lemmas;
     tokio::spawn(async move {
         let result = open_course_service::session::generate_session_exercises(
             &config,
             &prompt,
             &forced_lemmas,
             &forced_forms,
+            &existing_lemmas,
             &tx,
             Some(data_dir.as_path()),
         )

--- a/crates/cli/tests/prompts_test.rs
+++ b/crates/cli/tests/prompts_test.rs
@@ -118,6 +118,21 @@ fn exercise_prompt_includes_forced_vocabulary() {
 }
 
 #[test]
+fn exercise_prompt_always_requests_vocabulary_extraction() {
+    let p = profile();
+    let all = vec![topic("t1")];
+    let target = vec![topic("t1")];
+    // No forced learning items, no forced vocabulary: the "vocabulary"
+    // extraction request must still be present, independent of forced
+    // vocabulary — it's how genuinely new words get previewed.
+    let prompt = build_exercise_prompt(&p, &target, &[], &all, &[], &[], 3, 0.75);
+
+    assert!(prompt.contains("\"vocabulary\""));
+    assert!(prompt.contains("CONTENT word"));
+    assert!(!prompt.contains("\"warmup\""));
+}
+
+#[test]
 fn analysis_prompt_includes_answers() {
     use open_course_cli::core::session::Exercise;
 

--- a/crates/core/src/llm/parse.rs
+++ b/crates/core/src/llm/parse.rs
@@ -14,6 +14,13 @@ pub struct Exercises {
     /// lemma. Optional: older prompts and bare-array responses have none.
     #[serde(default)]
     pub warmup: Vec<RawWarmupItem>,
+    /// Content vocabulary the model used across the generated exercises,
+    /// requested independently of `warmup`/forced vocabulary so genuinely
+    /// new words (not yet in the learner's vocabulary table) can be
+    /// previewed too (see `vocabulary::new_word_items`). Optional: older
+    /// prompts and bare-array responses have none.
+    #[serde(default)]
+    pub vocabulary: Vec<RawVocabularyItem>,
 }
 
 /// Warm-up entry as returned by the LLM, before it is matched against the
@@ -32,6 +39,29 @@ pub struct RawWarmupItem {
     pub translation: Option<String>,
     #[serde(default)]
     pub example: Option<String>,
+}
+
+/// Content-vocabulary entry as returned by the LLM for the exercises it just
+/// generated, before it is diffed against the learner's existing vocabulary
+/// (see `vocabulary::new_word_items`). Every field is optional so a partial
+/// entry never breaks parsing of the whole response.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RawVocabularyItem {
+    #[serde(default)]
+    pub lemma: String,
+    /// The exact inflected form as it appears in the sentence — checked
+    /// against the generated text instead of `lemma` (which, for an
+    /// inflected verb like "como" from "comer", usually never appears
+    /// verbatim), so a chatty LLM can't invent vocabulary that isn't there.
+    #[serde(default)]
+    pub surface: String,
+    #[serde(default)]
+    pub pos: Option<String>,
+    #[serde(default)]
+    pub cefr_level: Option<String>,
+    #[serde(default)]
+    pub translation: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -76,6 +106,7 @@ pub fn parse_session_exercises(
         return Ok(Exercises {
             exercises: vec,
             warmup: vec![],
+            vocabulary: vec![],
         });
     }
 

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -168,6 +168,24 @@ pub fn build_exercise_prompt(
         )
     };
 
+    let vocabulary_extraction_note = format!(
+        "\nIn addition to the exercises{warmup_ref}, return a top-level \"vocabulary\" array \
+         listing every CONTENT word (NOUN, VERB, ADJ, ADV, PROPN only — skip articles, \
+         prepositions, pronouns, auxiliaries, conjunctions) that appears in the target sentences \
+         you just wrote, one entry per distinct word, each with these fields:\n\
+         - lemma: the dictionary headword\n\
+         - surface: the exact inflected form as it appears in the sentence\n\
+         - pos: part of speech (Universal Dependencies tag)\n\
+         - cefrLevel: approximate CEFR level (\"A1\"–\"C2\")\n\
+         - translation: the translation in {native}\n",
+        warmup_ref = if forced_vocabulary.is_empty() {
+            ""
+        } else {
+            " and the requested \"warmup\" array"
+        },
+        native = profile.native_language,
+    );
+
     format!(
         "You are a language tutor. Generate {count} connected translation exercises from {native} to {target}.
 
@@ -195,7 +213,7 @@ For each exercise output a JSON object with these fields:
 - expectedPatterns: grammar patterns the student should use
 - hint: optional short hint
 
-Output a JSON object with the key \"exercises\" containing an array of the exercise objects.{warmup_output_note}",
+Output a JSON object with the key \"exercises\" containing an array of the exercise objects.{warmup_output_note}{vocabulary_extraction_note}",
         native = profile.native_language,
         target = profile.target_language,
         warmup_output_note = if forced_vocabulary.is_empty() {

--- a/crates/core/src/session/mod.rs
+++ b/crates/core/src/session/mod.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 pub use models::{
     AnalysisResult, EvaluatedTopic, Exercise, FeedbackComment, GrammarError, GrammarErrorType,
-    NewTopicRef, SemanticVerdict, SentenceAnalysis, VocabularyUse, WarmupItem,
+    NewTopicRef, SemanticVerdict, SentenceAnalysis, VocabularyUse, WarmupItem, WarmupKind,
 };
 pub use scoring::{
     average, clamp_score, collect_topic_errors, count_topic_occurrences, error_based_score,

--- a/crates/core/src/session/models.rs
+++ b/crates/core/src/session/models.rs
@@ -53,15 +53,33 @@ where
     deserializer.deserialize_any(StringOrVec)
 }
 
-/// One warm-up card shown before the session's exercises: a forced
-/// vocabulary lemma with its translation and an optional example sentence.
-/// Filled by matching the LLM's `warmup` output against the session's
-/// forced lemmas (see `vocabulary::match_warmup_items`); never persisted.
+/// Whether a warm-up card reinforces a word the learner has already been
+/// evaluated on (`Review`) or introduces one they haven't (`New`) — either a
+/// word with no `Lemma` row at all, or one that exists but is still
+/// `STATUS_NEW` (never evaluated). Both count as "new" to the learner and
+/// get the same visual treatment; only words the learner has actually been
+/// scored on (`STATUS_PRACTICING`, possibly weak) are `Review`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum WarmupKind {
+    #[default]
+    Review,
+    New,
+}
+
+/// One warm-up card shown before the session's exercises: either a forced
+/// vocabulary lemma being reinforced, or a genuinely new word previewed from
+/// the session's freshly-generated exercises. Filled by matching the LLM's
+/// `warmup`/`vocabulary` output against the session's forced lemmas and
+/// existing vocabulary (see `vocabulary::match_warmup_items` and
+/// `vocabulary::new_word_items`); never persisted.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct WarmupItem {
-    /// Id of the lemma this card was built from.
+    /// Id of the lemma this card was built from; `None` for a genuinely new
+    /// word that has no `Lemma` row yet.
     #[serde(default)]
     pub lemma_id: Option<String>,
     pub lemma: String,
@@ -77,6 +95,10 @@ pub struct WarmupItem {
     /// Short example sentence in the target language.
     #[serde(default)]
     pub example: Option<String>,
+    /// `Review` (reinforcing a known-but-weak word) or `New` (previewing a
+    /// word the learner hasn't been evaluated on yet).
+    #[serde(default)]
+    pub kind: WarmupKind,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -203,7 +203,10 @@ fn exercise_tokens(exercises: &[crate::session::Exercise]) -> HashSet<String> {
 /// matches supplies the translation and example; otherwise the stored
 /// translation is used with no example. Lemmas without any translation are
 /// skipped (there is nothing to teach), and raw entries matching no forced
-/// lemma are dropped.
+/// lemma are dropped. Each card is tagged `WarmupKind::New` when the lemma
+/// hasn't been evaluated yet (`STATUS_NEW`) or `WarmupKind::Review`
+/// otherwise (see `new_word_items` for words with no `Lemma` row at all,
+/// tagged `New` the same way).
 pub fn match_warmup_items(
     forced: &[Lemma],
     forms: &[Form],
@@ -248,6 +251,15 @@ pub fn match_warmup_items(
         })
         .filter_map(|lemma| {
             let key = normalize_key(&lemma.lemma);
+            // A lemma the learner hasn't been evaluated on yet (STATUS_NEW,
+            // mastery 0) counts as "new" to them, same as a word with no
+            // Lemma row at all (see `new_word_items`) — only a word already
+            // scored at least once (STATUS_PRACTICING) is a plain review.
+            let kind = if lemma.status == STATUS_NEW {
+                crate::session::WarmupKind::New
+            } else {
+                crate::session::WarmupKind::Review
+            };
             let item = match by_key.get(&key) {
                 Some(raw) => {
                     let translation = non_empty(raw.translation.clone())
@@ -261,6 +273,7 @@ pub fn match_warmup_items(
                             .or_else(|| lemma.cefr_level.clone()),
                         translation,
                         example: non_empty(raw.example.clone()),
+                        kind,
                     }
                 }
                 None => crate::session::WarmupItem {
@@ -270,6 +283,7 @@ pub fn match_warmup_items(
                     cefr_level: lemma.cefr_level.clone(),
                     translation: lemma.translation.clone(),
                     example: None,
+                    kind,
                 },
             };
             if item.translation.is_empty() {
@@ -281,6 +295,65 @@ pub fn match_warmup_items(
         // Cap cards, not candidate lemmas: a translation-less lemma must not
         // eat a slot that a later translated lemma could have filled.
         .take(MAX_WARMUP_ITEMS)
+        .collect()
+}
+
+/// Builds warm-up preview cards for genuinely new words: content words the
+/// LLM reports using in the session's exercises (`raw`, the `"vocabulary"`
+/// array from `Exercises`) that have no `Lemma` row at all yet in
+/// `existing_lemmas`, regardless of that lemma's status — a word already in
+/// the table (even `STATUS_NEW`) is `match_warmup_items`'s job, not this
+/// one. Same invariants as `match_warmup_items`: the word must actually
+/// appear in a generated exercise (no hallucinated vocabulary) — checked
+/// against `surface` (the inflected form actually used), not `lemma` itself,
+/// since an inflected verb's dictionary headword usually never appears
+/// verbatim (falls back to `lemma` when the LLM omits `surface`) — and
+/// non-content POS and empty translations are skipped. Every card is tagged
+/// `WarmupKind::New`.
+pub fn new_word_items(
+    existing_lemmas: &[Lemma],
+    exercises: &[crate::session::Exercise],
+    raw: Vec<crate::llm::parse::RawVocabularyItem>,
+) -> Vec<crate::session::WarmupItem> {
+    use std::collections::HashSet;
+
+    let known_keys: HashSet<String> = existing_lemmas
+        .iter()
+        .map(|l| normalize_key(&l.lemma))
+        .collect();
+    let tokens = exercise_tokens(exercises);
+
+    let mut seen_keys: HashSet<String> = HashSet::new();
+    raw.into_iter()
+        .filter_map(|item| {
+            let key = normalize_key(item.lemma.trim());
+            if key.is_empty() || known_keys.contains(&key) || !seen_keys.insert(key.clone()) {
+                return None;
+            }
+            let pos = item.pos.clone().unwrap_or_default();
+            if !is_content_pos(&pos) {
+                return None;
+            }
+            let surface_key = normalize_key(item.surface.trim());
+            let appears = if surface_key.is_empty() {
+                tokens.contains(&key)
+            } else {
+                tokens.contains(&surface_key)
+            };
+            if !appears {
+                return None;
+            }
+            let translation = non_empty(item.translation)?;
+            Some(crate::session::WarmupItem {
+                lemma_id: None,
+                lemma: item.lemma,
+                pos: non_empty(item.pos),
+                cefr_level: non_empty(item.cefr_level),
+                translation,
+                example: None,
+                kind: crate::session::WarmupKind::New,
+            })
+        })
         .collect()
 }
 
@@ -1028,5 +1101,117 @@ mod tests {
         assert_eq!(items.len(), MAX_WARMUP_ITEMS);
         assert_eq!(items[0].lemma, "w1");
         assert_eq!(items[MAX_WARMUP_ITEMS - 1].lemma, "w8");
+    }
+
+    #[test]
+    fn match_warmup_items_tags_new_status_as_new() {
+        let forced = vec![forced_lemma("es-comer", "comer", "есть")];
+        // forced_lemma defaults status to STATUS_NEW (0).
+        let items = match_warmup_items(&forced, &[], &[], vec![raw_warmup("comer", None, None)]);
+        assert_eq!(items[0].kind, crate::session::WarmupKind::New);
+    }
+
+    #[test]
+    fn match_warmup_items_tags_practicing_status_as_review() {
+        let mut lemma = forced_lemma("es-comer", "comer", "есть");
+        lemma.status = STATUS_PRACTICING;
+        lemma.mastery = 20.0;
+        let items = match_warmup_items(&[lemma], &[], &[], vec![raw_warmup("comer", None, None)]);
+        assert_eq!(items[0].kind, crate::session::WarmupKind::Review);
+    }
+
+    // --- new_word_items ---
+
+    fn raw_vocabulary(
+        lemma: &str,
+        surface: &str,
+        pos: &str,
+        translation: Option<&str>,
+    ) -> crate::llm::parse::RawVocabularyItem {
+        crate::llm::parse::RawVocabularyItem {
+            lemma: lemma.to_string(),
+            surface: surface.to_string(),
+            pos: Some(pos.to_string()),
+            cefr_level: None,
+            translation: translation.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn new_word_items_excludes_existing_lemmas() {
+        let existing = vec![forced_lemma("es-comer", "comer", "есть")];
+        // "comer" appears via its exact headword form here, so the surface
+        // check wouldn't be what excludes it — the existing-lemma check is.
+        let exercises = vec![exercise("Quiero comer y beber.")];
+        let raw = vec![
+            raw_vocabulary("comer", "comer", "VERB", Some("кушать")),
+            raw_vocabulary("beber", "beber", "VERB", Some("пить")),
+        ];
+        let items = new_word_items(&existing, &exercises, raw);
+        // "comer" already has a Lemma row (any status) — not new, even
+        // though the LLM reported it too; only "beber" is genuinely new.
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma, "beber");
+        assert_eq!(items[0].lemma_id, None);
+        assert_eq!(items[0].kind, crate::session::WarmupKind::New);
+    }
+
+    #[test]
+    fn new_word_items_matches_inflected_surface_not_headword() {
+        // The dictionary headword "comer" never appears verbatim — only its
+        // inflected surface "como" does. Matching must go through `surface`.
+        let exercises = vec![exercise("Como pan cada día.")];
+        let raw = vec![raw_vocabulary("comer", "como", "VERB", Some("кушать"))];
+        let items = new_word_items(&[], &exercises, raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma, "comer");
+    }
+
+    #[test]
+    fn new_word_items_falls_back_to_lemma_when_surface_missing() {
+        let exercises = vec![exercise("Quiero comer pan.")];
+        let raw = vec![raw_vocabulary("comer", "", "VERB", Some("кушать"))];
+        let items = new_word_items(&[], &exercises, raw);
+        assert_eq!(items.len(), 1);
+    }
+
+    #[test]
+    fn new_word_items_excludes_function_pos() {
+        let exercises = vec![exercise("Quiero comer con ella.")];
+        let raw = vec![
+            raw_vocabulary("comer", "comer", "VERB", Some("кушать")),
+            raw_vocabulary("con", "con", "ADP", Some("с")),
+        ];
+        let items = new_word_items(&[], &exercises, raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma, "comer");
+    }
+
+    #[test]
+    fn new_word_items_requires_translation() {
+        let exercises = vec![exercise("Quiero comer pan.")];
+        let raw = vec![raw_vocabulary("comer", "comer", "VERB", None)];
+        assert!(new_word_items(&[], &exercises, raw).is_empty());
+    }
+
+    #[test]
+    fn new_word_items_requires_appearance_in_exercises() {
+        // The LLM claims "beber" but it never made it into any sentence —
+        // same anti-hallucination guard as match_warmup_items.
+        let exercises = vec![exercise("Quiero comer pan.")];
+        let raw = vec![raw_vocabulary("beber", "bebo", "VERB", Some("пить"))];
+        assert!(new_word_items(&[], &exercises, raw).is_empty());
+    }
+
+    #[test]
+    fn new_word_items_dedups_repeated_lemmas() {
+        let exercises = vec![exercise("Como pan y como fruta.")];
+        let raw = vec![
+            raw_vocabulary("comer", "como", "VERB", Some("кушать")),
+            raw_vocabulary("comer", "como", "VERB", Some("есть (дубль)")),
+        ];
+        let items = new_word_items(&[], &exercises, raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].translation, "кушать");
     }
 }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -14,6 +14,7 @@ futures-util = { workspace = true }
 chrono = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/db/src/lemmas.rs
+++ b/crates/db/src/lemmas.rs
@@ -6,6 +6,7 @@ use futures_util::stream::TryStreamExt;
 use lancedb::Connection;
 use lancedb::database::CreateTableMode;
 use lancedb::query::{ExecutableQuery, QueryBase};
+use rand::seq::SliceRandom;
 
 use crate::util::eq_predicate;
 use open_course_core::curriculum::cefr_to_numeric;
@@ -19,6 +20,22 @@ pub const TABLE_NAME: &str = "lemmas";
 /// `core::session::MASTERY_THRESHOLD`; the constant is deliberately
 /// duplicated here to keep the db layer self-contained.
 const LEMMA_MASTERY_THRESHOLD: f64 = 50.0;
+
+/// How much wider than `n` the rotation window is: `weakest` samples `n`
+/// lemmas at random from the `n * ROTATION_POOL_FACTOR` weakest qualifying
+/// candidates instead of always returning the same top `n`. A lemma the LLM
+/// keeps skipping never updates `last_seen`, so without this it would tie at
+/// the very top of the ranking forever and get forced every session.
+const ROTATION_POOL_FACTOR: usize = 3;
+
+/// Windows `qualified` (already sorted weakest-first) down to the rotation
+/// pool a caller should sample `n` lemmas from. Pure and separate from the
+/// shuffle so the windowing math is unit-testable without asserting on
+/// randomness.
+fn rotation_pool(qualified: Vec<Lemma>, n: usize) -> Vec<Lemma> {
+    let pool_size = (n * ROTATION_POOL_FACTOR).min(qualified.len());
+    qualified.into_iter().take(pool_size).collect()
+}
 
 pub(crate) fn schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
@@ -171,6 +188,11 @@ impl LemmasTable {
     /// lemmas with a CEFR level more than one step above the frontier sort
     /// after everything else but are never excluded. Lemmas without a level
     /// (or when `frontier_cefr` is `None`) keep the plain weakness order.
+    ///
+    /// The final `n` are sampled at random from the `n * ROTATION_POOL_FACTOR`
+    /// weakest qualifying candidates (see `rotation_pool`) rather than always
+    /// being the literal weakest `n`, so the same handful of words aren't
+    /// forced into every session.
     pub fn weakest(lemmas: &[Lemma], n: usize, frontier_cefr: Option<i32>) -> Vec<Lemma> {
         // 0 = at/just above the frontier or unknown level; 1 = further ahead.
         let level_group = |l: &Lemma| match (frontier_cefr, l.cefr_level.as_deref()) {
@@ -208,8 +230,38 @@ impl LemmasTable {
                 (None, None) => std::cmp::Ordering::Equal,
             }
         });
-        qualified.into_iter().take(n).collect()
+        // Rotate within each frontier level-group separately, never across
+        // them: `qualified` is already sorted group-0-then-group-1, so the
+        // first index where the group flips to 1 is the boundary. Group 1
+        // (deferred) only fills slots group 0 couldn't — mixing the two into
+        // one shuffle pool would let a deferred word leak ahead of an
+        // available level-appropriate one purely by luck of the shuffle,
+        // defeating the frontier soft-preference.
+        let boundary = qualified
+            .iter()
+            .position(|l| level_group(l) == 1)
+            .unwrap_or(qualified.len());
+        let far = qualified.split_off(boundary);
+        let mut result = rotate_within_group(qualified, n);
+        if result.len() < n {
+            result.extend(rotate_within_group(far, n - result.len()));
+        }
+        result
     }
+}
+
+/// Samples up to `n` lemmas at random from the `n * ROTATION_POOL_FACTOR`
+/// weakest of `qualified` (already sorted weakest-first). Returns
+/// `qualified` untouched, in order, when it's no wider than `n` — no
+/// rotation choice to make, so the meaningful weakest-first order (e.g.
+/// warm-up card order) is preserved rather than scrambled for nothing.
+fn rotate_within_group(qualified: Vec<Lemma>, n: usize) -> Vec<Lemma> {
+    let mut pool = rotation_pool(qualified, n);
+    if pool.len() <= n {
+        return pool;
+    }
+    pool.shuffle(&mut rand::rng());
+    pool.into_iter().take(n).collect()
 }
 
 pub(crate) fn lemma_to_record_batch(lemma: &Lemma) -> Result<RecordBatch> {
@@ -427,6 +479,96 @@ mod tests {
         let weak = LemmasTable::weakest(&lemmas, 4, None);
         let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();
         assert_eq!(ids, ["noun", "no-pos"]);
+    }
+
+    #[test]
+    fn rotation_pool_returns_everything_when_qualified_fits() {
+        let lemmas: Vec<Lemma> = (0..3)
+            .map(|i| make_lemma(&format!("w{i}"), STATUS_NEW, 10.0, None))
+            .collect();
+        assert_eq!(rotation_pool(lemmas.clone(), 5).len(), 3);
+        assert_eq!(rotation_pool(lemmas, 3).len(), 3);
+    }
+
+    #[test]
+    fn rotation_pool_bounds_at_n_times_factor() {
+        let lemmas: Vec<Lemma> = (0..20)
+            .map(|i| make_lemma(&format!("w{i}"), STATUS_NEW, 10.0, None))
+            .collect();
+        // n=5 -> pool capped at 5 * ROTATION_POOL_FACTOR (3) = 15, not 20.
+        assert_eq!(rotation_pool(lemmas, 5).len(), 15);
+    }
+
+    #[test]
+    fn weakest_does_not_shuffle_when_pool_fits_n() {
+        // Exactly as many qualifying lemmas as requested: no rotation choice
+        // to make, so the weakest-first order must be preserved exactly.
+        let lemmas = vec![
+            make_lemma("weakest", STATUS_NEW, 5.0, None),
+            make_lemma("middle", STATUS_NEW, 15.0, None),
+            make_lemma("strongest", STATUS_PRACTICING, 25.0, None),
+        ];
+        let weak = LemmasTable::weakest(&lemmas, 3, None);
+        let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, ["weakest", "middle", "strongest"]);
+    }
+
+    #[test]
+    fn weakest_rotation_samples_from_pool_without_exceeding_it() {
+        // 20 equally-weak candidates, only 5 forced: every result must come
+        // from the top-15 rotation pool (5 * ROTATION_POOL_FACTOR), and the
+        // literal top-5 must not be the only ones ever chosen. Run several
+        // times so a single unlucky shuffle doesn't fail the assertion.
+        let lemmas: Vec<Lemma> = (0..20)
+            .map(|i| make_lemma(&format!("w{i}"), STATUS_NEW, 10.0, None))
+            .collect();
+        let pool_ids: std::collections::HashSet<String> =
+            (0..15).map(|i| format!("w{i}")).collect();
+
+        let mut saw_outside_top_5 = false;
+        for _ in 0..20 {
+            let weak = LemmasTable::weakest(&lemmas, 5, None);
+            assert_eq!(weak.len(), 5);
+            for lemma in &weak {
+                assert!(
+                    pool_ids.contains(&lemma.id),
+                    "{} is outside the rotation pool",
+                    lemma.id
+                );
+            }
+            if weak
+                .iter()
+                .any(|l| !["w0", "w1", "w2", "w3", "w4"].contains(&l.id.as_str()))
+            {
+                saw_outside_top_5 = true;
+            }
+        }
+        assert!(
+            saw_outside_top_5,
+            "rotation never picked a lemma outside the literal top 5 across 20 tries"
+        );
+    }
+
+    #[test]
+    fn weakest_rotation_never_crosses_frontier_group_boundary() {
+        // 10 level-appropriate candidates plus one deferred (far-above-
+        // frontier) lemma, only 3 requested: the deferred lemma must never
+        // be chosen while 10 appropriate ones are available, across many
+        // shuffles.
+        let mut ahead = make_lemma("ahead", STATUS_NEW, 10.0, None);
+        ahead.cefr_level = Some("C1".to_string());
+        let mut lemmas: Vec<Lemma> = (0..10)
+            .map(|i| make_lemma(&format!("w{i}"), STATUS_NEW, 10.0, None))
+            .collect();
+        lemmas.push(ahead);
+
+        for _ in 0..20 {
+            let weak = LemmasTable::weakest(&lemmas, 3, Some(2));
+            assert!(
+                weak.iter().all(|l| l.id != "ahead"),
+                "deferred lemma leaked into the result ahead of an available one"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/service/src/session.rs
+++ b/crates/service/src/session.rs
@@ -15,7 +15,7 @@ use open_course_core::session::{
     NextSessionTopic, pick_next_session_topic, recent_success_rate, select_side_topics,
     unique_topic_ids,
 };
-use open_course_core::vocabulary::{Form, Lemma, match_warmup_items};
+use open_course_core::vocabulary::{Form, Lemma, match_warmup_items, new_word_items};
 use open_course_db::Database;
 use open_course_db::apply::apply_analysis_to_db;
 use open_course_db::curriculum::{Topic, cefr_to_numeric};
@@ -44,6 +44,10 @@ pub struct ExercisePreparation {
     /// Known inflected forms of the forced lemmas, used to match warm-up
     /// cards against the words the exercises actually contain.
     pub forced_forms: Vec<Form>,
+    /// The learner's full existing vocabulary (all statuses, this pair's
+    /// target language) — used to tell genuinely new words (previewed via
+    /// `vocabulary::new_word_items`) apart from ones already in the table.
+    pub existing_lemmas: Vec<Lemma>,
 }
 
 /// Reads progress, learning items and history from the database, picks side
@@ -89,7 +93,11 @@ pub async fn prepare_exercises(
         .into_iter()
         .filter(|li| li.target_lang == profile.target_language)
         .collect();
-    let forced_learning_items = LearningItemsTable::weakest(&learning_items, 3);
+    // Forced counts scale to the session's batch size so a small batch
+    // doesn't get crowded out by forced review vocabulary, leaving room for
+    // organic/curriculum content.
+    let batch_size = config.preferences.batch_size as usize;
+    let forced_learning_items = LearningItemsTable::weakest(&learning_items, batch_size.min(3));
     let forced_learning_item_ids = forced_learning_items
         .iter()
         .map(|li| li.id.clone())
@@ -108,7 +116,7 @@ pub async fn prepare_exercises(
     // core::session::topic_selection, which has no public helper). `None`
     // when no level information is available.
     let frontier_cefr = frontier_cefr(all_topics, &progress);
-    let forced_vocabulary = LemmasTable::weakest(&lemmas, 5, frontier_cefr);
+    let forced_vocabulary = LemmasTable::weakest(&lemmas, batch_size.min(5), frontier_cefr);
     let forced_lemma_ids: Vec<String> = forced_vocabulary.iter().map(|l| l.id.clone()).collect();
     let forced_forms: Vec<Form> = db
         .forms()
@@ -139,28 +147,39 @@ pub async fn prepare_exercises(
         forced_lemma_ids,
         forced_lemmas: forced_vocabulary,
         forced_forms,
+        existing_lemmas: lemmas,
     })
 }
 
-/// Runs the exercise-generation LLM call for a prepared prompt and matches
-/// the returned warm-up entries against the session's forced lemmas, keeping
-/// only cards for words the generated exercises actually contain.
+/// Runs the exercise-generation LLM call for a prepared prompt and builds
+/// the warm-up phase from two sources: the returned `warmup` entries matched
+/// against the session's forced lemmas (review cards, only for words the
+/// generated exercises actually contain), and genuinely new words the LLM
+/// reports using that aren't in `existing_lemmas` yet (preview cards, see
+/// `vocabulary::new_word_items`). Combined and capped at `MAX_WARMUP_ITEMS`.
 pub async fn generate_session_exercises(
     config: &OpenCourseConfig,
     prompt: &str,
     forced_lemmas: &[Lemma],
     forced_forms: &[Form],
+    existing_lemmas: &[Lemma],
     tx: &mpsc::Sender<LlmResult>,
     data_dir: Option<&Path>,
 ) -> Result<GeneratedSession> {
     let model = create_llm_model(config)?;
     let parsed = generate_exercises(model.as_ref(), prompt, Some(tx), data_dir).await?;
-    let warmup = match_warmup_items(
+    let mut warmup = match_warmup_items(
         forced_lemmas,
         forced_forms,
         &parsed.exercises,
         parsed.warmup,
     );
+    warmup.extend(new_word_items(
+        existing_lemmas,
+        &parsed.exercises,
+        parsed.vocabulary,
+    ));
+    warmup.truncate(open_course_core::vocabulary::MAX_WARMUP_ITEMS);
     Ok(GeneratedSession {
         exercises: parsed.exercises,
         warmup,


### PR DESCRIPTION
### Description
Before a session, the warm-up phase only reinforced words already in the
learner's vocabulary table (forced weak/unevaluated lemmas). Genuinely new
words — never extracted into the `lemmas` table — could never appear,
because vocabulary extraction only happened at analysis time, after the
student had already answered. Separately, the forced-word selection had no
rotation: a word the LLM kept skipping never updated `last_seen`, so it tied
at the top of the ranking forever and got forced every single session.

### Changes Made
- `build_exercise_prompt` now unconditionally asks the LLM for a `"vocabulary"`
  array (lemma, surface, pos, cefrLevel, translation) for every content word
  used in the generated exercises — independent of forced vocabulary.
- New `vocabulary::new_word_items`: diffs that array against the learner's
  existing lemmas, keeps only words with no `Lemma` row at all, validated
  against the exercise text via the reported `surface` form (an inflected
  verb's headword rarely appears verbatim — matching the analysis prompt's
  `usedVocabulary.surface` pattern), non-content POS and missing translations
  filtered out. Nothing is persisted — same "never persisted" contract as the
  existing warm-up.
- `WarmupItem` gains a `kind: Review | New` field. `match_warmup_items` tags a
  card `New` when the underlying lemma is `STATUS_NEW` (never evaluated) —
  same priority as a genuinely new word — and `Review` otherwise.
- `LemmasTable::weakest` rotation: instead of always returning the literal
  weakest `n`, it samples `n` at random from the `n * 3` weakest qualifying
  candidates, so the same handful of words aren't forced into every session.
  Rotation is scoped within each frontier CEFR level-group so a deferred
  above-level word can never leak ahead of an available level-appropriate one.
- Forced counts (`weakest(..., 5, ...)` / learning items `3`) now scale to
  `batch_size` (2–5) instead of being fixed, so a small batch doesn't get
  crowded out by forced review vocabulary.
- CLI: a "NEW" badge on warm-up cards tagged `WarmupKind::New`.

### Related Issues
None.

### Additional Notes
- `open-course-server`'s `sessions/flow.rs` is a hand-written parity port of
  this flow and needs the equivalent change; follow-up PR once this merges
  and the release tag publishes (server pins `open-course-core` by tag in
  its production Dockerfile).
- `open-course-web` needs a `kind` field on its `WarmupItem` type and a
  badge; independent PR, no merge-order dependency (optional field,
  backward/forward compatible).
- Adds `rand` as a workspace dependency (already used elsewhere for the
  server side of this feature).

### PR Checklist
- [x] Code follows project coding guidelines.
- [x] Documentation reflects the changes made.
- [x] I have already covered the unit testing.