### PR TITLE
feat(llm): support enable_thinking option for OpenAI-compatible providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.15.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/src/ui/views/onboarding/mod.rs
+++ b/crates/cli/src/ui/views/onboarding/mod.rs
@@ -356,6 +356,7 @@ fn build_config_from_onboarding(onboarding: &OnboardingState) -> OpenCourseConfi
         },
         endpoint: None,
         reasoning_effort: None,
+        enable_thinking: None,
     };
 
     let mut config = OpenCourseConfig::new(onboarding.provider, provider_config, profile);

--- a/crates/cli/src/ui/views/settings/provider_setup.rs
+++ b/crates/cli/src/ui/views/settings/provider_setup.rs
@@ -360,6 +360,7 @@ fn ensure_provider_config(config: &mut OpenCourseConfig, provider_id: ProviderId
             base_url: default_url,
             endpoint: None,
             reasoning_effort: None,
+            enable_thinking: None,
         },
     );
 }

--- a/crates/cli/tests/config_test.rs
+++ b/crates/cli/tests/config_test.rs
@@ -28,6 +28,7 @@ fn config_roundtrip() {
         base_url: None,
         endpoint: None,
         reasoning_effort: None,
+        enable_thinking: None,
     };
     let config = OpenCourseConfig::new(ProviderId::OpenAi, provider_config, profile);
     write_config(&config, dir.path()).unwrap();

--- a/crates/cli/tests/footer_hints_test.rs
+++ b/crates/cli/tests/footer_hints_test.rs
@@ -53,6 +53,7 @@ async fn setup_state() -> AppState {
         base_url: None,
         endpoint: None,
         reasoning_effort: None,
+        enable_thinking: None,
     };
     let mut config = OpenCourseConfig::new(ProviderId::OpenAi, provider_config, profile);
     config.preferences = UserPreferences {

--- a/crates/cli/tests/settings_layout_test.rs
+++ b/crates/cli/tests/settings_layout_test.rs
@@ -37,6 +37,7 @@ fn make_test_config() -> OpenCourseConfig {
         base_url: None,
         endpoint: None,
         reasoning_effort: None,
+        enable_thinking: None,
     };
     let mut config = OpenCourseConfig::new(ProviderId::OpenAi, provider_config, profile);
     config.preferences = UserPreferences {

--- a/crates/config/src/migration.rs
+++ b/crates/config/src/migration.rs
@@ -25,6 +25,7 @@ pub fn try_migrate_from_profile_md(
             base_url: None,
             endpoint: None,
             reasoning_effort: None,
+            enable_thinking: None,
         },
         profile,
     );

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -115,6 +115,8 @@ pub enum ProviderConfig {
         endpoint: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         reasoning_effort: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        enable_thinking: Option<bool>,
     },
 }
 
@@ -144,6 +146,8 @@ impl<'de> Deserialize<'de> for ProviderConfig {
             endpoint: Option<String>,
             #[serde(default)]
             reasoning_effort: Option<String>,
+            #[serde(default)]
+            enable_thinking: Option<bool>,
         }
         let helper = Helper::deserialize(deserializer)?;
         match helper.ty.as_str() {
@@ -153,6 +157,7 @@ impl<'de> Deserialize<'de> for ProviderConfig {
                 base_url: helper.base_url,
                 endpoint: helper.endpoint,
                 reasoning_effort: helper.reasoning_effort,
+                enable_thinking: helper.enable_thinking,
             }),
             _ => Err(serde::de::Error::custom(format!(
                 "unknown provider config type: {}",
@@ -197,6 +202,14 @@ impl ProviderConfig {
         }
     }
 
+    pub fn enable_thinking(&self) -> Option<bool> {
+        match self {
+            ProviderConfig::ApiKey {
+                enable_thinking, ..
+            } => *enable_thinking,
+        }
+    }
+
     /// Returns a copy with a different API key.
     pub fn with_api_key(mut self, api_key: Option<String>) -> Self {
         match &mut self {
@@ -227,5 +240,30 @@ impl ProviderConfig {
             ProviderConfig::ApiKey { endpoint: slot, .. } => *slot = endpoint,
         }
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_without_enable_thinking() {
+        let json = r#"{"type":"apiKey","model":"test-model"}"#;
+        let config: ProviderConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.enable_thinking(), None);
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(!serialized.contains("enable_thinking"));
+    }
+
+    #[test]
+    fn round_trips_with_enable_thinking() {
+        let json = r#"{"type":"apiKey","model":"test-model","enable_thinking":false}"#;
+        let config: ProviderConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.enable_thinking(), Some(false));
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(serialized.contains(r#""enable_thinking":false"#));
+        let reparsed: ProviderConfig = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(reparsed, config);
     }
 }

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -103,6 +103,7 @@ pub struct RigClient {
     base_url: String,
     api_key: String,
     reasoning_effort: Option<String>,
+    enable_thinking: Option<bool>,
 }
 
 impl RigClient {
@@ -120,6 +121,7 @@ impl RigClient {
 
         let api_key = api_key.unwrap_or_default();
         let reasoning_effort = config.reasoning_effort().map(|s| s.to_string());
+        let enable_thinking = config.enable_thinking();
 
         let (inner, base_url) = match provider_id {
             ProviderId::Anthropic => {
@@ -174,6 +176,7 @@ impl RigClient {
             base_url,
             api_key,
             reasoning_effort,
+            enable_thinking,
         })
     }
 
@@ -188,12 +191,15 @@ impl RigClient {
         for attempt in 1..=LLM_MAX_RETRIES {
             let result = match &self.inner {
                 RigClientInner::OpenAi(client) => {
-                    let extractor = ExtractorBuilder::<_, T>::new(
+                    let mut extractor = ExtractorBuilder::<_, T>::new(
                         openai::completion::CompletionModel::new(client.clone(), &self.model),
                     )
-                    .max_tokens(max_tokens as u64)
-                    .build();
-                    extractor.extract(prompt).await
+                    .max_tokens(max_tokens as u64);
+                    if self.enable_thinking == Some(false) {
+                        extractor = extractor
+                            .additional_params(serde_json::json!({"enable_thinking": false}));
+                    }
+                    extractor.build().extract(prompt).await
                 }
                 RigClientInner::Anthropic(client) => {
                     client
@@ -242,10 +248,16 @@ impl RigClient {
         model: &str,
         system: Option<&str>,
         max_tokens: u32,
+        enable_thinking: Option<bool>,
     ) -> Agent<openai::completion::CompletionModel> {
         let builder =
             openai::completion::CompletionModel::new(client.clone(), model).into_agent_builder();
         let builder = builder.max_tokens(max_tokens as u64);
+        let builder = if enable_thinking == Some(false) {
+            builder.additional_params(serde_json::json!({"enable_thinking": false}))
+        } else {
+            builder
+        };
         let builder = if let Some(system) = system {
             builder.preamble(system)
         } else {
@@ -292,9 +304,15 @@ impl LlmClient for RigClient {
         for attempt in 1..=LLM_MAX_RETRIES {
             let result = match &self.inner {
                 RigClientInner::OpenAi(client) => {
-                    Self::openai_agent(client, &self.model, system, max_tokens)
-                        .prompt(prompt)
-                        .await
+                    Self::openai_agent(
+                        client,
+                        &self.model,
+                        system,
+                        max_tokens,
+                        self.enable_thinking,
+                    )
+                    .prompt(prompt)
+                    .await
                 }
                 RigClientInner::Anthropic(client) => {
                     Self::anthropic_agent(client, &self.model, system, max_tokens)
@@ -343,6 +361,7 @@ impl LlmClient for RigClient {
                     system,
                     prompt,
                     self.reasoning_effort.as_deref(),
+                    self.enable_thinking,
                     max_tokens,
                 )
                 .await
@@ -405,6 +424,7 @@ mod tests {
             base_url: base_url.map(str::to_string),
             endpoint: endpoint.map(str::to_string),
             reasoning_effort: None,
+            enable_thinking: None,
         }
     }
 

--- a/crates/llm/src/streaming.rs
+++ b/crates/llm/src/streaming.rs
@@ -145,16 +145,14 @@ fn parse_anthropic_frame(frame: &str) -> Option<StreamChunk> {
     })
 }
 
-pub async fn stream_openai_compatible(
-    base_url: &str,
-    api_key: &str,
+fn build_openai_request_body(
     model: &str,
     system: Option<&str>,
     prompt: &str,
     reasoning_effort: Option<&str>,
+    enable_thinking: Option<bool>,
     max_tokens: u32,
-) -> Result<LlmStream> {
-    let client = Client::new();
+) -> serde_json::Value {
     let mut messages = Vec::new();
     if let Some(system) = system {
         messages.push(json!({ "role": "system", "content": system }));
@@ -169,6 +167,32 @@ pub async fn stream_openai_compatible(
     if let Some(effort) = reasoning_effort {
         body["reasoning_effort"] = json!(effort);
     }
+    if let Some(enable_thinking) = enable_thinking {
+        body["enable_thinking"] = json!(enable_thinking);
+    }
+    body
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn stream_openai_compatible(
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    system: Option<&str>,
+    prompt: &str,
+    reasoning_effort: Option<&str>,
+    enable_thinking: Option<bool>,
+    max_tokens: u32,
+) -> Result<LlmStream> {
+    let client = Client::new();
+    let body = build_openai_request_body(
+        model,
+        system,
+        prompt,
+        reasoning_effort,
+        enable_thinking,
+        max_tokens,
+    );
     let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
 
     let mut request = client
@@ -243,4 +267,26 @@ pub fn stream_from_text(text: String) -> LlmStream {
     Box::pin(futures_util::stream::once(async move {
         Ok(StreamChunk::Content(text))
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_body_omits_enable_thinking_when_unset() {
+        let body = build_openai_request_body("m", None, "hi", None, None, 100);
+        assert!(body.get("enable_thinking").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn request_body_includes_enable_thinking_when_set() {
+        let body = build_openai_request_body("m", Some("sys"), "hi", Some("low"), Some(false), 100);
+        assert_eq!(body["enable_thinking"], json!(false));
+        assert_eq!(body["reasoning_effort"], json!("low"));
+        assert_eq!(body["stream"], json!(true));
+        assert_eq!(body["max_tokens"], json!(100));
+        assert_eq!(body["messages"].as_array().unwrap().len(), 2);
+    }
 }


### PR DESCRIPTION
## Problem

Alibaba DashScope-compatible endpoints (e.g. qwen3.6-flash) default to thinking mode ON. The model emits ~8-10K reasoning tokens before the actual answer, making the CLI 3-6x slower.

Measured against a DashScope-compatible endpoint:

| Model | default | with `enable_thinking: false` |
|---|---|---|
| qwen3.6-flash | 18.3s | 2.96s |
| deepseek-v4-flash-0731 | 5.9s | 3.6s |

Verified via curl that sending `"enable_thinking": false` in the chat/completions body eliminates the reasoning trace. The existing `reasoning_effort` config field is ignored by DashScope, so a dedicated field is needed.

## Change

- `crates/config`: new optional `enable_thinking: Option<bool>` on `ProviderConfig::ApiKey` (same serde pattern as `reasoning_effort`), with accessor and round-trip tests.
- `crates/llm`:
  - Streaming path (`stream_openai_compatible`): sends `enable_thinking` in the request body when set. Body construction factored into a testable `build_openai_request_body` helper with unit tests for include/omit behavior.
  - Non-streaming paths (rig 0.20): the OpenAI agent builder and `ExtractorBuilder` both support `additional_params`, which the rig OpenAI provider merges into the request body — so `prompt()` and structured extraction forward `{"enable_thinking": false}` when configured. Only `false` is forwarded, since it is the only value that changes provider behavior.
- Struct-literal constructors in tests/onboarding/settings updated with `enable_thinking: None`.

## Usage

```json
{
  "type": "apiKey",
  "model": "qwen3.6-flash",
  "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
  "api_key": "...",
  "enable_thinking": false
}
```

## Compatibility

When `enable_thinking` is absent from the config, request bodies are byte-identical to before — the parameter is omitted entirely on all paths.

Note: the commit also syncs `Cargo.lock` with the `open-course-cli` version on main (0.17.0); the lockfile on main was stale at 0.15.1.

## Verification

- `cargo build --workspace` — clean
- `cargo test --all-features` — all suites pass (incl. new round-trip tests in `config` and request-body tests in `llm`)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean