### PR TITLE
feat(core): add cloze-with-word-bank session stage to the LLM contract

### DIFF
--- a/crates/core/src/llm/parse.rs
+++ b/crates/core/src/llm/parse.rs
@@ -21,6 +21,11 @@ pub struct Exercises {
     /// prompts and bare-array responses have none.
     #[serde(default)]
     pub vocabulary: Vec<RawVocabularyItem>,
+    /// Cloze (word-bank) items, one per word of `vocabulary`, for words
+    /// without positive learning progress (see `vocabulary::cloze_items`).
+    /// Optional: older prompts and bare-array responses have none.
+    #[serde(default)]
+    pub cloze: Vec<RawClozeItem>,
 }
 
 /// Warm-up entry as returned by the LLM, before it is matched against the
@@ -62,6 +67,30 @@ pub struct RawVocabularyItem {
     pub cefr_level: Option<String>,
     #[serde(default)]
     pub translation: Option<String>,
+}
+
+/// Cloze (fill-in-the-blank with a word bank) entry as returned by the LLM,
+/// before it is validated and matched against the learner's vocabulary (see
+/// `vocabulary::cloze_items`). Every field is optional so a partial entry
+/// never breaks parsing of the whole response. The sentence is returned
+/// complete — the pipeline blanks the answer out itself.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RawClozeItem {
+    #[serde(default)]
+    pub lemma: String,
+    #[serde(default)]
+    pub sentence: String,
+    #[serde(default)]
+    pub answer: String,
+    #[serde(default)]
+    pub distractors: Vec<String>,
+    #[serde(default)]
+    pub translation: Option<String>,
+    #[serde(default)]
+    pub pos: Option<String>,
+    #[serde(default)]
+    pub cefr_level: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -107,6 +136,7 @@ pub fn parse_session_exercises(
             exercises: vec,
             warmup: vec![],
             vocabulary: vec![],
+            cloze: vec![],
         });
     }
 
@@ -595,6 +625,45 @@ mod tests {
         let result = parse_session_exercises(&cleaned, 0, 0).unwrap();
         assert_eq!(result.exercises.len(), 1);
         assert!(result.warmup.is_empty());
+        assert!(result.cloze.is_empty());
+    }
+
+    // --- cloze parsing ---
+
+    #[test]
+    fn parse_session_exercises_defaults_cloze_when_absent() {
+        let cleaned = format!(r#"{{"exercises": [{}]}}"#, exercise_json("ex1"));
+        let result = parse_session_exercises(&cleaned, 0, 0).unwrap();
+        assert_eq!(result.exercises.len(), 1);
+        assert!(result.cloze.is_empty());
+    }
+
+    #[test]
+    fn parse_session_exercises_parses_cloze() {
+        let cleaned = format!(
+            r#"{{"exercises": [{}], "cloze": [
+                {{"lemma": "comer", "sentence": "Como pan cada día.", "answer": "Como", "distractors": ["Comes", "Comer"], "translation": "Я ем хлеб каждый день.", "pos": "VERB", "cefrLevel": "A1"}},
+                {{"lemma": "pequeño"}}
+            ]}}"#,
+            exercise_json("ex1")
+        );
+        let result = parse_session_exercises(&cleaned, 0, 0).unwrap();
+        assert_eq!(result.cloze.len(), 2);
+        assert_eq!(result.cloze[0].lemma, "comer");
+        assert_eq!(result.cloze[0].sentence, "Como pan cada día.");
+        assert_eq!(result.cloze[0].answer, "Como");
+        assert_eq!(result.cloze[0].distractors, ["Comes", "Comer"]);
+        assert_eq!(
+            result.cloze[0].translation.as_deref(),
+            Some("Я ем хлеб каждый день.")
+        );
+        assert_eq!(result.cloze[0].pos.as_deref(), Some("VERB"));
+        assert_eq!(result.cloze[0].cefr_level.as_deref(), Some("A1"));
+        // Partial entries parse too: missing fields fall back to defaults.
+        assert_eq!(result.cloze[1].lemma, "pequeño");
+        assert!(result.cloze[1].sentence.is_empty());
+        assert!(result.cloze[1].distractors.is_empty());
+        assert_eq!(result.cloze[1].translation, None);
     }
 
     // --- parse_analysis ---

--- a/crates/core/src/llm/prompts.rs
+++ b/crates/core/src/llm/prompts.rs
@@ -199,6 +199,25 @@ pub fn build_exercise_prompt(
         target = target_name,
     );
 
+    // The cloze stage drills the same content words the vocabulary array
+    // reports, so it is always requested — independent of forced vocabulary.
+    let cloze_extraction_note = format!(
+        "\nIn addition, return a top-level \"cloze\" array with ONE entry per word of the \
+         \"vocabulary\" array above, each with these fields:\n\
+         - lemma: the dictionary headword, exactly as in the \"vocabulary\" array\n\
+         - sentence: one NEW short, simple sentence in {target} containing the exact inflected \
+         form of the word. It MUST obey the same sentence-shape limits stated above, it must \
+         NOT be any sentence used in the exercises or warm-up examples, and it must be written \
+         ENTIRELY in {target}\n\
+         - answer: the exact inflected form of the word as it appears in sentence\n\
+         - distractors: array of 2–3 plausible but incorrect options for the blank — similar \
+         grammatical forms (other inflections of the same lemma or the same part of speech) \
+         that are grammatically or lexically wrong in this sentence\n\
+         - translation: the translation of sentence in {native}\n",
+        native = native_name,
+        target = target_name,
+    );
+
     format!(
         "You are a language tutor. Generate {count} connected translation exercises from {native} to {target}.
 
@@ -226,7 +245,7 @@ For each exercise output a JSON object with these fields:
 - expectedPatterns: grammar patterns the student should use
 - hint: optional short hint
 
-Output a JSON object with the key \"exercises\" containing an array of the exercise objects.{warmup_output_note}{vocabulary_extraction_note}
+Output a JSON object with the key \"exercises\" containing an array of the exercise objects.{warmup_output_note}{vocabulary_extraction_note}{cloze_extraction_note}
 
 CRITICAL: language separation. Each targetSentence must be 100% {native} and each translation (expectedTranslation, acceptableTranslations) must be 100% {target}. Never mix both languages within one sentence. If a sentence would naturally borrow a {target} word, translate that word into {native} instead.",
         native = native_name,
@@ -733,6 +752,25 @@ mod tests {
         assert!(prompt.contains("the translation in Russian"));
         assert!(prompt.contains("example sentence in Spanish"));
         assert!(prompt.contains("must NOT appear in any exercise"));
+        // The cloze contract is requested once per vocabulary word, always.
+        assert!(prompt.contains("\"cloze\""));
+        assert!(prompt.contains("ONE entry per word of the \"vocabulary\" array"));
+        assert!(prompt.contains("exactly as in the \"vocabulary\" array"));
+        assert!(prompt.contains("distractors"));
+        assert!(prompt.contains("the translation of sentence in Russian"));
+    }
+
+    #[test]
+    fn exercise_prompt_requests_cloze_per_vocabulary_word() {
+        // Requested even without forced vocabulary, and constrained by the
+        // same sentence-shape limits and novelty rules as exercises.
+        let prompt = build_exercise_prompt(&profile(), &[], &[], &[], &[], &[], 3, 0.8);
+        assert!(prompt.contains("\"cloze\""));
+        assert!(prompt.contains("ONE entry per word of the \"vocabulary\" array"));
+        assert!(prompt.contains("sentence-shape limits"));
+        assert!(prompt.contains("must NOT be any sentence used in the exercises or warm-up"));
+        assert!(prompt.contains("ENTIRELY in Spanish"));
+        assert!(prompt.contains("2–3 plausible but incorrect options"));
     }
 
     #[test]
@@ -758,6 +796,8 @@ mod tests {
         let prompt = build_exercise_prompt(&profile(), &[], &[], &[], &[], &[], 3, 0.8);
         assert!(!prompt.contains("need extra practice"));
         assert!(!prompt.contains("\"warmup\""));
+        // Cloze is independent of forced vocabulary: always requested.
+        assert!(prompt.contains("\"cloze\""));
     }
 
     #[test]

--- a/crates/core/src/session/mod.rs
+++ b/crates/core/src/session/mod.rs
@@ -5,8 +5,9 @@ pub mod topic_selection;
 use std::collections::{HashMap, HashSet};
 
 pub use models::{
-    AnalysisResult, EvaluatedTopic, Exercise, FeedbackComment, GrammarError, GrammarErrorType,
-    NewTopicRef, SemanticVerdict, SentenceAnalysis, VocabularyUse, WarmupItem, WarmupKind,
+    AnalysisResult, ClozeItem, EvaluatedTopic, Exercise, FeedbackComment, GrammarError,
+    GrammarErrorType, NewTopicRef, SemanticVerdict, SentenceAnalysis, VocabularyUse, WarmupItem,
+    WarmupKind,
 };
 pub use scoring::{
     average, clamp_score, collect_topic_errors, count_topic_occurrences, error_based_score,

--- a/crates/core/src/session/models.rs
+++ b/crates/core/src/session/models.rs
@@ -101,6 +101,40 @@ pub struct WarmupItem {
     pub kind: WarmupKind,
 }
 
+/// One cloze (fill-in-the-blank with a word bank) item shown after the
+/// warm-up and before the translation exercises: a simple target-language
+/// sentence with the target word blanked out and 3–4 options to choose
+/// from. Built by matching the LLM's `cloze` output against the learner's
+/// vocabulary (see `vocabulary::cloze_items`) for content words without
+/// positive learning progress; never persisted.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct ClozeItem {
+    /// Id of the lemma this item was built from; `None` for a word that has
+    /// no `Lemma` row yet (same convention as `WarmupItem`).
+    #[serde(default)]
+    pub lemma_id: Option<String>,
+    pub lemma: String,
+    /// Universal Dependencies part-of-speech tag ("NOUN", "VERB", ...).
+    #[serde(default)]
+    pub pos: Option<String>,
+    /// Approximate CEFR level ("A1"–"C2").
+    #[serde(default)]
+    pub cefr_level: Option<String>,
+    /// Full target-language sentence with the target word replaced by a
+    /// single `_____` placeholder (inserted by the pipeline, not the LLM).
+    pub sentence: String,
+    /// The correct word form as it appears in the sentence.
+    pub answer: String,
+    /// 3–4 choices including `answer`; order is shuffled by the caller.
+    pub options: Vec<String>,
+    /// Translation of the sentence in the learner's native language
+    /// (learner support).
+    #[serde(default)]
+    pub translation: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -1531,7 +1531,12 @@ mod tests {
     fn cloze_items_drops_answer_absent_from_sentence() {
         // The LLM claims "comes" but the sentence says "como" — probable
         // hallucination, dropped.
-        let raw = vec![raw_cloze("comer", "Como pan.", "Comes", &["Comen", "Comer"])];
+        let raw = vec![raw_cloze(
+            "comer",
+            "Como pan.",
+            "Comes",
+            &["Comen", "Comer"],
+        )];
         assert!(cloze_items(&[], &[], raw).is_empty());
     }
 
@@ -1539,7 +1544,12 @@ mod tests {
     fn cloze_items_blanks_answer_case_insensitively_at_real_boundaries() {
         // Answer casing differs from the sentence; the match is normalized,
         // the replacement keeps the rest of the sentence untouched.
-        let raw = vec![raw_cloze("comer", "Yo como pan cada día.", "Como", &["comes", "comen"])];
+        let raw = vec![raw_cloze(
+            "comer",
+            "Yo como pan cada día.",
+            "Como",
+            &["comes", "comen"],
+        )];
         let items = cloze_items(&[], &[], raw);
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].sentence, "Yo _____ pan cada día.");

--- a/crates/core/src/vocabulary.rs
+++ b/crates/core/src/vocabulary.rs
@@ -382,6 +382,120 @@ pub fn new_word_items(
         .collect()
 }
 
+/// Placeholder replacing the answer in a cloze sentence. Inserted by
+/// `cloze_items` at the real char boundaries of the matched token, never by
+/// the LLM, so every item shares the exact same marker.
+pub const CLOZE_BLANK: &str = "_____";
+
+/// Replaces the first word token of `sentence` whose normalized form equals
+/// `answer_key` with `CLOZE_BLANK`, returning the rewritten sentence.
+/// Matching is case- and Unicode-normalized (via `normalize_key`) but the
+/// replacement happens at the real char boundaries of the original text.
+/// `None` when the answer does not appear as a token — the item must be
+/// dropped as a probable hallucination.
+fn blank_answer(sentence: &str, answer_key: &str) -> Option<String> {
+    let mut token_start: Option<usize> = None;
+    let check = |start: usize, end: usize| {
+        (normalize_key(&sentence[start..end]) == answer_key)
+            .then(|| format!("{}{}{}", &sentence[..start], CLOZE_BLANK, &sentence[end..]))
+    };
+    for (i, c) in sentence.char_indices() {
+        if c.is_alphanumeric() {
+            if token_start.is_none() {
+                token_start = Some(i);
+            }
+        } else if let Some(start) = token_start.take()
+            && let Some(blanked) = check(start, i)
+        {
+            return Some(blanked);
+        }
+    }
+    if let Some(start) = token_start {
+        return check(start, sentence.len());
+    }
+    None
+}
+
+/// Builds cloze (word-bank) items for a session from the LLM's raw `cloze`
+/// output (the `"cloze"` array from `Exercises`). Only words without
+/// positive learning progress get an item: those with no `Lemma` row at all
+/// (matched by `normalize_key(lemma)`, same as `new_word_items`) or whose
+/// existing row has `correct_uses == 0`; forced-vocabulary lemmas count as
+/// existing rows too, so a forced lemma with `correct_uses == 0` is kept and
+/// linked even when it is absent from `existing_lemmas`. Anti-hallucination
+/// validation: the `answer` (compared via `normalize_key`) must appear in
+/// `sentence`; the first matching token is replaced with `CLOZE_BLANK` at
+/// the real char boundaries, so the placeholder is guaranteed consistent —
+/// the item is dropped otherwise. `options` is the answer plus distractors,
+/// deduped via `normalize_key`; items that do not end up with 3–4 unique
+/// options are dropped. Items are deduped by `normalize_key(lemma)` (first
+/// wins). For a word with an existing row the item carries that row's id
+/// and falls back to the stored `pos`/`cefr_level` when the raw item's are
+/// empty.
+pub fn cloze_items(
+    existing_lemmas: &[Lemma],
+    forced_vocabulary: &[Lemma],
+    raw: Vec<crate::llm::parse::RawClozeItem>,
+) -> Vec<crate::session::ClozeItem> {
+    use std::collections::HashMap;
+
+    let mut by_key: HashMap<String, &Lemma> = HashMap::new();
+    for lemma in forced_vocabulary {
+        by_key.insert(normalize_key(&lemma.lemma), lemma);
+    }
+    // Existing rows win over forced duplicates: they are the fuller record.
+    for lemma in existing_lemmas {
+        by_key.insert(normalize_key(&lemma.lemma), lemma);
+    }
+
+    let mut seen_keys: HashSet<String> = HashSet::new();
+    raw.into_iter()
+        .filter_map(|item| {
+            let key = normalize_key(item.lemma.trim());
+            if key.is_empty() || !seen_keys.insert(key.clone()) {
+                return None;
+            }
+            let existing = by_key.get(&key).copied();
+            if existing.is_some_and(|lemma| lemma.correct_uses > 0) {
+                return None;
+            }
+            let answer = item.answer.trim();
+            let answer_key = normalize_key(answer);
+            if answer_key.is_empty() {
+                return None;
+            }
+            let sentence = blank_answer(item.sentence.trim(), &answer_key)?;
+            let mut options: Vec<String> = Vec::new();
+            let mut option_keys: HashSet<String> = HashSet::new();
+            options.push(answer.to_string());
+            option_keys.insert(answer_key);
+            for distractor in &item.distractors {
+                let distractor = distractor.trim();
+                let distractor_key = normalize_key(distractor);
+                if distractor_key.is_empty() || !option_keys.insert(distractor_key) {
+                    continue;
+                }
+                options.push(distractor.to_string());
+            }
+            if !(3..=4).contains(&options.len()) {
+                return None;
+            }
+            Some(crate::session::ClozeItem {
+                lemma_id: existing.map(|lemma| lemma.id.clone()),
+                lemma: item.lemma,
+                pos: non_empty(item.pos)
+                    .or_else(|| existing.and_then(|lemma| non_empty(Some(lemma.pos.clone())))),
+                cefr_level: non_empty(item.cefr_level)
+                    .or_else(|| existing.and_then(|lemma| lemma.cefr_level.clone())),
+                sentence,
+                answer: answer.to_string(),
+                options,
+                translation: non_empty(item.translation).unwrap_or_default(),
+            })
+        })
+        .collect()
+}
+
 /// Priority rank of a CEFR source: user-curated data ("manual"/"list") is 4,
 /// curriculum topics ("topic") 3, LLM estimates ("llm") 2, and anything else
 /// or `None` is 0.
@@ -1334,5 +1448,140 @@ mod tests {
             .collect();
         let items = new_word_items(&[], &exercises, raw);
         assert_eq!(items.len(), 12);
+    }
+
+    // --- cloze_items ---
+
+    fn raw_cloze(
+        lemma: &str,
+        sentence: &str,
+        answer: &str,
+        distractors: &[&str],
+    ) -> crate::llm::parse::RawClozeItem {
+        crate::llm::parse::RawClozeItem {
+            lemma: lemma.to_string(),
+            sentence: sentence.to_string(),
+            answer: answer.to_string(),
+            distractors: distractors.iter().map(|s| s.to_string()).collect(),
+            translation: Some("t".to_string()),
+            pos: None,
+            cefr_level: None,
+        }
+    }
+
+    #[test]
+    fn cloze_items_excludes_lemmas_answered_correctly() {
+        let mut known = forced_lemma("es-comer", "comer", "есть");
+        known.correct_uses = 3;
+        let existing = vec![known];
+        let raw = vec![
+            raw_cloze("comer", "Como pan.", "Como", &["Comes", "Comen"]),
+            raw_cloze("beber", "Bebo agua.", "Bebo", &["Bebes", "Beber"]),
+        ];
+        let items = cloze_items(&existing, &[], raw);
+        // "comer" was answered correctly before — no item; "beber" has no
+        // Lemma row at all and qualifies.
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma, "beber");
+        assert_eq!(items[0].lemma_id, None);
+    }
+
+    #[test]
+    fn cloze_items_links_existing_lemma_never_answered_correctly() {
+        let mut only_errors = forced_lemma("es-comer", "comer", "есть");
+        only_errors.status = STATUS_PRACTICING;
+        only_errors.incorrect_uses = 2;
+        only_errors.cefr_level = Some("A1".to_string());
+        let raw = vec![raw_cloze("Comer", "Como pan.", "Como", &["Comes", "Comen"])];
+        let items = cloze_items(&[only_errors], &[], raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma_id.as_deref(), Some("es-comer"));
+        // Stored pos/cefr fill the raw item's gaps.
+        assert_eq!(items[0].pos.as_deref(), Some("VERB"));
+        assert_eq!(items[0].cefr_level.as_deref(), Some("A1"));
+        // The display form comes from the raw item, not the stored lemma.
+        assert_eq!(items[0].lemma, "Comer");
+    }
+
+    #[test]
+    fn cloze_items_keeps_forced_lemma_with_zero_correct_uses() {
+        // A forced lemma whose row is not in `existing_lemmas` still counts
+        // as an existing row: kept while correct_uses == 0, dropped once it
+        // has positive progress.
+        let forced = vec![forced_lemma("es-comer", "comer", "есть")];
+        let items = cloze_items(
+            &[],
+            &forced,
+            vec![raw_cloze("comer", "Como pan.", "Como", &["Comes", "Comen"])],
+        );
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].lemma_id.as_deref(), Some("es-comer"));
+
+        let mut practiced = forced_lemma("es-comer", "comer", "есть");
+        practiced.correct_uses = 1;
+        let items = cloze_items(
+            &[],
+            &[practiced],
+            vec![raw_cloze("comer", "Como pan.", "Como", &["Comes", "Comen"])],
+        );
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn cloze_items_drops_answer_absent_from_sentence() {
+        // The LLM claims "comes" but the sentence says "como" — probable
+        // hallucination, dropped.
+        let raw = vec![raw_cloze("comer", "Como pan.", "Comes", &["Comen", "Comer"])];
+        assert!(cloze_items(&[], &[], raw).is_empty());
+    }
+
+    #[test]
+    fn cloze_items_blanks_answer_case_insensitively_at_real_boundaries() {
+        // Answer casing differs from the sentence; the match is normalized,
+        // the replacement keeps the rest of the sentence untouched.
+        let raw = vec![raw_cloze("comer", "Yo como pan cada día.", "Como", &["comes", "comen"])];
+        let items = cloze_items(&[], &[], raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].sentence, "Yo _____ pan cada día.");
+        assert_eq!(items[0].answer, "Como");
+    }
+
+    #[test]
+    fn cloze_items_options_dedup_and_count() {
+        // A distractor duplicating the answer (different case) is deduped;
+        // two remaining distractors give exactly 3 options.
+        let raw = vec![raw_cloze(
+            "comer",
+            "Como pan.",
+            "Como",
+            &["como", "Comes", "Comen"],
+        )];
+        let items = cloze_items(&[], &[], raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].options, ["Como", "Comes", "Comen"]);
+
+        // Fewer than 3 unique options: dropped.
+        let raw = vec![raw_cloze("comer", "Como pan.", "Como", &["como"])];
+        assert!(cloze_items(&[], &[], raw).is_empty());
+
+        // More than 4 unique options: contract violation, dropped.
+        let raw = vec![raw_cloze(
+            "comer",
+            "Como pan.",
+            "Como",
+            &["comes", "comen", "comer", "comed"],
+        )];
+        assert!(cloze_items(&[], &[], raw).is_empty());
+    }
+
+    #[test]
+    fn cloze_items_dedups_repeated_lemmas() {
+        let raw = vec![
+            raw_cloze("Comer", "Como pan.", "Como", &["Comes", "Comen"]),
+            raw_cloze("comer", "Como fruta.", "Como", &["Comes", "Comen"]),
+        ];
+        let items = cloze_items(&[], &[], raw);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].sentence, "_____ pan.");
     }
 }

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -121,6 +121,14 @@ Curriculum generation runs in parallel by CEFR level. The screen shows per-level
 5. A batch of exercises is generated for the selected topic (using `batch_size` from preferences). All exercises in the batch are generated in a single LLM request.
 6. The user sees translation sentences one by one, types the translation, and presses `Enter` to move to the next exercise.
 
+### Session stages
+
+A session runs up to three stages in order:
+
+1. **Warm-up** — flashcards for content words the learner has never answered correctly (no `Lemma` row, or a row with `correct_uses == 0`): forced vocabulary being reinforced plus new words previewed from the freshly generated exercises.
+2. **Cloze with word bank** — for every content word without positive learning progress (same `correct_uses == 0` predicate), one simple target-language sentence with the target word blanked out (`_____`) and 3–4 options: the correct inflected form plus 2–3 distractors of similar grammatical shape. Scoring is deterministic right/wrong (the chosen option either is the answer or not) and is counted into word progress server-side.
+3. **Translation exercises** — the main batch described above, analyzed by the LLM after the last answer.
+
 During a session:
 
 - `Enter` submits the answer and advances.


### PR DESCRIPTION
## What

Adds a new **cloze with word bank** session stage to the `open-course-core` LLM contract, shown **after the warm-up and before the translation exercises**. For every content word without positive learning progress (no `Lemma` row, or an existing row with `correct_uses == 0` — the same predicate as `vocabulary::new_word_items`), the learner gets one simple target-language sentence with the target word blanked out (`_____`) and a word bank of 3–4 options (the correct inflected form + 2–3 similar-form distractors).

## Contract changes (`crates/core`)

- **`session::ClozeItem`** (new DTO, camelCase serde + `schemars` + `utoipa`): `lemmaId` (`None` for words with no `Lemma` row, same convention as `WarmupItem`), `lemma`, `pos`, `cefrLevel`, `sentence` (with a single `_____` placeholder inserted by the pipeline, not the LLM), `answer`, `options` (shuffled by the caller), `translation` (native-language learner support).
- **`build_exercise_prompt`** now always requests a top-level `"cloze"` array with **one entry per word of the `"vocabulary"` array** — independent of forced vocabulary. Each entry: `lemma` (exactly as in `vocabulary`), `sentence` (new, simple, obeying the same per-CEFR `sentence_shape_guidance` limits, never reused from exercises/warm-up, entirely in the target language), `answer` (exact inflected form), `distractors` (2–3 plausible but wrong similar grammatical forms), `translation`.
- **`llm::parse`**: new tolerant `RawClozeItem` (all fields optional) and `Exercises.cloze` defaulting to empty — older prompts and bare-array responses keep parsing.
- **`vocabulary::cloze_items`** (new): keeps only no-positive-progress words (also keeping forced-vocabulary lemmas with `correct_uses == 0`), validates anti-hallucination that `answer` appears in `sentence` (normalized compare, replaced at real char boundaries with `_____`, dropped otherwise), assembles and dedups `options` via `normalize_key` (items not ending with 3–4 unique options dropped), dedups by lemma (first wins), and links/fills `lemma_id`/`pos`/`cefr_level` from existing `Lemma` rows.

## Docs

- `docs/flow.md`: new "Session stages" section under "New Topic Session" documenting the warm-up → cloze → translation order and the cloze scoring intent (deterministic right/wrong, counted into word progress server-side).

## Verification

- `cargo test -p open-course-core`: 106 passed (incl. new parse/prompt/vocabulary tests)
- `cargo clippy -p open-course-core --all-features`: clean
- `cargo check --workspace`: clean

Server and web PRs wiring this stage into session preparation, scoring, and the UI follow.
