### PR TITLE
fix(prompts): anchor vocabulary extraction to expectedTranslation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/tests/prompts_test.rs
+++ b/crates/cli/tests/prompts_test.rs
@@ -136,6 +136,20 @@ fn exercise_prompt_always_requests_vocabulary_extraction() {
 }
 
 #[test]
+fn exercise_prompt_anchors_vocabulary_extraction_to_expected_translation() {
+    let p = profile();
+    let all = vec![topic("t1")];
+    let target = vec![topic("t1")];
+    let prompt = build_exercise_prompt(&p, &target, &[], &all, &[], &[], 3, 0.75);
+
+    // `targetSentence` holds the native-language sentence; the vocabulary
+    // instructions must name `expectedTranslation` explicitly so the model
+    // extracts target-language words instead.
+    assert!(prompt.contains("appears in the expectedTranslation fields"));
+    assert!(prompt.contains("never extract words from targetSentence"));
+}
+
+#[test]
 fn analysis_prompt_includes_answers() {
     use open_course_cli::core::session::Exercise;
 

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -175,13 +175,18 @@ pub fn build_exercise_prompt(
         )
     };
 
+    // "Target sentences" alone is ambiguous: the exercise field
+    // `targetSentence` holds the NATIVE-language sentence, so models read it
+    // as a field reference and extract native words (with a same-language
+    // "translation"). Name the exact field to extract from instead.
     let vocabulary_extraction_note = format!(
         "\nIn addition to the exercises{warmup_ref}, return a top-level \"vocabulary\" array \
          listing every CONTENT word (NOUN, VERB, ADJ, ADV, PROPN, SCONJ, CCONJ only — skip \
-         articles, prepositions, pronouns, auxiliaries) that appears in the target sentences \
-         you just wrote, one entry per distinct word, each with these fields:\n\
-         - lemma: the dictionary headword\n\
-         - surface: the exact inflected form as it appears in the sentence\n\
+         articles, prepositions, pronouns, auxiliaries) that appears in the expectedTranslation \
+         fields you just wrote (the {target} sentences — never extract words from \
+         targetSentence, which is {native}), one entry per distinct word, each with these fields:\n\
+         - lemma: the dictionary headword in {target}\n\
+         - surface: the exact inflected form as it appears in the expectedTranslation\n\
          - pos: part of speech (Universal Dependencies tag)\n\
          - cefrLevel: approximate CEFR level (\"A1\"–\"C2\")\n\
          - translation: the translation in {native}\n",
@@ -191,6 +196,7 @@ pub fn build_exercise_prompt(
             " and the requested \"warmup\" array"
         },
         native = native_name,
+        target = target_name,
     );
 
     format!(


### PR DESCRIPTION
## Problem

Warm-up cards for a native→target pair (e.g. es→en) intermittently showed **both** the word and its hidden translation in the native language — sometimes all cards, sometimes part. Reproduced across models (qwen, deepseek), so not model-specific.

Root cause: the vocabulary extraction note in the exercise prompt said words must appear in "the target sentences you just wrote". The exercise contract names the **native-language** field `targetSentence` (the sentence the student translates), so models resolved "target sentences" to that field and extracted native-language words, each with a same-language `translation` (the prompt asks for the translation in the native language). The code-side verification (`vocabulary::exercise_tokens`) tokenizes the same `target_sentence`, so native words pass the appearance check while correct target-language words are dropped — which is why the surviving cards were the native-language ones.

## Change (prompt-only, minimal)

In `build_exercise_prompt`'s vocabulary extraction note (`crates/core/src/llm/prompts.rs`):

- "appears in the target sentences you just wrote" → "appears in the **expectedTranslation** fields you just wrote (the {target} sentences — never extract words from targetSentence, which is {native})"
- `lemma`: "the dictionary headword" → "the dictionary headword in {target}"
- `surface`: "...as it appears in the sentence" → "...as it appears in the expectedTranslation"

No code-path changes; the deliberately out-of-scope follow-ups are the `exercise_tokens` token source and cleanup of already-polluted lemmas.

## Tests

- New test `exercise_prompt_anchors_vocabulary_extraction_to_expected_translation` locks the wording.
- `cargo test --test prompts_test`, `cargo clippy -p open-course-core -D warnings`, `cargo fmt --check` all green.