### PR TITLE
Remap retired gemini-2.5-flash model ids to gemini-3.6-flash

### DIFF
--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -125,7 +125,16 @@ impl RigClient {
     pub fn from_config(config: &ProviderConfig, provider_id: ProviderId) -> Result<Self> {
         let meta = ProviderMeta::for_provider(provider_id);
         let api_key = meta.resolve_api_key(config.api_key());
-        let model = config.model().to_string();
+        // Configs saved before Google retired gemini-2.5-flash now 404
+        // ("Please update your code to use models/gemini-3.6-flash");
+        // silently follow the replacement instead of failing at runtime.
+        let model = if provider_id == ProviderId::Google
+            && crate::provider::GOOGLE_RETIRED_MODELS.contains(&config.model())
+        {
+            crate::provider::GOOGLE_RETIRED_MODEL_REPLACEMENT.to_string()
+        } else {
+            config.model().to_string()
+        };
         let base_url = config.base_url().or(meta.default_base_url);
 
         if meta.requires_api_key && !meta.api_key_optional && api_key.is_none() {
@@ -607,5 +616,42 @@ mod tests {
         let cfg = config(Some("key"), None, None);
         let client = RigClient::from_config(&cfg, ProviderId::DeepSeek).expect("should build");
         assert_eq!(client.openai_additional_params(), None);
+    }
+
+    #[test]
+    fn google_retired_models_remap_to_replacement() {
+        for retired in crate::provider::GOOGLE_RETIRED_MODELS {
+            let mut cfg = config(Some("gemini-key"), None, None);
+            let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+            *model = retired.to_string();
+            let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
+            assert_eq!(
+                client.model,
+                crate::provider::GOOGLE_RETIRED_MODEL_REPLACEMENT,
+                "stored model {retired:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn google_other_models_are_untouched() {
+        for kept in ["gemini-3.6-flash", "gemini-3-pro", "test-model"] {
+            let mut cfg = config(Some("gemini-key"), None, None);
+            let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+            *model = kept.to_string();
+            let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
+            assert_eq!(client.model, kept, "model {kept:?}");
+        }
+    }
+
+    #[test]
+    fn retired_google_model_ids_do_not_affect_other_providers() {
+        // A non-Google provider configured with a retired Google model id
+        // (e.g. an OpenAI-compatible gateway proxying Gemini) keeps it.
+        let mut cfg = config(Some("key"), Some("https://proxy.example.com/v1"), None);
+        let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+        *model = "gemini-2.5-flash".to_string();
+        let client = RigClient::from_config(&cfg, ProviderId::Custom).expect("should build");
+        assert_eq!(client.model, "gemini-2.5-flash");
     }
 }

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -10,6 +10,15 @@ pub const MINIMAX_DEFAULT_BASE_URL: &str = "https://api.minimax.io/anthropic";
 /// listing still uses it (the `/anthropic` path serves messages only).
 pub const MINIMAX_LEGACY_BASE_URL: &str = "https://api.minimax.io/v1";
 
+/// Google model ids retired from the Gemini API: requests 404 with
+/// "Please update your code to use models/gemini-3.6-flash". Configs still
+/// carrying one of these ids are remapped to `GOOGLE_RETIRED_MODEL_REPLACEMENT`
+/// at client construction time.
+pub const GOOGLE_RETIRED_MODELS: [&str; 2] = ["gemini-2.5-flash", "models/gemini-2.5-flash"];
+
+/// Replacement served for every id in `GOOGLE_RETIRED_MODELS`.
+pub const GOOGLE_RETIRED_MODEL_REPLACEMENT: &str = "gemini-3.6-flash";
+
 pub struct ProviderMeta {
     pub id: ProviderId,
     pub label: &'static str,


### PR DESCRIPTION
## Summary

Google retired `gemini-2.5-flash`: API requests 404 with "Please update your code to use models/gemini-3.6-flash". Since the model id comes from each user's local CLI config, existing installs break without manual edits.

This adds a runtime remap mirroring the existing MiniMax legacy base-URL migration:

- `crates/llm/src/provider.rs`: new documented consts `GOOGLE_RETIRED_MODELS` (`gemini-2.5-flash`, `models/gemini-2.5-flash`) and `GOOGLE_RETIRED_MODEL_REPLACEMENT` (`gemini-3.6-flash`), quoting Google's 404 message.
- `crates/llm/src/client.rs` (`RigClient::from_config`): when the provider is Google and the configured model matches a retired id, substitute the replacement at construction time. All runtime paths (prompt, streaming, structured extraction) read `self.model`, so the single remap covers them consistently. Non-persistent — the config file is untouched.

## Tests

New unit tests in `client.rs`:
- retired ids (bare and `models/`-prefixed) remap to `gemini-3.6-flash`
- other Google models pass through unchanged
- non-Google providers carrying the same string (e.g. an OpenAI-compatible gateway) are untouched

## Verification

- `cargo test -p open-course-llm` — 41 passed, 0 failed
- `cargo test --workspace` — all pass
- `cargo clippy -p open-course-llm --all-targets` — clean