### PR TITLE
feat(core): demand native/target language separation in exercise prompt

### DIFF
--- a/crates/cli/src/app/llm_results.rs
+++ b/crates/cli/src/app/llm_results.rs
@@ -173,7 +173,11 @@ fn handle_exercises(state: &mut AppState, res: Result<GeneratedSession>) {
             state.session.cursor = 0;
         }
         Err(e) => {
-            state.toast = Some(Toast::error(e.to_string()));
+            // A toast disappears after a few seconds and leaves the user on
+            // the topic-selection screen with no way to retry; show a
+            // persistent error screen with retry/settings/home instead.
+            state.session.generation_error = Some(e.to_string());
+            state.session.mode = session::Mode::Error;
         }
     }
 }

--- a/crates/cli/src/app/mod.rs
+++ b/crates/cli/src/app/mod.rs
@@ -712,4 +712,28 @@ mod tests {
         state.view = View::Session;
         assert!(!view_content_overflows(&state));
     }
+
+    #[tokio::test]
+    async fn failed_exercise_generation_shows_error_mode() {
+        // A generation failure must surface as a persistent error screen
+        // (retry/settings/home), not a disappearing toast.
+        let mut state = test_state().await;
+        state.view = View::Session;
+        state.session.loading = true;
+
+        apply_llm_result(
+            &mut state,
+            LlmResult::Exercises(Err(open_course_core::error::AppError::Config(
+                "boom".to_string(),
+            ))),
+        )
+        .await;
+
+        assert_eq!(state.session.mode, session::Mode::Error);
+        assert_eq!(
+            state.session.generation_error.as_deref(),
+            Some("Config error: boom")
+        );
+        assert!(state.toast.is_none());
+    }
 }

--- a/crates/cli/src/ui/help.rs
+++ b/crates/cli/src/ui/help.rs
@@ -197,6 +197,13 @@ fn session_groups(state: &AppState, labels: ReportLabels, common: CommonLabels) 
             ),
             group(common.group_exit, vec![entry("Esc", labels.back)]),
         ],
+        SessionMode::Error => vec![
+            group(
+                common.group_actions,
+                vec![entry("r", labels.retry), entry("p", labels.settings)],
+            ),
+            group(common.group_exit, vec![entry("Esc", common.dashboard)]),
+        ],
     }
 }
 

--- a/crates/cli/src/ui/views/session.rs
+++ b/crates/cli/src/ui/views/session.rs
@@ -7,10 +7,10 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wid
 use crate::app::{AppState, LlmResult, View};
 use crate::ui::colors;
 use crate::ui::labels::{get_common_labels, get_report_labels, native_language_code};
-use crate::ui::views::{curriculum, settings};
 use crate::ui::views::utils::{
     screen_chunks, select_next_wrapping, select_previous_wrapping, wrapped_input_text,
 };
+use crate::ui::views::{curriculum, settings};
 use crate::ui::widgets::{Card, build_footer_wrapped, error_lines};
 use open_course_core::error::{AppError, Result};
 use open_course_core::session::{MentorSession, NextSessionTopic, WarmupItem, WarmupKind};

--- a/crates/cli/src/ui/views/session.rs
+++ b/crates/cli/src/ui/views/session.rs
@@ -7,22 +7,25 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wid
 use crate::app::{AppState, LlmResult, View};
 use crate::ui::colors;
 use crate::ui::labels::{get_common_labels, get_report_labels, native_language_code};
-use crate::ui::views::curriculum;
+use crate::ui::views::{curriculum, settings};
 use crate::ui::views::utils::{
     screen_chunks, select_next_wrapping, select_previous_wrapping, wrapped_input_text,
 };
-use crate::ui::widgets::{Card, build_footer_wrapped};
+use crate::ui::widgets::{Card, build_footer_wrapped, error_lines};
 use open_course_core::error::{AppError, Result};
 use open_course_core::session::{MentorSession, NextSessionTopic, WarmupItem, WarmupKind};
 use open_course_db::curriculum::Topic;
 use open_course_llm::pipeline::log_debug_event;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum Mode {
     #[default]
     TopicSelection,
     WarmUp,
     Practicing,
+    /// Exercise generation failed: show the error with retry/settings/home
+    /// actions instead of silently returning to topic selection.
+    Error,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -45,6 +48,8 @@ pub struct SessionState {
     pub warmup_index: usize,
     /// Whether the current warm-up card's translation is visible.
     pub warmup_revealed: bool,
+    /// Set when exercise generation fails; shown in `Mode::Error`.
+    pub generation_error: Option<String>,
 }
 
 impl SessionState {
@@ -132,6 +137,14 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         Mode::Practicing => {
             build_footer_wrapped(&[("Enter", labels.submit), ("Esc", labels.back)], width)
         }
+        Mode::Error => build_footer_wrapped(
+            &[
+                ("r", labels.retry),
+                ("p", labels.settings),
+                ("Esc", common.dashboard),
+            ],
+            width,
+        ),
     };
     let chunks = screen_chunks(area, footer_text.lines().count() as u16);
 
@@ -259,6 +272,19 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                 chunks[2],
             );
         }
+        Mode::Error => {
+            let message = state.session.generation_error.as_deref().unwrap_or("");
+            let mut card = Card::new(labels.error.to_string());
+            for line in error_lines(message) {
+                card = card.line(line);
+            }
+            frame.render_widget(card, chunks[0]);
+
+            frame.render_widget(
+                Paragraph::new(footer_text.clone()).style(Style::default().fg(Color::DarkGray)),
+                chunks[2],
+            );
+        }
     }
 }
 
@@ -267,7 +293,36 @@ pub async fn handle_key(state: &mut AppState, code: KeyCode) -> Result<()> {
         Mode::TopicSelection => handle_topic_selection(state, code).await,
         Mode::WarmUp => handle_warmup(state, code).await,
         Mode::Practicing => handle_practicing(state, code).await,
+        Mode::Error => handle_generation_error(state, code).await,
     }
+}
+
+/// Generation-error screen: `r` retries with the same target topic, `p` opens
+/// the LLM provider settings, `Esc` returns to the dashboard. Any other key
+/// keeps the error visible (unlike the global error box, which dismisses on
+/// any key).
+async fn handle_generation_error(state: &mut AppState, code: KeyCode) -> Result<()> {
+    match code {
+        KeyCode::Char('r') => {
+            state.session.generation_error = None;
+            state.session.mode = Mode::TopicSelection;
+            if let Some(topic_id) = state.session.target_topic_id.clone() {
+                start_exercises_for_topic(state, &topic_id, None).await?;
+            }
+        }
+        KeyCode::Char('p') => {
+            state.session.generation_error = None;
+            state.session.mode = Mode::TopicSelection;
+            state.settings.section = settings::Section::Provider;
+            state.view = View::Settings;
+        }
+        KeyCode::Esc => {
+            reset_session(&mut state.session);
+            state.view = View::Dashboard;
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 /// Warm-up phase: forward-only flashcards. Enter (or Space) reveals the
@@ -639,6 +694,7 @@ pub(crate) fn reset_session(session: &mut SessionState) {
     session.warmup_items.clear();
     session.warmup_index = 0;
     session.warmup_revealed = false;
+    session.generation_error = None;
 }
 
 #[cfg(test)]

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -212,15 +212,17 @@ The {count} sentences should form a short coherent dialogue or mini-story while 
 
 For each exercise output a JSON object with these fields:
 - id: unique string
-- targetSentence: sentence in {native} for the student to translate
-- expectedTranslation: one natural correct translation in {target}
-- acceptableTranslations: array of 1–3 additional valid translations in {target} that are semantically equivalent but may use different wording, synonyms, or word order. Include only genuinely equivalent variants.
+- targetSentence: sentence in {native} for the student to translate — written ENTIRELY in {native}; every single word must be {native}, never mix in {target} words or phrases
+- expectedTranslation: one natural correct translation in {target}, written ENTIRELY in {target}
+- acceptableTranslations: array of 1–3 additional valid translations in {target}, all written ENTIRELY in {target}, that are semantically equivalent but may use different wording, synonyms, or word order. Include only genuinely equivalent variants.
 - targetTopicIds: array of target topic ids from the list above (use empty array if none apply)
 - sideTopicIds: array of side topic ids from the list above (use empty array if none apply)
 - expectedPatterns: grammar patterns the student should use
 - hint: optional short hint
 
-Output a JSON object with the key \"exercises\" containing an array of the exercise objects.{warmup_output_note}{vocabulary_extraction_note}",
+Output a JSON object with the key \"exercises\" containing an array of the exercise objects.{warmup_output_note}{vocabulary_extraction_note}
+
+CRITICAL: language separation. Each targetSentence must be 100% {native} and each translation (expectedTranslation, acceptableTranslations) must be 100% {target}. Never mix both languages within one sentence. If a sentence would naturally borrow a {target} word, translate that word into {native} instead.",
         native = native_name,
         target = target_name,
         warmup_output_note = if forced_vocabulary.is_empty() {
@@ -750,6 +752,20 @@ mod tests {
         let prompt = build_exercise_prompt(&profile(), &[], &[], &[], &[], &[], 3, 0.8);
         assert!(!prompt.contains("need extra practice"));
         assert!(!prompt.contains("\"warmup\""));
+    }
+
+    #[test]
+    fn exercise_prompt_demands_language_separation() {
+        // Weak models sometimes return a targetSentence that mixes the native
+        // and target languages; the prompt must forbid that explicitly, with
+        // the expanded language names (see `english_name`).
+        let prompt = build_exercise_prompt(&profile(), &[], &[], &[], &[], &[], 3, 0.8);
+        assert!(prompt.contains("written ENTIRELY in Russian"));
+        assert!(prompt.contains("written ENTIRELY in Spanish"));
+        assert!(prompt.contains("CRITICAL: language separation."));
+        assert!(prompt.contains("must be 100% Russian"));
+        assert!(prompt.contains("must be 100% Spanish"));
+        assert!(prompt.contains("Never mix both languages within one sentence"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Generated exercises sometimes come back with a `targetSentence` that mixes the native and target languages, e.g. «Я взял книгу из библиотеки, and after that I'll read it.» The previous instruction was a single soft clause (`sentence in {native} for the student to translate`), which weaker models (DeepSeek etc.) don't reliably follow.

## What

In `build_exercise_prompt` (`crates/core/src/llm/prompts.rs`):

- `targetSentence` / `expectedTranslation` / `acceptableTranslations` field descriptions now state the text is written **ENTIRELY** in the respective language.
- Added an end-of-prompt `CRITICAL: language separation` rule: 100% native in `targetSentence`, 100% target in translations, never mix both languages within one sentence, and translate borrowed target-language words back into the native language.

The prompt is shared: the server calls the same builder via the `open-course-core` dependency (`open-course-server/src/sessions/flow.rs`), so this fixes both CLI and web sessions. Production server deploys pick it up via the Dockerfile `CORE_TAG` bump — not part of this PR.

No runtime mixed-language validation: reliable detection isn't feasible for same-script language pairs, so prompt hardening is the proportionate fix.

## Verification

- `cargo test -p open-course-core` — 93 passed, including a new test asserting the language-separation wording with expanded language names.
- `cargo check` in `open-course-server` against this core — green.