### PR TITLE
fix(llm): route minimax through the Anthropic-compatible API

### DIFF
--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -83,7 +83,7 @@ impl ProviderId {
     pub fn default_base_url(&self) -> Option<&'static str> {
         match self {
             ProviderId::OpenRouter => Some("https://openrouter.ai/api/v1"),
-            ProviderId::MiniMax => Some("https://api.minimax.io/v1"),
+            ProviderId::MiniMax => Some("https://api.minimax.io/anthropic"),
             ProviderId::Ollama => Some("http://localhost:11434/v1"),
             ProviderId::Custom => None,
             _ => None,

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -52,6 +52,12 @@ fn classify_llm_error<E: std::fmt::Display>(e: E) -> AppError {
     }
 }
 
+/// `additional_params` that keep MiniMax-M3 thinking off on its
+/// Anthropic-compatible API (M2.x models accept but ignore this).
+fn anthropic_disable_thinking_params() -> serde_json::Value {
+    serde_json::json!({ "thinking": { "type": "disabled" } })
+}
+
 #[async_trait]
 pub trait LlmClient: Send + Sync + Any {
     async fn prompt(&self, prompt: &str, system: Option<&str>, max_tokens: u32) -> Result<String>;
@@ -108,10 +114,11 @@ pub struct RigClient {
     /// requires `max_completion_tokens` and rejects unknown parameters such
     /// as the Qwen/Aliyun `enable_thinking` extension.
     openai_native: bool,
-    /// MiniMax thinking models return reasoning inline in `content` wrapped
-    /// in `<think>` tags unless the request asks for `reasoning_split`,
-    /// which would break JSON parsing downstream.
-    reasoning_split: bool,
+    /// MiniMax is called through its Anthropic-compatible API where
+    /// MiniMax-M3 keeps thinking off by default; the explicit
+    /// `thinking: {"type": "disabled"}` additional param guards against a
+    /// default change (M2.x models accept but ignore it).
+    disable_thinking: bool,
 }
 
 impl RigClient {
@@ -171,6 +178,22 @@ impl RigClient {
                     anthropic_base.to_string(),
                 )
             }
+            ProviderId::MiniMax => {
+                // Rows saved before the move to the Anthropic-compatible
+                // API still carry the old OpenAI-compatible default; treat
+                // it as unset so they follow the new default.
+                let base_url = match config.base_url().map(|u| u.trim_end_matches('/')) {
+                    None | Some("") | Some(crate::provider::MINIMAX_LEGACY_BASE_URL) => {
+                        crate::provider::MINIMAX_DEFAULT_BASE_URL
+                    }
+                    Some(custom) => custom,
+                };
+                let client = anthropic::ClientBuilder::new(&api_key)
+                    .base_url(base_url)
+                    .build()
+                    .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
+                (RigClientInner::Anthropic(client), base_url.to_string())
+            }
             _ => {
                 let base_url = base_url.ok_or_else(|| {
                     AppError::ProviderConfig(format!(
@@ -193,25 +216,18 @@ impl RigClient {
             reasoning_effort,
             enable_thinking,
             openai_native,
-            reasoning_split: provider_id == ProviderId::MiniMax,
+            disable_thinking: provider_id == ProviderId::MiniMax,
         })
     }
 
     /// Extra request fields for OpenAI-compatible providers: the
-    /// Qwen/Aliyun `enable_thinking` toggle and MiniMax's `reasoning_split`,
-    /// merged into one object (rig's `additional_params` is set once).
+    /// Qwen/Aliyun `enable_thinking` toggle (rig's `additional_params` is
+    /// set once).
     fn openai_additional_params(&self) -> Option<serde_json::Value> {
-        let mut params = serde_json::Map::new();
         if self.enable_thinking == Some(false) {
-            params.insert("enable_thinking".to_string(), serde_json::json!(false));
-        }
-        if self.reasoning_split {
-            params.insert("reasoning_split".to_string(), serde_json::json!(true));
-        }
-        if params.is_empty() {
-            None
+            Some(serde_json::json!({ "enable_thinking": false }))
         } else {
-            Some(serde_json::Value::Object(params))
+            None
         }
     }
 
@@ -236,12 +252,14 @@ impl RigClient {
                     extractor.build().extract(prompt).await
                 }
                 RigClientInner::Anthropic(client) => {
-                    client
+                    let mut extractor = client
                         .extractor::<T>(&self.model)
-                        .max_tokens(max_tokens as u64)
-                        .build()
-                        .extract(prompt)
-                        .await
+                        .max_tokens(max_tokens as u64);
+                    if self.disable_thinking {
+                        extractor =
+                            extractor.additional_params(anthropic_disable_thinking_params());
+                    }
+                    extractor.build().extract(prompt).await
                 }
                 RigClientInner::Gemini(client) => {
                     let mut extractor = client
@@ -305,8 +323,12 @@ impl RigClient {
         model: &str,
         system: Option<&str>,
         max_tokens: u32,
+        disable_thinking: bool,
     ) -> Agent<anthropic::completion::CompletionModel> {
         let mut builder = client.agent(model).max_tokens(max_tokens as u64);
+        if disable_thinking {
+            builder = builder.additional_params(anthropic_disable_thinking_params());
+        }
         if let Some(system) = system {
             builder = builder.preamble(system);
         }
@@ -349,9 +371,15 @@ impl LlmClient for RigClient {
                     .await
                 }
                 RigClientInner::Anthropic(client) => {
-                    Self::anthropic_agent(client, &self.model, system, max_tokens)
-                        .prompt(prompt)
-                        .await
+                    Self::anthropic_agent(
+                        client,
+                        &self.model,
+                        system,
+                        max_tokens,
+                        self.disable_thinking,
+                    )
+                    .prompt(prompt)
+                    .await
                 }
                 RigClientInner::Gemini(client) => {
                     Self::gemini_agent(client, &self.model, system, max_tokens)
@@ -409,6 +437,7 @@ impl LlmClient for RigClient {
                     system,
                     prompt,
                     max_tokens,
+                    self.disable_thinking,
                 )
                 .await
             }
@@ -535,19 +564,41 @@ mod tests {
     }
 
     #[test]
-    fn minimax_builds_with_default_base_url_and_reasoning_split() {
+    fn minimax_uses_anthropic_api_with_thinking_disabled() {
         with_env_var("MINIMAX_API_KEY", None, || {
             let cfg = config(Some("minimax-key"), None, None);
             let client = RigClient::from_config(&cfg, ProviderId::MiniMax).expect("should build");
-            assert_eq!(client.base_url, "https://api.minimax.io/v1");
-            assert!(matches!(client.inner, RigClientInner::OpenAi(_)));
-            let params = client
-                .openai_additional_params()
-                .expect("minimax always requests reasoning_split");
-            assert_eq!(
-                params.get("reasoning_split"),
-                Some(&serde_json::json!(true))
+            assert_eq!(client.base_url, crate::provider::MINIMAX_DEFAULT_BASE_URL);
+            assert!(matches!(client.inner, RigClientInner::Anthropic(_)));
+            assert!(client.disable_thinking);
+        });
+    }
+
+    #[test]
+    fn minimax_legacy_base_url_migrates_to_anthropic_endpoint() {
+        with_env_var("MINIMAX_API_KEY", None, || {
+            for stored in [
+                None,
+                Some("https://api.minimax.io/v1"),
+                Some("https://api.minimax.io/v1/"),
+            ] {
+                let cfg = config(Some("minimax-key"), stored, None);
+                let client =
+                    RigClient::from_config(&cfg, ProviderId::MiniMax).expect("should build");
+                assert_eq!(
+                    client.base_url,
+                    crate::provider::MINIMAX_DEFAULT_BASE_URL,
+                    "stored base_url {stored:?}"
+                );
+            }
+            // A genuinely custom base URL is kept.
+            let cfg = config(
+                Some("minimax-key"),
+                Some("https://proxy.example.com/anthropic"),
+                None,
             );
+            let client = RigClient::from_config(&cfg, ProviderId::MiniMax).expect("should build");
+            assert_eq!(client.base_url, "https://proxy.example.com/anthropic");
         });
     }
 

--- a/crates/llm/src/model_listing.rs
+++ b/crates/llm/src/model_listing.rs
@@ -18,7 +18,24 @@ pub async fn list_models(
     match provider_id {
         ProviderId::Anthropic => list_anthropic_models(api_key, base_url).await,
         ProviderId::Google => list_gemini_models(api_key, base_url).await,
+        ProviderId::MiniMax => {
+            // Chat moved to the Anthropic-compatible API, which serves
+            // messages only; model listing stays on the OpenAI-compatible
+            // endpoint. Configs carrying either known default map to it.
+            let base_url = minimax_listing_base_url(base_url);
+            list_openai_models_at(base_url, api_key).await
+        }
         _ => list_openai_compatible_models(provider_id, api_key, base_url).await,
+    }
+}
+
+/// Base URL for MiniMax model listing: known chat defaults (old and new)
+/// map to the OpenAI-compatible endpoint, custom URLs are kept as-is.
+fn minimax_listing_base_url(base_url: Option<&str>) -> &str {
+    use crate::provider::{MINIMAX_DEFAULT_BASE_URL, MINIMAX_LEGACY_BASE_URL};
+    match base_url.map(|u| u.trim_end_matches('/')) {
+        None | Some("") | Some(MINIMAX_DEFAULT_BASE_URL) => MINIMAX_LEGACY_BASE_URL,
+        Some(custom) => custom,
     }
 }
 
@@ -125,8 +142,12 @@ async fn list_openai_compatible_models(
     let meta = ProviderMeta::for_provider(provider_id);
     let base_url = base_url
         .or(meta.default_base_url)
-        .ok_or_else(|| AppError::ProviderConfig(format!("{provider_id:?} requires a base URL")))?
-        .trim_end_matches('/');
+        .ok_or_else(|| AppError::ProviderConfig(format!("{provider_id:?} requires a base URL")))?;
+    list_openai_models_at(base_url, api_key).await
+}
+
+async fn list_openai_models_at(base_url: &str, api_key: Option<&str>) -> Result<Vec<ModelInfo>> {
+    let base_url = base_url.trim_end_matches('/');
     let url = format!("{base_url}/models");
 
     let client = http_client()?;
@@ -211,5 +232,23 @@ mod tests {
     #[test]
     fn http_client_builds() {
         let _client = http_client().unwrap();
+    }
+
+    #[test]
+    fn minimax_listing_uses_openai_compatible_endpoint_for_known_defaults() {
+        use crate::provider::{MINIMAX_DEFAULT_BASE_URL, MINIMAX_LEGACY_BASE_URL};
+        assert_eq!(minimax_listing_base_url(None), MINIMAX_LEGACY_BASE_URL);
+        assert_eq!(
+            minimax_listing_base_url(Some(MINIMAX_DEFAULT_BASE_URL)),
+            MINIMAX_LEGACY_BASE_URL
+        );
+        assert_eq!(
+            minimax_listing_base_url(Some("https://api.minimax.io/v1/")),
+            MINIMAX_LEGACY_BASE_URL
+        );
+        assert_eq!(
+            minimax_listing_base_url(Some("https://proxy.example.com/v1")),
+            "https://proxy.example.com/v1"
+        );
     }
 }

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -1,5 +1,15 @@
 use open_course_config::provider::ProviderId;
 
+/// MiniMax's Anthropic-compatible API: MiniMax-M3 keeps thinking off by
+/// default there, unlike the OpenAI-compatible endpoint where reasoning
+/// burns the completion budget and the answer comes back empty.
+pub const MINIMAX_DEFAULT_BASE_URL: &str = "https://api.minimax.io/anthropic";
+
+/// MiniMax's OpenAI-compatible API: the pre-Anthropic chat default. Chat
+/// configs carrying it are migrated to `MINIMAX_DEFAULT_BASE_URL`; model
+/// listing still uses it (the `/anthropic` path serves messages only).
+pub const MINIMAX_LEGACY_BASE_URL: &str = "https://api.minimax.io/v1";
+
 pub struct ProviderMeta {
     pub id: ProviderId,
     pub label: &'static str,
@@ -65,7 +75,7 @@ impl ProviderMeta {
                 label: "MiniMax",
                 requires_api_key: true,
                 api_key_optional: false,
-                default_base_url: Some("https://api.minimax.io/v1"),
+                default_base_url: Some(MINIMAX_DEFAULT_BASE_URL),
                 env_key: Some("MINIMAX_API_KEY"),
             },
             ProviderId::Ollama => ProviderMeta {

--- a/crates/llm/src/streaming.rs
+++ b/crates/llm/src/streaming.rs
@@ -232,15 +232,13 @@ pub async fn stream_openai_compatible(
     }))
 }
 
-pub async fn stream_anthropic_messages(
-    base_url: &str,
-    api_key: &str,
+fn build_anthropic_request_body(
     model: &str,
     system: Option<&str>,
     prompt: &str,
     max_tokens: u32,
-) -> Result<LlmStream> {
-    let client = Client::new();
+    disable_thinking: bool,
+) -> serde_json::Value {
     let mut body = json!({
         "model": model,
         "max_tokens": max_tokens,
@@ -250,6 +248,27 @@ pub async fn stream_anthropic_messages(
     if let Some(system) = system {
         body["system"] = json!(system);
     }
+    // MiniMax-M3 keeps thinking off by default on its Anthropic-compatible
+    // API; the explicit `disabled` guards against a default change. M2.x
+    // models accept but ignore it (thinking stays on).
+    if disable_thinking {
+        body["thinking"] = json!({"type": "disabled"});
+    }
+    body
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn stream_anthropic_messages(
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    system: Option<&str>,
+    prompt: &str,
+    max_tokens: u32,
+    disable_thinking: bool,
+) -> Result<LlmStream> {
+    let client = Client::new();
+    let body = build_anthropic_request_body(model, system, prompt, max_tokens, disable_thinking);
     let url = format!("{}/v1/messages", base_url.trim_end_matches('/'));
 
     let response = client
@@ -309,5 +328,20 @@ mod tests {
         assert!(body.get("max_tokens").is_none());
         assert_eq!(body["reasoning_effort"], json!("low"));
         assert!(body.get("enable_thinking").is_none());
+    }
+
+    #[test]
+    fn anthropic_body_omits_thinking_by_default() {
+        let body = build_anthropic_request_body("m", Some("sys"), "hi", 100, false);
+        assert!(body.get("thinking").is_none());
+        assert_eq!(body["max_tokens"], json!(100));
+        assert_eq!(body["system"], json!("sys"));
+    }
+
+    #[test]
+    fn anthropic_body_disables_thinking_when_requested() {
+        let body = build_anthropic_request_body("m", None, "hi", 100, true);
+        assert_eq!(body["thinking"], json!({"type": "disabled"}));
+        assert_eq!(body["stream"], json!(true));
     }
 }


### PR DESCRIPTION
## Problem

MiniMax thinking models reason by default on the OpenAI-compatible endpoint (`api.minimax.io/v1`), reasoning tokens count against the completion budget, and thinking cannot be disabled there (`enable_thinking` is ignored). With `reasoning_split` the thinking moves out of `content`, so a generation call whose budget is consumed by reasoning comes back with empty content — the same failure observed server-side for `session_prepare` jobs (scriptology/open-course-server#47).

## Fix

MiniMax exposes an Anthropic-compatible API at `https://api.minimax.io/anthropic` where **MiniMax-M3 has thinking off by default** (`thinking: {"type": "disabled"}` keeps it off explicitly; M2.x models accept but ignore it, and rig splits their `thinking` blocks from the text).

- `RigClient::from_config` builds a rig `anthropic::Client` for MiniMax against `/anthropic` and sends `thinking: {"type": "disabled"}` via `additional_params` on prompt/extract/stream requests.
- Stored configs carrying the legacy default base URL (`https://api.minimax.io/v1`) are treated as unset and follow the new default; custom base URLs are preserved.
- Model listing stays on the OpenAI-compatible `/v1/models` endpoint (the `/anthropic` path documents messages/count_tokens only); known chat defaults map back to it for listing.
- The dead `reasoning_split` plumbing is removed; streaming bodies for MiniMax include `thinking: disabled`.

## Verification

- `cargo test --workspace` — all tests pass, including new ones: MiniMax builds an Anthropic client with thinking disabled, legacy base URL migration (empty/old default/trailing slash/custom preserved), Anthropic request body with/without `thinking`, listing base URL mapping.
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --check` clean.