### PR TITLE
fix(llm): empty reasoning_content no longer swallows streamed content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.18.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/llm/src/streaming.rs
+++ b/crates/llm/src/streaming.rs
@@ -101,21 +101,23 @@ fn parse_sse_content(
 
 fn parse_openai_frame(frame: &str) -> Option<StreamChunk> {
     parse_sse_content(frame, |value| {
-        if let Some(content) = value
+        let delta = value
             .get("choices")
             .and_then(|c| c.as_array())
             .and_then(|c| c.first())
-            .and_then(|c| c.get("delta"))
+            .and_then(|c| c.get("delta"));
+        // Some gateways (e.g. Aliyun Model Studio's compatible mode) put
+        // both keys in every delta, with `reasoning_content: ""` once the
+        // real content starts — an empty reasoning string must not swallow
+        // the content in the same frame.
+        if let Some(content) = delta
             .and_then(|d| d.get("reasoning_content"))
             .and_then(|c| c.as_str())
+            && !content.is_empty()
         {
             return Some(StreamChunk::Reasoning(content.to_string()));
         }
-        if let Some(content) = value
-            .get("choices")
-            .and_then(|c| c.as_array())
-            .and_then(|c| c.first())
-            .and_then(|c| c.get("delta"))
+        if let Some(content) = delta
             .and_then(|d| d.get("content"))
             .and_then(|c| c.as_str())
         {
@@ -329,6 +331,27 @@ mod tests {
         assert!(body.get("max_tokens").is_none());
         assert_eq!(body["reasoning_effort"], json!("low"));
         assert!(body.get("enable_thinking").is_none());
+    }
+
+    #[test]
+    fn openai_frame_prefers_non_empty_reasoning() {
+        let frame =
+            r#"data: {"choices":[{"index":0,"delta":{"content":"","reasoning_content":"We"}}]}"#;
+        match parse_openai_frame(frame) {
+            Some(StreamChunk::Reasoning(text)) => assert_eq!(text, "We"),
+            other => panic!("expected reasoning chunk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn openai_frame_empty_reasoning_does_not_swallow_content() {
+        // Aliyun-compatible gateways emit both keys in one delta, with
+        // `reasoning_content: ""` once the answer content starts.
+        let frame = r#"data: {"choices":[{"index":0,"delta":{"content":"STREAM_OK","reasoning_content":""}}]}"#;
+        match parse_openai_frame(frame) {
+            Some(StreamChunk::Content(text)) => assert_eq!(text, "STREAM_OK"),
+            other => panic!("expected content chunk, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Against Aliyun Model Studio's OpenAI-compatible mode (`...maas.aliyuncs.com/compatible-mode/v1`) with reasoning models (deepseek-v4-pro), model diagnostics showed:

- ✓ Connectivity
- ✗ Streaming — "no content chunk received"
- ✗ Exercise generation / Answer analysis — 90s timeouts

Root cause found by replaying raw SSE from the endpoint: **every** delta carries both keys, e.g.

```json
{"delta":{"content":"STREAM_OK","reasoning_content":""}}
```

`parse_openai_frame` checked `reasoning_content` first and returned it unconditionally, so the empty reasoning string swallowed the real content in the same frame. The stream then ended with zero content chunks → diagnostics failed, and the real session pipeline's streaming attempt fell back to parsing reasoning text → parse failure → retries → timeouts.

## Fix

Only treat `reasoning_content` as a reasoning chunk when it is **non-empty**; otherwise fall through to `content` in the same frame. Added unit tests for both shapes.

## Note (follow-up, not in this PR)

deepseek-v4-pro on this gateway thinks by default; reasoning burns the `max_tokens` budget and adds latency (small JSON gen: 15s thinking on vs 5.6s off). The gateway honors the Aliyun `enable_thinking: false` extension which the CLI already supports in `ProviderConfig` but never exposes in the UI — worth surfacing a toggle for OpenAI-compatible providers.

## Test plan

- [x] `cargo test -p open-course-llm` — 46 passed, incl. 2 new parser tests
- [x] `cargo clippy -p open-course-llm --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean