### PR TITLE
feat(llm): disable thinking for Anthropic-family providers and remap retired gemini-2.5-flash

### DIFF
--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -52,8 +52,11 @@ fn classify_llm_error<E: std::fmt::Display>(e: E) -> AppError {
     }
 }
 
-/// `additional_params` that keep MiniMax-M3 thinking off on its
-/// Anthropic-compatible API (M2.x models accept but ignore this).
+/// `additional_params` that keep reasoning off on Anthropic-family APIs:
+/// newer Claude models (e.g. claude-sonnet-5) enable adaptive thinking by
+/// default, which adds latency and burns output tokens, and MiniMax-M3 is
+/// guarded against a thinking-on default change (older models accept but
+/// ignore this field).
 fn anthropic_disable_thinking_params() -> serde_json::Value {
     serde_json::json!({ "thinking": { "type": "disabled" } })
 }
@@ -114,10 +117,11 @@ pub struct RigClient {
     /// requires `max_completion_tokens` and rejects unknown parameters such
     /// as the Qwen/Aliyun `enable_thinking` extension.
     openai_native: bool,
-    /// MiniMax is called through its Anthropic-compatible API where
-    /// MiniMax-M3 keeps thinking off by default; the explicit
-    /// `thinking: {"type": "disabled"}` additional param guards against a
-    /// default change (M2.x models accept but ignore it).
+    /// Anthropic-family providers (Anthropic, MiniMax, and custom
+    /// `messages` endpoints) are asked to keep thinking off for speed via
+    /// the `thinking: {"type": "disabled"}` request field; newer Claude
+    /// models enable adaptive thinking by default, and the explicit field
+    /// guards MiniMax-M3 against a default change.
     disable_thinking: bool,
 }
 
@@ -208,6 +212,8 @@ impl RigClient {
             }
         };
 
+        let disable_thinking = matches!(inner, RigClientInner::Anthropic(_));
+
         Ok(Self {
             inner,
             model,
@@ -216,7 +222,7 @@ impl RigClient {
             reasoning_effort,
             enable_thinking,
             openai_native,
-            disable_thinking: provider_id == ProviderId::MiniMax,
+            disable_thinking,
         })
     }
 
@@ -572,6 +578,31 @@ mod tests {
             assert!(matches!(client.inner, RigClientInner::Anthropic(_)));
             assert!(client.disable_thinking);
         });
+    }
+
+    #[test]
+    fn anthropic_uses_thinking_disabled() {
+        let cfg = config(Some("anthropic-key"), None, None);
+        let client = RigClient::from_config(&cfg, ProviderId::Anthropic).expect("should build");
+        assert!(matches!(client.inner, RigClientInner::Anthropic(_)));
+        assert!(client.disable_thinking);
+    }
+
+    #[test]
+    fn custom_messages_endpoint_uses_thinking_disabled() {
+        let mut cfg = config(Some("key"), Some("https://example.com/v1"), None);
+        let ProviderConfig::ApiKey { endpoint, .. } = &mut cfg;
+        *endpoint = Some("messages".to_string());
+        let client = RigClient::from_config(&cfg, ProviderId::Custom).expect("should build");
+        assert!(matches!(client.inner, RigClientInner::Anthropic(_)));
+        assert!(client.disable_thinking);
+    }
+
+    #[test]
+    fn openai_compatible_providers_keep_thinking_untouched() {
+        let cfg = config(Some("key"), None, None);
+        let client = RigClient::from_config(&cfg, ProviderId::DeepSeek).expect("should build");
+        assert!(!client.disable_thinking);
     }
 
     #[test]

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -125,7 +125,16 @@ impl RigClient {
     pub fn from_config(config: &ProviderConfig, provider_id: ProviderId) -> Result<Self> {
         let meta = ProviderMeta::for_provider(provider_id);
         let api_key = meta.resolve_api_key(config.api_key());
-        let model = config.model().to_string();
+        // Configs saved before Google retired gemini-2.5-flash now 404
+        // ("Please update your code to use models/gemini-3.6-flash");
+        // silently follow the replacement instead of failing at runtime.
+        let model = if provider_id == ProviderId::Google
+            && crate::provider::GOOGLE_RETIRED_MODELS.contains(&config.model())
+        {
+            crate::provider::GOOGLE_RETIRED_MODEL_REPLACEMENT.to_string()
+        } else {
+            config.model().to_string()
+        };
         let base_url = config.base_url().or(meta.default_base_url);
 
         if meta.requires_api_key && !meta.api_key_optional && api_key.is_none() {
@@ -607,5 +616,42 @@ mod tests {
         let cfg = config(Some("key"), None, None);
         let client = RigClient::from_config(&cfg, ProviderId::DeepSeek).expect("should build");
         assert_eq!(client.openai_additional_params(), None);
+    }
+
+    #[test]
+    fn google_retired_models_remap_to_replacement() {
+        for retired in crate::provider::GOOGLE_RETIRED_MODELS {
+            let mut cfg = config(Some("gemini-key"), None, None);
+            let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+            *model = retired.to_string();
+            let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
+            assert_eq!(
+                client.model,
+                crate::provider::GOOGLE_RETIRED_MODEL_REPLACEMENT,
+                "stored model {retired:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn google_other_models_are_untouched() {
+        for kept in ["gemini-3.6-flash", "gemini-3-pro", "test-model"] {
+            let mut cfg = config(Some("gemini-key"), None, None);
+            let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+            *model = kept.to_string();
+            let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
+            assert_eq!(client.model, kept, "model {kept:?}");
+        }
+    }
+
+    #[test]
+    fn retired_google_model_ids_do_not_affect_other_providers() {
+        // A non-Google provider configured with a retired Google model id
+        // (e.g. an OpenAI-compatible gateway proxying Gemini) keeps it.
+        let mut cfg = config(Some("key"), Some("https://proxy.example.com/v1"), None);
+        let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+        *model = "gemini-2.5-flash".to_string();
+        let client = RigClient::from_config(&cfg, ProviderId::Custom).expect("should build");
+        assert_eq!(client.model, "gemini-2.5-flash");
     }
 }

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -10,6 +10,15 @@ pub const MINIMAX_DEFAULT_BASE_URL: &str = "https://api.minimax.io/anthropic";
 /// listing still uses it (the `/anthropic` path serves messages only).
 pub const MINIMAX_LEGACY_BASE_URL: &str = "https://api.minimax.io/v1";
 
+/// Google model ids retired from the Gemini API: requests 404 with
+/// "Please update your code to use models/gemini-3.6-flash". Configs still
+/// carrying one of these ids are remapped to `GOOGLE_RETIRED_MODEL_REPLACEMENT`
+/// at client construction time.
+pub const GOOGLE_RETIRED_MODELS: [&str; 2] = ["gemini-2.5-flash", "models/gemini-2.5-flash"];
+
+/// Replacement served for every id in `GOOGLE_RETIRED_MODELS`.
+pub const GOOGLE_RETIRED_MODEL_REPLACEMENT: &str = "gemini-3.6-flash";
+
 pub struct ProviderMeta {
     pub id: ProviderId,
     pub label: &'static str,

--- a/crates/llm/src/streaming.rs
+++ b/crates/llm/src/streaming.rs
@@ -248,9 +248,10 @@ fn build_anthropic_request_body(
     if let Some(system) = system {
         body["system"] = json!(system);
     }
-    // MiniMax-M3 keeps thinking off by default on its Anthropic-compatible
-    // API; the explicit `disabled` guards against a default change. M2.x
-    // models accept but ignore it (thinking stays on).
+    // Anthropic-family providers are asked to keep thinking off for speed:
+    // newer Claude models (e.g. claude-sonnet-5) enable adaptive thinking by
+    // default, and the explicit `disabled` guards MiniMax-M3 against a
+    // default change. Older models accept but ignore the field.
     if disable_thinking {
         body["thinking"] = json!({"type": "disabled"});
     }


### PR DESCRIPTION
## What

Two Anthropic/Google robustness fixes, combined into one branch:

1. **Disable thinking for all Anthropic-family providers** (was MiniMax-only from #102): Claude Sonnet 5 enables adaptive thinking by default, which adds a thinking content block, extra latency and output-token burn. Verified against the live API: `thinking: {"type": "disabled"}` is accepted by claude-sonnet-5, claude-sonnet-4-6 and claude-haiku-4-5 (no-op on the older two) and cuts ~25% latency / ~37% output tokens on a small JSON task. The existing `disable_thinking` flag now covers Anthropic, MiniMax and custom messages-endpoint providers across all call paths (rig agent, extractor, streaming).

2. **Remap retired gemini-2.5-flash to gemini-3.6-flash**: Google's API 404s the retired id, causing repeated production job failures. The model id lives in user configs, so `RigClient::from_config` now substitutes the replacement at construction time (non-persistent, mirroring the MiniMax legacy base-URL remap). Covers both `gemini-2.5-flash` and `models/gemini-2.5-flash`; other providers and models are untouched.

## Verification

- `cargo test -p open-course-llm`: 44 passed, 0 failed (incl. 6 new tests)
- `cargo test --workspace`: green
- `cargo clippy -p open-course-llm --all-targets`: clean

Supersedes #105.
