### PR TITLE
fix(vocabulary): track conjunctions as content vocabulary

### DIFF
--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -177,8 +177,8 @@ pub fn build_exercise_prompt(
 
     let vocabulary_extraction_note = format!(
         "\nIn addition to the exercises{warmup_ref}, return a top-level \"vocabulary\" array \
-         listing every CONTENT word (NOUN, VERB, ADJ, ADV, PROPN only — skip articles, \
-         prepositions, pronouns, auxiliaries, conjunctions) that appears in the target sentences \
+         listing every CONTENT word (NOUN, VERB, ADJ, ADV, PROPN, SCONJ, CCONJ only — skip \
+         articles, prepositions, pronouns, auxiliaries) that appears in the target sentences \
          you just wrote, one entry per distinct word, each with these fields:\n\
          - lemma: the dictionary headword\n\
          - surface: the exact inflected form as it appears in the sentence\n\
@@ -296,7 +296,7 @@ New topic rules (CRITICAL):
 - If the student answered in the wrong language (e.g. a language other than {target}), mark the affected words as errors, give the correct {target} translation in the explanation, and do NOT create newTopics for that other language.
 
 Vocabulary extraction rules (usedVocabulary):
-- For each sentence, list the CONTENT words (NOUN, VERB, ADJ, ADV, PROPN only) in `usedVocabulary`. Skip function words (articles, prepositions, pronouns, auxiliaries, conjunctions).
+- For each sentence, list the CONTENT words (NOUN, VERB, ADJ, ADV, PROPN, SCONJ, CCONJ only) in `usedVocabulary`. Skip function words (articles, prepositions, pronouns, auxiliaries).
 - Words from the expected translation: side "target", no spellingOk/usageOk fields.
 - Words from the student's translation: side "student", WITH spellingOk and usageOk.
 - spellingOk is false ONLY for a real misspelling; missing accents, diacritics, punctuation, or capitalization do NOT make spellingOk false.

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -12,12 +12,23 @@ use crate::learning_items::{significant_words, slugify, text_contains_any_word};
 use crate::session::{COMPLETED_THRESHOLD, GrammarError, MASTERY_THRESHOLD, SentenceAnalysis};
 
 /// Content-word POS tags eligible for forced vocabulary practice.
-pub const CONTENT_POS: &[&str] = &["NOUN", "VERB", "ADJ", "ADV", "PROPN"];
+///
+/// Conjunctions (SCONJ/CCONJ) count as content: discourse markers like
+/// "although", "because", "however", "therefore" are a small, semantically
+/// rich closed class students genuinely need to learn word by word — no
+/// different from the conjunctive adverbs ("however", "moreover") already
+/// tracked here as ADV. Excluding them meant a topic like "Discourse
+/// Markers and Connectors" could track literally none of its own target
+/// vocabulary, since most of it is SCONJ/CCONJ.
+pub const CONTENT_POS: &[&str] = &["NOUN", "VERB", "ADJ", "ADV", "PROPN", "SCONJ", "CCONJ"];
 
 /// Function-word POS tags (the closed UD set) excluded from forced
-/// vocabulary practice.
+/// vocabulary practice: purely grammatical scaffolding (prepositions,
+/// determiners, pronouns, auxiliaries, particles, interjections,
+/// punctuation, symbols) rather than words with independent lexical
+/// meaning.
 const FUNCTION_POS: &[&str] = &[
-    "ADP", "AUX", "CCONJ", "DET", "INTJ", "PART", "PRON", "PUNCT", "SCONJ", "SYM", "X",
+    "ADP", "AUX", "DET", "INTJ", "PART", "PRON", "PUNCT", "SYM", "X",
 ];
 
 /// Whether a lemma with this POS tag is a content-word candidate for
@@ -575,10 +586,15 @@ mod tests {
 
     #[test]
     fn is_content_pos_filters_function_words() {
-        for pos in ["NOUN", "verb", "Adj", "ADV", "PROPN"] {
+        // Conjunctions count as content: discourse markers ("although",
+        // "however", "therefore") are lexical items worth tracking, not
+        // grammatical scaffolding.
+        for pos in [
+            "NOUN", "verb", "Adj", "ADV", "PROPN", "SCONJ", "CCONJ", "sconj",
+        ] {
             assert!(is_content_pos(pos), "{pos} should be content");
         }
-        for pos in ["PART", "ADP", "DET", "PRON", "AUX", "CCONJ", "PUNCT"] {
+        for pos in ["PART", "ADP", "DET", "PRON", "AUX", "PUNCT"] {
             assert!(!is_content_pos(pos), "{pos} should be function");
         }
         // Empty or unrecognized tags are lazily accepted.
@@ -1185,6 +1201,18 @@ mod tests {
         let items = new_word_items(&[], &exercises, raw);
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].lemma, "comer");
+    }
+
+    #[test]
+    fn new_word_items_tracks_discourse_marker_conjunctions() {
+        // Regression: "although" (SCONJ) must be previewable as a new word,
+        // same as any noun/verb — only truly grammatical POS (ADP, DET, ...)
+        // are excluded.
+        let exercises = vec![exercise("Aunque llueve, salgo.")];
+        let raw = vec![raw_vocabulary("aunque", "aunque", "SCONJ", Some("хотя"))];
+        let items = new_word_items(&[], &exercises, raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma, "aunque");
     }
 
     #[test]

--- a/crates/db/src/lemmas.rs
+++ b/crates/db/src/lemmas.rs
@@ -482,6 +482,23 @@ mod tests {
     }
 
     #[test]
+    fn weakest_tracks_discourse_marker_conjunctions() {
+        // Regression: a topic like "Discourse Markers and Connectors" is
+        // mostly SCONJ/CCONJ vocabulary ("although", "but"). These must be
+        // selectable for review, not silently filtered out as function
+        // words the way prepositions/determiners are.
+        let mut although = make_lemma("although", STATUS_PRACTICING, 20.0, None);
+        although.pos = "SCONJ".to_string();
+        let mut but = make_lemma("but", STATUS_NEW, 10.0, None);
+        but.pos = "CCONJ".to_string();
+        let lemmas = vec![although, but];
+
+        let weak = LemmasTable::weakest(&lemmas, 4, None);
+        let ids: Vec<&str> = weak.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, ["but", "although"]);
+    }
+
+    #[test]
     fn rotation_pool_returns_everything_when_qualified_fits() {
         let lemmas: Vec<Lemma> = (0..3)
             .map(|i| make_lemma(&format!("w{i}"), STATUS_NEW, 10.0, None))


### PR DESCRIPTION
### Description
Starting the "Discourse Markers and Connectors" topic (or any topic centered on connectors) produced zero warm-up cards, and specific words like "although" never came up even though they were already tracked, studied, and below mastery. Root cause: `is_content_pos` (the filter that decides which vocabulary is eligible for review/preview) classified `SCONJ`/`CCONJ` (subordinating/coordinating conjunctions — "although", "because", "but", "so"...) as function words, in the same bucket as prepositions and determiners. That filter gates:
- `weakest`/`weakest_lemmas` (which unmastered words get forced into review) — identical logic in the CLI and the server.
- `new_word_items` (which newly-used words get previewed as new).

On top of that, the exercise-generation and analysis prompts explicitly told the LLM to skip conjunctions when reporting used vocabulary, so even a relaxed filter wouldn't have helped without also updating the prompt.

Since warm-up cards are built exclusively from vocabulary (not from grammar/learning-item topics), a topic whose core content is discourse markers had essentially its entire target vocabulary invisible to the system on every layer at once.

Conjunctive adverbs like "however"/"moreover" (tagged `ADV`) were never affected by this — only the `SCONJ`/`CCONJ` half of the same semantic class was excluded, which is the inconsistency this fixes.

### Changes Made
- `crates/core/src/vocabulary.rs`: moved `SCONJ`/`CCONJ` from `FUNCTION_POS` to `CONTENT_POS`. Genuinely grammatical POS (prepositions, determiners, pronouns, auxiliaries, particles, interjections, punctuation, symbols) stay excluded.
- `crates/core/src/llm/prompts.rs`: updated the two vocabulary-extraction instructions (exercise generation + analysis) to stop telling the model to skip conjunctions, and to list `SCONJ`/`CCONJ` alongside the other content POS tags.
- Added regression tests: `weakest_tracks_discourse_marker_conjunctions` (db), `new_word_items_tracks_discourse_marker_conjunctions` (core), updated `is_content_pos_filters_function_words`.

`open-course-server` needs no separate change — it consumes these exact functions/prompts from `open-course-core` (its own `weakest_lemmas` in `flow.rs` is a documented port of the same logic and reuses `is_content_pos` directly), so this fixes both the CLI and the web app once the server's `CORE_TAG` is bumped to the release containing this fix.

### Related Issues
None filed — found via user report (empty warm-up on topic start, "although" missing despite being tracked).

### Additional Notes
Basic conjunctions ("and", "if") become trackable vocabulary for every pair now, not just connector-focused topics. Not expected to add noise: the existing `mastery < 50` gate already self-limits this the same way it does for any other easy, quickly-mastered word — once a student uses "and"/"if" correctly a few times, it drops out of the weak-word pool like any noun or verb would.

Per the required release order: this needs a new CLI tag before `open-course-server`'s `CORE_TAG` can be bumped to pick it up.

### PR Checklist
- [x] Code follows project coding guidelines.
- [x] Documentation reflects the changes made (doc comments updated).
- [x] I have already covered the unit testing.
