### PR TITLE
fix(llm): use max_completion_tokens for the OpenAI provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.18.0"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -104,6 +104,10 @@ pub struct RigClient {
     api_key: String,
     reasoning_effort: Option<String>,
     enable_thinking: Option<bool>,
+    /// True for the real OpenAI API (not OpenAI-compatible gateways):
+    /// requires `max_completion_tokens` and rejects unknown parameters such
+    /// as the Qwen/Aliyun `enable_thinking` extension.
+    openai_native: bool,
 }
 
 impl RigClient {
@@ -121,7 +125,14 @@ impl RigClient {
 
         let api_key = api_key.unwrap_or_default();
         let reasoning_effort = config.reasoning_effort().map(|s| s.to_string());
-        let enable_thinking = config.enable_thinking();
+        let openai_native = provider_id == ProviderId::OpenAi;
+        // OpenAI rejects unknown parameters with a 400, and enable_thinking
+        // is a Qwen/Aliyun extension — drop it for the real OpenAI API.
+        let enable_thinking = if openai_native {
+            None
+        } else {
+            config.enable_thinking()
+        };
 
         let (inner, base_url) = match provider_id {
             ProviderId::Anthropic => {
@@ -177,6 +188,7 @@ impl RigClient {
             api_key,
             reasoning_effort,
             enable_thinking,
+            openai_native,
         })
     }
 
@@ -363,6 +375,7 @@ impl LlmClient for RigClient {
                     self.reasoning_effort.as_deref(),
                     self.enable_thinking,
                     max_tokens,
+                    self.openai_native,
                 )
                 .await
             }
@@ -475,5 +488,27 @@ mod tests {
         let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
         assert_eq!(client.base_url, "https://generativelanguage.googleapis.com");
         assert!(matches!(client.inner, RigClientInner::Gemini(_)));
+    }
+
+    #[test]
+    fn openai_drops_enable_thinking_and_marks_native_api() {
+        let mut cfg = config(Some("openai-key"), None, None);
+        let ProviderConfig::ApiKey {
+            enable_thinking, ..
+        } = &mut cfg;
+        *enable_thinking = Some(false);
+        let client = RigClient::from_config(&cfg, ProviderId::OpenAi).expect("should build");
+        assert!(client.openai_native);
+        assert_eq!(client.enable_thinking, None);
+
+        // Custom gateways keep the configured enable_thinking.
+        let mut custom_cfg = config(Some("key"), Some("https://example.com/v1"), None);
+        let ProviderConfig::ApiKey {
+            enable_thinking, ..
+        } = &mut custom_cfg;
+        *enable_thinking = Some(false);
+        let custom = RigClient::from_config(&custom_cfg, ProviderId::Custom).expect("should build");
+        assert!(!custom.openai_native);
+        assert_eq!(custom.enable_thinking, Some(false));
     }
 }

--- a/crates/llm/src/streaming.rs
+++ b/crates/llm/src/streaming.rs
@@ -152,6 +152,7 @@ fn build_openai_request_body(
     reasoning_effort: Option<&str>,
     enable_thinking: Option<bool>,
     max_tokens: u32,
+    openai_native: bool,
 ) -> serde_json::Value {
     let mut messages = Vec::new();
     if let Some(system) = system {
@@ -162,12 +163,20 @@ fn build_openai_request_body(
         "model": model,
         "messages": messages,
         "stream": true,
-        "max_tokens": max_tokens,
     });
+    // OpenAI's gpt-5/o-series models reject `max_tokens` and require
+    // `max_completion_tokens`; OpenAI-compatible gateways expect
+    // `max_tokens`.
+    if openai_native {
+        body["max_completion_tokens"] = json!(max_tokens);
+    } else {
+        body["max_tokens"] = json!(max_tokens);
+    }
     if let Some(effort) = reasoning_effort {
         body["reasoning_effort"] = json!(effort);
     }
-    if let Some(enable_thinking) = enable_thinking {
+    // OpenAI rejects the Qwen/Aliyun `enable_thinking` extension with a 400.
+    if !openai_native && let Some(enable_thinking) = enable_thinking {
         body["enable_thinking"] = json!(enable_thinking);
     }
     body
@@ -183,6 +192,7 @@ pub async fn stream_openai_compatible(
     reasoning_effort: Option<&str>,
     enable_thinking: Option<bool>,
     max_tokens: u32,
+    openai_native: bool,
 ) -> Result<LlmStream> {
     let client = Client::new();
     let body = build_openai_request_body(
@@ -192,6 +202,7 @@ pub async fn stream_openai_compatible(
         reasoning_effort,
         enable_thinking,
         max_tokens,
+        openai_native,
     );
     let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
 
@@ -275,18 +286,29 @@ mod tests {
 
     #[test]
     fn request_body_omits_enable_thinking_when_unset() {
-        let body = build_openai_request_body("m", None, "hi", None, None, 100);
+        let body = build_openai_request_body("m", None, "hi", None, None, 100, false);
         assert!(body.get("enable_thinking").is_none());
         assert!(body.get("reasoning_effort").is_none());
     }
 
     #[test]
     fn request_body_includes_enable_thinking_when_set() {
-        let body = build_openai_request_body("m", Some("sys"), "hi", Some("low"), Some(false), 100);
+        let body =
+            build_openai_request_body("m", Some("sys"), "hi", Some("low"), Some(false), 100, false);
         assert_eq!(body["enable_thinking"], json!(false));
         assert_eq!(body["reasoning_effort"], json!("low"));
         assert_eq!(body["stream"], json!(true));
         assert_eq!(body["max_tokens"], json!(100));
         assert_eq!(body["messages"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn openai_native_body_uses_max_completion_tokens_and_drops_enable_thinking() {
+        let body =
+            build_openai_request_body("m", None, "hi", Some("low"), Some(false), 100, true);
+        assert_eq!(body["max_completion_tokens"], json!(100));
+        assert!(body.get("max_tokens").is_none());
+        assert_eq!(body["reasoning_effort"], json!("low"));
+        assert!(body.get("enable_thinking").is_none());
     }
 }

--- a/crates/llm/src/streaming.rs
+++ b/crates/llm/src/streaming.rs
@@ -304,8 +304,7 @@ mod tests {
 
     #[test]
     fn openai_native_body_uses_max_completion_tokens_and_drops_enable_thinking() {
-        let body =
-            build_openai_request_body("m", None, "hi", Some("low"), Some(false), 100, true);
+        let body = build_openai_request_body("m", None, "hi", Some("low"), Some(false), 100, true);
         assert_eq!(body["max_completion_tokens"], json!(100));
         assert!(body.get("max_tokens").is_none());
         assert_eq!(body["reasoning_effort"], json!("low"));


### PR DESCRIPTION
## Problem

Streaming chat calls for users with an OpenAI model failed with:

```
provider returned 400: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

Verified live against the OpenAI API: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.6-luna`, `o4-mini` all reject `max_tokens` and work with `max_completion_tokens`; `gpt-4o`/`gpt-4o-mini` accept both.

Two paths in the CLI were affected:

- **Streaming** (`stream_openai_compatible` in `crates/llm/src/streaming.rs`) always sent `max_tokens` — broken for every gpt-5/o-series model.
- **Non-streaming** (rig 0.20) never serializes `max_tokens` at all, so it was unaffected — but a configured `enable_thinking` was passed through as an additional param, and OpenAI 400s on unknown parameters (`enable_thinking` is a Qwen/Aliyun extension).

## Fix

- `RigClient` gains an `openai_native` flag (`provider_id == ProviderId::OpenAi`).
- Streaming request body uses `max_completion_tokens` for the native OpenAI API; OpenAI-compatible gateways (DeepSeek, Mistral, OpenRouter, Ollama, custom) keep `max_tokens`.
- `enable_thinking` is dropped for the OpenAI provider in `from_config` (covers both the rig and streaming paths); custom gateways keep it.

## Verification

- New unit tests: native-OpenAI body shape, gateway body shape, `from_config` stripping.
- `cargo test --workspace`: all green; `cargo clippy --workspace`: clean.
- Live-checked against the OpenAI API that `max_completion_tokens` + `reasoning_effort: low` succeeds for gpt-5.6-luna.

Server-side counterpart: scriptology/open-course-server#36

Closes #94