### PR TITLE
feat(cli): discover server-side pairs on sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/src/app/sync.rs
+++ b/crates/cli/src/app/sync.rs
@@ -7,13 +7,13 @@
 
 use std::sync::Arc;
 
-use open_course_config::{pair_db_path, resolve_sync_server_url};
+use open_course_config::{merge_remote_pairs, pair_db_path, resolve_sync_server_url, write_config};
 use open_course_db::Database;
 use open_course_sync::{
     BindScenario, PushError, SyncClient, SyncError, TokenStore, backfill_outbox,
 };
 
-use crate::app::AppState;
+use crate::app::{AppState, View};
 use crate::ui::views::settings::account::{PairSyncStatus, SyncFailure, SyncMessage, SyncReport};
 
 /// Why a background sync was scheduled.
@@ -75,12 +75,60 @@ pub async fn schedule(state: &mut AppState, trigger: SyncTrigger) {
             spawn_pull_all(state);
         }
         SyncTrigger::AfterLogin => {
+            discover_pairs(state).await;
             state.sync.active = true;
             spawn_sync_all(state, SyncAllMode::AfterLogin);
         }
         SyncTrigger::Manual => {
+            discover_pairs(state).await;
             state.sync.active = true;
             spawn_sync_all(state, SyncAllMode::Manual);
+        }
+    }
+}
+
+/// Fetches the account's pair list from the server and merges pairs the
+/// config does not know yet (created on the web or another device) into it,
+/// so the sync-all run that follows binds and pulls them. Best-effort: any
+/// failure (signed out, offline) keeps the local pair list.
+async fn discover_pairs(state: &mut AppState) {
+    let base_url = resolve_sync_server_url(state.config.as_ref());
+    let token = match TokenStore::new(state.data_dir.clone()).load().await {
+        Ok(Some(token)) => token,
+        _ => return,
+    };
+    let client = match SyncClient::new(&base_url) {
+        Ok(client) => client.with_access_token(token.access_token),
+        Err(_) => return,
+    };
+    let remote = match client.list_pairs().await {
+        Ok(pairs) => pairs,
+        Err(_) => return,
+    };
+    let Some(config) = state.config.as_mut() else {
+        return;
+    };
+    let added = merge_remote_pairs(config, &remote);
+    if added.is_empty() {
+        return;
+    }
+    if write_config(config, &state.data_dir).is_err() {
+        return;
+    }
+    // The SyncAll view seeded its rows before the orchestrator ran; add rows
+    // for the discovered pairs so their progress is visible too.
+    if state.view == View::SyncAll && !state.sync_all.done {
+        for pair in &config.pairs {
+            if added.contains(&pair.id) {
+                state.sync_all.rows.push(crate::ui::views::sync_all::PairSyncRow {
+                    pair_id: pair.id.clone(),
+                    title: format!(
+                        "{} → {}",
+                        pair.profile.native_language, pair.profile.target_language
+                    ),
+                    status: None,
+                });
+            }
         }
     }
 }

--- a/crates/cli/src/app/sync.rs
+++ b/crates/cli/src/app/sync.rs
@@ -6,6 +6,7 @@
 //! only decides WHAT runs and spawns the tasks.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use open_course_config::{merge_remote_pairs, pair_db_path, resolve_sync_server_url, write_config};
 use open_course_db::Database;
@@ -43,6 +44,29 @@ pub struct SyncSchedulerState {
     pub pending: Option<SyncTrigger>,
 }
 
+/// Per-pair ceiling for the quiet app-start pull: the short HTTP timeout
+/// plus room for opening the pair's database. A hung step is skipped — it
+/// must never wedge the scheduler.
+const PAIR_PULL_TIMEOUT: Duration = Duration::from_secs(15);
+/// Per-pair ceiling for a sync-all run (a bind can backfill and push a large
+/// outbox: several retried requests). A hung pair is marked failed.
+const PAIR_SYNC_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Appends a timestamped line to `.open-course-cli/sync-debug.log`
+/// (diagnostics for sync scheduling/hang investigations).
+fn debug_log(data_dir: &std::path::Path, message: &str) {
+    use std::io::Write;
+    let path = open_course_config::open_course_dir(data_dir).join("sync-debug.log");
+    let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    else {
+        return;
+    };
+    let _ = writeln!(file, "{} {}", chrono::Utc::now().to_rfc3339(), message);
+}
+
 /// One-off operations shared by the account view (the FreshLocal/FreshCloud
 /// bind follow-ups). Moved here so every spawned sync task lives in one
 /// module.
@@ -58,7 +82,12 @@ pub(crate) enum SyncKind {
 /// coalesced: the running task finishes, then the LAST pending trigger is
 /// re-run once.
 pub async fn schedule(state: &mut AppState, trigger: SyncTrigger) {
+    debug_log(&state.data_dir, &format!("schedule: {trigger:?}"));
     if state.sync.active {
+        debug_log(
+            &state.data_dir,
+            &format!("schedule: {trigger:?} coalesced (another run is active)"),
+        );
         state.sync.pending = Some(trigger);
         return;
     }
@@ -92,10 +121,14 @@ pub async fn schedule(state: &mut AppState, trigger: SyncTrigger) {
 /// so the sync-all run that follows binds and pulls them. Best-effort: any
 /// failure (signed out, offline) keeps the local pair list.
 async fn discover_pairs(state: &mut AppState) {
+    debug_log(&state.data_dir, "discover: fetching remote pairs");
     let base_url = resolve_sync_server_url(state.config.as_ref());
     let token = match TokenStore::new(state.data_dir.clone()).load().await {
         Ok(Some(token)) => token,
-        _ => return,
+        _ => {
+            debug_log(&state.data_dir, "discover: no token, skipped");
+            return;
+        }
     };
     let client = match SyncClient::new(&base_url) {
         Ok(client) => client.with_access_token(token.access_token),
@@ -103,12 +136,23 @@ async fn discover_pairs(state: &mut AppState) {
     };
     let remote = match client.list_pairs().await {
         Ok(pairs) => pairs,
-        Err(_) => return,
+        Err(e) => {
+            debug_log(&state.data_dir, &format!("discover: list failed: {e}"));
+            return;
+        }
     };
     let Some(config) = state.config.as_mut() else {
         return;
     };
     let added = merge_remote_pairs(config, &remote);
+    debug_log(
+        &state.data_dir,
+        &format!(
+            "discover: {} remote pair(s), {} added",
+            remote.len(),
+            added.len()
+        ),
+    );
     if added.is_empty() {
         return;
     }
@@ -261,6 +305,7 @@ fn spawn_pull_all(state: &AppState) {
     let active_db = Arc::clone(&state.db);
     let tx = state.sync_tx.clone();
     let inner = tokio::spawn(async move {
+        debug_log(&data_dir, "pull-all: started");
         let token = match TokenStore::new(data_dir.clone()).load().await {
             Ok(Some(token)) => token,
             // Signed out (or an unreadable store): nothing to pull.
@@ -272,12 +317,29 @@ fn spawn_pull_all(state: &AppState) {
         };
         let mut unauthorized = false;
         for pair_id in &pair_ids {
-            let Some(db) = open_pair_db(&data_dir, &active_db, &active_pair, pair_id).await else {
+            let step = async {
+                let db = open_pair_db(&data_dir, &active_db, &active_pair, pair_id).await?;
+                if !db.metadata().sync_enabled().await.unwrap_or(false) {
+                    return Some((db, false));
+                }
+                Some((db, true))
+            };
+            let Some((db, enabled)) = tokio::time::timeout(PAIR_PULL_TIMEOUT, step)
+                .await
+                .unwrap_or_else(|_| {
+                    debug_log(
+                        &data_dir,
+                        &format!("pull-all: {pair_id}: open/check TIMED OUT"),
+                    );
+                    None
+                })
+            else {
                 continue;
             };
-            if !db.metadata().sync_enabled().await.unwrap_or(false) {
+            if !enabled {
                 continue;
             }
+            debug_log(&data_dir, &format!("pull-all: {pair_id}: pulling"));
             match client.pull_with_timeout(&db, pair_id).await {
                 Ok(_) => {
                     let _ = db
@@ -293,6 +355,7 @@ fn spawn_pull_all(state: &AppState) {
                 Err(_) => {}
             }
         }
+        debug_log(&data_dir, "pull-all: finished");
         Some(unauthorized)
     });
     tokio::spawn(async move {
@@ -339,11 +402,16 @@ fn spawn_sync_all(state: &mut AppState, mode: SyncAllMode) {
     let active_db = Arc::clone(&state.db);
     let tx = state.sync_tx.clone();
     let total = pair_ids.len();
+    debug_log(
+        &data_dir,
+        &format!("sync-all: started ({total} pair(s), mode {mode:?})"),
+    );
     // (index of the pair currently syncing, its id) — for panic reporting.
     let current = Arc::new(std::sync::Mutex::new((0usize, String::new())));
     let inner = {
         let current = Arc::clone(&current);
         let tx = tx.clone();
+        let data_dir = data_dir.clone();
         tokio::spawn(async move {
             let token = match TokenStore::new(data_dir.clone()).load().await {
                 Ok(Some(token)) => token,
@@ -396,14 +464,28 @@ fn spawn_sync_all(state: &mut AppState, mode: SyncAllMode) {
                         status: PairSyncStatus::Running,
                     })
                     .await;
-                let status = match open_pair_db(&data_dir, &active_db, &active_pair, pair_id).await
-                {
-                    Some(db) => match mode {
-                        SyncAllMode::AfterLogin => bind_and_sync(&client, &db, pair_id).await,
-                        SyncAllMode::Manual => manual_sync_pair(&client, &db, pair_id).await,
-                    },
-                    None => PairSyncStatus::Failed("database unavailable".to_string()),
+                debug_log(&data_dir, &format!("sync-all: {pair_id}: running"));
+                let step = async {
+                    match open_pair_db(&data_dir, &active_db, &active_pair, pair_id).await {
+                        Some(db) => match mode {
+                            SyncAllMode::AfterLogin => {
+                                bind_and_sync(&data_dir, &client, &db, pair_id).await
+                            }
+                            SyncAllMode::Manual => {
+                                manual_sync_pair(&data_dir, &client, &db, pair_id).await
+                            }
+                        },
+                        None => PairSyncStatus::Failed("database unavailable".to_string()),
+                    }
                 };
+                let status = match tokio::time::timeout(PAIR_SYNC_TIMEOUT, step).await {
+                    Ok(status) => status,
+                    Err(_) => {
+                        debug_log(&data_dir, &format!("sync-all: {pair_id}: TIMED OUT"));
+                        PairSyncStatus::Failed("timed out".to_string())
+                    }
+                };
+                debug_log(&data_dir, &format!("sync-all: {pair_id}: {status:?}"));
                 if matches!(
                     status,
                     PairSyncStatus::Failed(_) | PairSyncStatus::Unauthorized
@@ -430,6 +512,10 @@ fn spawn_sync_all(state: &mut AppState, mode: SyncAllMode) {
                 // count every unfinished pair as failed.
                 let (index, pair_id) = current.lock().unwrap().clone();
                 let message = panic_message(&e);
+                debug_log(
+                    &data_dir,
+                    &format!("sync-all: task panicked at {pair_id}: {message}"),
+                );
                 if !pair_id.is_empty() {
                     let _ = tx
                         .send(SyncMessage::SyncAllProgress {
@@ -441,6 +527,10 @@ fn spawn_sync_all(state: &mut AppState, mode: SyncAllMode) {
                 (total.saturating_sub(index), false)
             }
         };
+        debug_log(
+            &data_dir,
+            &format!("sync-all: finished (failed={failed}, cancelled={cancelled})"),
+        );
         let _ = tx
             .send(SyncMessage::SyncAllFinished { failed, cancelled })
             .await;
@@ -463,7 +553,12 @@ fn panic_message(e: &tokio::task::JoinError) -> String {
 /// then pushes; a 409 curriculum conflict is auto-merged by `merge_bind`
 /// (last-writer-wins), like the after-login run. Runs even when the
 /// per-pair toggle is off — the user asked explicitly.
-async fn manual_sync_pair(client: &SyncClient, db: &Database, pair_id: &str) -> PairSyncStatus {
+async fn manual_sync_pair(
+    data_dir: &std::path::Path,
+    client: &SyncClient,
+    db: &Database,
+    pair_id: &str,
+) -> PairSyncStatus {
     // "Bound" marker: a canonical curriculum version is stamped by every
     // bind that pushed or merged topics; a pair bound by a pure pull (an
     // empty local database) has `last_pulled_seq` advanced instead.
@@ -475,7 +570,7 @@ async fn manual_sync_pair(client: &SyncClient, db: &Database, pair_id: &str) -> 
         .is_some()
         || db.metadata().last_pulled_seq().await.unwrap_or(0) > 0;
     if !bound {
-        return bind_and_sync(client, db, pair_id).await;
+        return bind_and_sync(data_dir, client, db, pair_id).await;
     }
     if let Err(e) = client.pull(db, pair_id).await {
         return sync_err_status(e);
@@ -500,12 +595,28 @@ async fn manual_sync_pair(client: &SyncClient, db: &Database, pair_id: &str) -> 
 /// Binds one pair and runs the first sync: push for a cloud-empty pair,
 /// pull for a locally-empty one, `merge_bind` for a conflict. Enables sync
 /// for the pair on success.
-async fn bind_and_sync(client: &SyncClient, db: &Database, pair_id: &str) -> PairSyncStatus {
+async fn bind_and_sync(
+    data_dir: &std::path::Path,
+    client: &SyncClient,
+    db: &Database,
+    pair_id: &str,
+) -> PairSyncStatus {
     let scenario = match client.first_bind_choices(db, pair_id).await {
         Ok(scenario) => scenario,
         Err(SyncError::Unauthorized) => return PairSyncStatus::Unauthorized,
         Err(e) => return PairSyncStatus::Failed(e.to_string()),
     };
+    debug_log(
+        data_dir,
+        &format!(
+            "sync-all: {pair_id}: bind scenario {}",
+            match &scenario {
+                BindScenario::FreshLocal => "FreshLocal",
+                BindScenario::FreshCloud => "FreshCloud",
+                BindScenario::Conflict(_) => "Conflict",
+            }
+        ),
+    );
     let result = match scenario {
         BindScenario::FreshLocal => {
             // Pre-sync data never entered the outbox: enqueue it first,

--- a/crates/cli/src/app/sync.rs
+++ b/crates/cli/src/app/sync.rs
@@ -120,14 +120,17 @@ async fn discover_pairs(state: &mut AppState) {
     if state.view == View::SyncAll && !state.sync_all.done {
         for pair in &config.pairs {
             if added.contains(&pair.id) {
-                state.sync_all.rows.push(crate::ui::views::sync_all::PairSyncRow {
-                    pair_id: pair.id.clone(),
-                    title: format!(
-                        "{} → {}",
-                        pair.profile.native_language, pair.profile.target_language
-                    ),
-                    status: None,
-                });
+                state
+                    .sync_all
+                    .rows
+                    .push(crate::ui::views::sync_all::PairSyncRow {
+                        pair_id: pair.id.clone(),
+                        title: format!(
+                            "{} → {}",
+                            pair.profile.native_language, pair.profile.target_language
+                        ),
+                        status: None,
+                    });
             }
         }
     }

--- a/crates/cli/src/app/sync.rs
+++ b/crates/cli/src/app/sync.rs
@@ -247,7 +247,8 @@ pub(crate) fn map_sync_err(e: SyncError) -> SyncFailure {
 
 /// App start: a quiet pull of every pair with sync enabled. Only a rejected
 /// token is surfaced (offline-first); per-pair network failures are
-/// swallowed. Always terminates with a message so the scheduler idles.
+/// swallowed. A supervisor sends the terminating message even when the pull
+/// task panics, so the scheduler never wedges.
 fn spawn_pull_all(state: &AppState) {
     let data_dir = state.data_dir.clone();
     let base_url = resolve_sync_server_url(state.config.as_ref());
@@ -259,21 +260,15 @@ fn spawn_pull_all(state: &AppState) {
         .unwrap_or_default();
     let active_db = Arc::clone(&state.db);
     let tx = state.sync_tx.clone();
-    tokio::spawn(async move {
+    let inner = tokio::spawn(async move {
         let token = match TokenStore::new(data_dir.clone()).load().await {
             Ok(Some(token)) => token,
             // Signed out (or an unreadable store): nothing to pull.
-            _ => {
-                let _ = tx.send(SyncMessage::SchedulerIdle).await;
-                return;
-            }
+            _ => return None,
         };
         let client = match SyncClient::new(&base_url) {
             Ok(client) => client.with_access_token(token.access_token),
-            Err(_) => {
-                let _ = tx.send(SyncMessage::SchedulerIdle).await;
-                return;
-            }
+            Err(_) => return None,
         };
         let mut unauthorized = false;
         for pair_id in &pair_ids {
@@ -298,12 +293,17 @@ fn spawn_pull_all(state: &AppState) {
                 Err(_) => {}
             }
         }
-        let msg = if unauthorized {
-            SyncMessage::PullOnStartFinished(Err(SyncFailure::unauthorized()))
-        } else {
+        Some(unauthorized)
+    });
+    tokio::spawn(async move {
+        let msg = match inner.await {
             // The report's revision is unused by the handler; it only
             // triggers a status refresh.
-            SyncMessage::PullOnStartFinished(Ok(SyncReport::sync(0)))
+            Ok(Some(false)) => SyncMessage::PullOnStartFinished(Ok(SyncReport::sync(0))),
+            Ok(Some(true)) => SyncMessage::PullOnStartFinished(Err(SyncFailure::unauthorized())),
+            // Signed out, no client, or the pull task panicked: release the
+            // scheduler quietly.
+            Ok(None) | Err(_) => SyncMessage::SchedulerIdle,
         };
         let _ = tx.send(msg).await;
     });
@@ -322,7 +322,12 @@ enum SyncAllMode {
 /// Binds and syncs EVERY pair, reporting per-pair progress to the SyncAll
 /// view. Conflicts are resolved by `merge_bind` (last-writer-wins by
 /// `updated_at`), no dialogs.
-fn spawn_sync_all(state: &AppState, mode: SyncAllMode) {
+///
+/// The run lives in an inner task whose abort handle the SyncAll view uses
+/// for Esc-cancellation; a supervisor awaits it and ALWAYS sends the
+/// terminating `SyncAllFinished` — a panic in the sync code must never leave
+/// the view spinning forever (and the scheduler wedged) again.
+fn spawn_sync_all(state: &mut AppState, mode: SyncAllMode) {
     let data_dir = state.data_dir.clone();
     let base_url = resolve_sync_server_url(state.config.as_ref());
     let pair_ids = pair_ids(state);
@@ -333,94 +338,123 @@ fn spawn_sync_all(state: &AppState, mode: SyncAllMode) {
         .unwrap_or_default();
     let active_db = Arc::clone(&state.db);
     let tx = state.sync_tx.clone();
-    tokio::spawn(async move {
-        let token = match TokenStore::new(data_dir.clone()).load().await {
-            Ok(Some(token)) => token,
-            Ok(None) => {
-                for pair_id in &pair_ids {
-                    let _ = tx
-                        .send(SyncMessage::SyncAllProgress {
-                            pair_id: pair_id.clone(),
-                            status: PairSyncStatus::Unauthorized,
-                        })
-                        .await;
+    let total = pair_ids.len();
+    // (index of the pair currently syncing, its id) — for panic reporting.
+    let current = Arc::new(std::sync::Mutex::new((0usize, String::new())));
+    let inner = {
+        let current = Arc::clone(&current);
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let token = match TokenStore::new(data_dir.clone()).load().await {
+                Ok(Some(token)) => token,
+                Ok(None) => {
+                    for pair_id in &pair_ids {
+                        let _ = tx
+                            .send(SyncMessage::SyncAllProgress {
+                                pair_id: pair_id.clone(),
+                                status: PairSyncStatus::Unauthorized,
+                            })
+                            .await;
+                    }
+                    return pair_ids.len();
                 }
-                let _ = tx
-                    .send(SyncMessage::SyncAllFinished {
-                        failed: pair_ids.len(),
-                    })
-                    .await;
-                return;
-            }
-            Err(e) => {
-                let message = e.to_string();
-                for pair_id in &pair_ids {
-                    let _ = tx
-                        .send(SyncMessage::SyncAllProgress {
-                            pair_id: pair_id.clone(),
-                            status: PairSyncStatus::Failed(message.clone()),
-                        })
-                        .await;
+                Err(e) => {
+                    let message = e.to_string();
+                    for pair_id in &pair_ids {
+                        let _ = tx
+                            .send(SyncMessage::SyncAllProgress {
+                                pair_id: pair_id.clone(),
+                                status: PairSyncStatus::Failed(message.clone()),
+                            })
+                            .await;
+                    }
+                    return pair_ids.len();
                 }
-                let _ = tx
-                    .send(SyncMessage::SyncAllFinished {
-                        failed: pair_ids.len(),
-                    })
-                    .await;
-                return;
-            }
-        };
-        let client = match SyncClient::new(&base_url) {
-            Ok(client) => client.with_access_token(token.access_token),
-            Err(e) => {
-                let message = e.to_string();
-                for pair_id in &pair_ids {
-                    let _ = tx
-                        .send(SyncMessage::SyncAllProgress {
-                            pair_id: pair_id.clone(),
-                            status: PairSyncStatus::Failed(message.clone()),
-                        })
-                        .await;
-                }
-                let _ = tx
-                    .send(SyncMessage::SyncAllFinished {
-                        failed: pair_ids.len(),
-                    })
-                    .await;
-                return;
-            }
-        };
-
-        let mut failed = 0usize;
-        for pair_id in &pair_ids {
-            let _ = tx
-                .send(SyncMessage::SyncAllProgress {
-                    pair_id: pair_id.clone(),
-                    status: PairSyncStatus::Running,
-                })
-                .await;
-            let status = match open_pair_db(&data_dir, &active_db, &active_pair, pair_id).await {
-                Some(db) => match mode {
-                    SyncAllMode::AfterLogin => bind_and_sync(&client, &db, pair_id).await,
-                    SyncAllMode::Manual => manual_sync_pair(&client, &db, pair_id).await,
-                },
-                None => PairSyncStatus::Failed("database unavailable".to_string()),
             };
-            if matches!(
-                status,
-                PairSyncStatus::Failed(_) | PairSyncStatus::Unauthorized
-            ) {
-                failed += 1;
-            }
-            let _ = tx
-                .send(SyncMessage::SyncAllProgress {
-                    pair_id: pair_id.clone(),
+            let client = match SyncClient::new(&base_url) {
+                Ok(client) => client.with_access_token(token.access_token),
+                Err(e) => {
+                    let message = e.to_string();
+                    for pair_id in &pair_ids {
+                        let _ = tx
+                            .send(SyncMessage::SyncAllProgress {
+                                pair_id: pair_id.clone(),
+                                status: PairSyncStatus::Failed(message.clone()),
+                            })
+                            .await;
+                    }
+                    return pair_ids.len();
+                }
+            };
+
+            let mut failed = 0usize;
+            for (index, pair_id) in pair_ids.iter().enumerate() {
+                *current.lock().unwrap() = (index, pair_id.clone());
+                let _ = tx
+                    .send(SyncMessage::SyncAllProgress {
+                        pair_id: pair_id.clone(),
+                        status: PairSyncStatus::Running,
+                    })
+                    .await;
+                let status = match open_pair_db(&data_dir, &active_db, &active_pair, pair_id).await
+                {
+                    Some(db) => match mode {
+                        SyncAllMode::AfterLogin => bind_and_sync(&client, &db, pair_id).await,
+                        SyncAllMode::Manual => manual_sync_pair(&client, &db, pair_id).await,
+                    },
+                    None => PairSyncStatus::Failed("database unavailable".to_string()),
+                };
+                if matches!(
                     status,
-                })
-                .await;
-        }
-        let _ = tx.send(SyncMessage::SyncAllFinished { failed }).await;
+                    PairSyncStatus::Failed(_) | PairSyncStatus::Unauthorized
+                ) {
+                    failed += 1;
+                }
+                let _ = tx
+                    .send(SyncMessage::SyncAllProgress {
+                        pair_id: pair_id.clone(),
+                        status,
+                    })
+                    .await;
+            }
+            failed
+        })
+    };
+    state.sync_all.abort = Some(inner.abort_handle());
+    tokio::spawn(async move {
+        let (failed, cancelled) = match inner.await {
+            Ok(failed) => (failed, false),
+            Err(e) if e.is_cancelled() => (0, true),
+            Err(e) => {
+                // The sync task panicked: report the pair it was on and
+                // count every unfinished pair as failed.
+                let (index, pair_id) = current.lock().unwrap().clone();
+                let message = panic_message(&e);
+                if !pair_id.is_empty() {
+                    let _ = tx
+                        .send(SyncMessage::SyncAllProgress {
+                            pair_id,
+                            status: PairSyncStatus::Failed(format!("internal error: {message}")),
+                        })
+                        .await;
+                }
+                (total.saturating_sub(index), false)
+            }
+        };
+        let _ = tx
+            .send(SyncMessage::SyncAllFinished { failed, cancelled })
+            .await;
     });
+}
+
+/// Extracts the panic message from a join error for the failure row.
+fn panic_message(e: &tokio::task::JoinError) -> String {
+    let panic = e.to_string();
+    panic
+        .strip_prefix("task panicked")
+        .map(str::trim)
+        .unwrap_or(&panic)
+        .to_string()
 }
 
 /// Manual "Sync now" for one pair. A never-bound pair (created after the
@@ -479,19 +513,24 @@ async fn bind_and_sync(client: &SyncClient, db: &Database, pair_id: &str) -> Pai
             let version = db.curriculum().read_all().await.ok().map(|c| c.version);
             match backfill_outbox(db, true).await.map_err(sync_err_status) {
                 Err(status) => Err(status),
-                Ok(()) => {
-                    let pushed = client
-                        .push(db, pair_id)
-                        .await
-                        .map(|_| PairSyncStatus::Done)
-                        .map_err(push_err_status);
-                    if pushed.is_ok()
-                        && let Some(version) = version
-                    {
-                        let _ = db.metadata().set_cloud_curriculum_version(version).await;
+                Ok(()) => match client.push(db, pair_id).await {
+                    Ok(_) => {
+                        if let Some(version) = version {
+                            let _ = db.metadata().set_cloud_curriculum_version(version).await;
+                        }
+                        Ok(PairSyncStatus::Done)
                     }
-                    pushed
-                }
+                    // The pair may already exist in the cloud with an
+                    // empty canon (created on the web): the first topic
+                    // push is a 409 by design — merge instead of failing.
+                    // `merge_bind` stamps the cloud version itself.
+                    Err(PushError::CurriculumConflict(_)) => client
+                        .merge_bind(db, pair_id)
+                        .await
+                        .map(PairSyncStatus::Merged)
+                        .map_err(push_err_status),
+                    Err(e) => Err(push_err_status(e)),
+                },
             }
         }
         BindScenario::FreshCloud => client

--- a/crates/cli/src/ui/labels.rs
+++ b/crates/cli/src/ui/labels.rs
@@ -1005,8 +1005,11 @@ pub struct SyncAllLabels {
     pub status_done: &'static str,
     pub status_merged: &'static str,
     pub status_unauthorized: &'static str,
+    pub status_cancelled: &'static str,
     pub summary_ok: &'static str,
     pub summary_failed: &'static str,
+    pub summary_cancelled: &'static str,
+    pub cancel_hint: &'static str,
     pub continue_hint: &'static str,
 }
 
@@ -1017,8 +1020,11 @@ const EN_SYNC_ALL: SyncAllLabels = SyncAllLabels {
     status_done: "synced",
     status_merged: "merged",
     status_unauthorized: "sign in again",
+    status_cancelled: "cancelled",
     summary_ok: "All pairs are in sync.",
     summary_failed: "Done with errors: {failed} pair(s) did not sync.",
+    summary_cancelled: "Sync cancelled.",
+    cancel_hint: "Esc — cancel",
     continue_hint: "Enter — continue",
 };
 
@@ -1029,8 +1035,11 @@ const RU_SYNC_ALL: SyncAllLabels = SyncAllLabels {
     status_done: "готово",
     status_merged: "объединено",
     status_unauthorized: "нужен повторный вход",
+    status_cancelled: "отменено",
     summary_ok: "Все пары синхронизированы.",
     summary_failed: "Завершено с ошибками: не синхронизировано пар: {failed}.",
+    summary_cancelled: "Синхронизация отменена.",
+    cancel_hint: "Esc — отменить",
     continue_hint: "Enter — продолжить",
 };
 

--- a/crates/cli/src/ui/views/settings/account.rs
+++ b/crates/cli/src/ui/views/settings/account.rs
@@ -47,8 +47,10 @@ pub enum SyncMessage {
         status: PairSyncStatus,
     },
     /// The sync-all run finished; `failed` counts pairs that did not sync.
+    /// `cancelled` marks a run interrupted by the user (Esc).
     SyncAllFinished {
         failed: usize,
+        cancelled: bool,
     },
     /// A background task skipped silently (signed out / toggle off); only
     /// releases the sync scheduler.
@@ -65,6 +67,9 @@ pub enum PairSyncStatus {
     Merged(open_course_sync::MergeReport),
     Failed(String),
     Unauthorized,
+    /// The user interrupted the run (Esc) before this pair was reached or
+    /// while it was running.
+    Cancelled,
 }
 
 #[derive(Debug)]
@@ -549,7 +554,7 @@ pub async fn apply_sync_message(state: &mut AppState, message: SyncMessage) {
         SyncMessage::SyncAllProgress { pair_id, status } => {
             crate::ui::views::sync_all::apply_progress(state, &pair_id, status);
         }
-        SyncMessage::SyncAllFinished { failed } => {
+        SyncMessage::SyncAllFinished { failed, cancelled } => {
             // The rows are still populated here (cleared when the view is
             // dismissed): an all-around "unauthorized" means the login is
             // gone — surface it like the old single-pair manual sync did.
@@ -563,7 +568,7 @@ pub async fn apply_sync_message(state: &mut AppState, message: SyncMessage) {
             if unauthorized {
                 account.relogin_required = true;
             }
-            crate::ui::views::sync_all::apply_finished(state, failed).await;
+            crate::ui::views::sync_all::apply_finished(state, failed, cancelled).await;
             crate::app::sync::finish(state).await;
         }
         SyncMessage::SchedulerIdle => {

--- a/crates/cli/src/ui/views/sync_all.rs
+++ b/crates/cli/src/ui/views/sync_all.rs
@@ -29,7 +29,11 @@ pub struct SyncAllState {
     pub rows: Vec<PairSyncRow>,
     pub done: bool,
     pub failed: usize,
+    /// The finished run was interrupted by the user (Esc).
+    pub cancelled: bool,
     pub return_to: Option<View>,
+    /// Abort handle of the running sync-all task; `Some` while it runs.
+    pub abort: Option<tokio::task::AbortHandle>,
 }
 
 /// Seeds the rows from the config and switches to the view. The caller then
@@ -56,7 +60,9 @@ pub fn start(state: &mut AppState) {
         rows,
         done: false,
         failed: 0,
+        cancelled: false,
         return_to: Some(state.view),
+        abort: None,
     };
     state.view = View::SyncAll;
 }
@@ -72,21 +78,25 @@ pub fn apply_progress(state: &mut AppState, pair_id: &str, status: PairSyncStatu
     }
 }
 
-pub async fn apply_finished(state: &mut AppState, failed: usize) {
+pub async fn apply_finished(state: &mut AppState, failed: usize, cancelled: bool) {
     state.sync_all.done = true;
     state.sync_all.failed = failed;
+    state.sync_all.cancelled = cancelled;
+    state.sync_all.abort = None;
     let labels = get_sync_all_labels(native_language_code(state.config.as_ref()));
-    let summary = if failed == 0 {
+    let summary = if cancelled {
+        labels.summary_cancelled.to_string()
+    } else if failed == 0 {
         labels.summary_ok.to_string()
     } else {
         labels
             .summary_failed
             .replace("{failed}", &failed.to_string())
     };
-    state.toast = Some(if failed == 0 {
-        Toast::info(summary)
-    } else {
+    state.toast = Some(if cancelled || failed > 0 {
         Toast::error(summary)
+    } else {
+        Toast::info(summary)
     });
     // The account section shows the fresh sync state when it opens next.
     state.settings.account.sync_enabled = state.db.metadata().sync_enabled().await.unwrap_or(false);
@@ -98,7 +108,9 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
     let labels = get_sync_all_labels(native_language_code(state.config.as_ref()));
 
     let footer = if state.sync_all.done {
-        let summary = if state.sync_all.failed == 0 {
+        let summary = if state.sync_all.cancelled {
+            labels.summary_cancelled.to_string()
+        } else if state.sync_all.failed == 0 {
             labels.summary_ok.to_string()
         } else {
             labels
@@ -107,7 +119,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
         };
         format!("{}\n{}", summary, labels.continue_hint)
     } else {
-        labels.running.to_string()
+        format!("{}\n{}", labels.running, labels.cancel_hint)
     };
     let footer_height = footer.lines().count() as u16;
     let chunks = Layout::vertical([
@@ -175,6 +187,11 @@ fn render_row<'a>(
             Style::default().fg(Color::Red),
             labels.status_unauthorized.to_string(),
         ),
+        Some(PairSyncStatus::Cancelled) => (
+            "–".to_string(),
+            Style::default().fg(Color::DarkGray),
+            labels.status_cancelled.to_string(),
+        ),
         Some(PairSyncStatus::Failed(message)) => (
             "✗".to_string(),
             Style::default().fg(Color::Red),
@@ -198,9 +215,21 @@ fn render_row<'a>(
 
 pub async fn handle_key(state: &mut AppState, code: KeyCode) -> Result<()> {
     if !state.sync_all.done {
-        // The run cannot be interrupted; Esc only is ignored too, so the
-        // user does not land on a half-bound account by accident.
-        let _ = code;
+        // Esc interrupts the run: the task is aborted, unfinished rows are
+        // marked cancelled, and the supervisor finalizes the view with
+        // `SyncAllFinished` once the task actually stops.
+        if code == KeyCode::Esc && state.sync_all.abort.is_some() {
+            if let Some(handle) = state.sync_all.abort.take() {
+                handle.abort();
+            }
+            // A queued trigger must not restart the run the user cancelled.
+            state.sync.pending = None;
+            for row in &mut state.sync_all.rows {
+                if row.status.is_none() || matches!(row.status, Some(PairSyncStatus::Running)) {
+                    row.status = Some(PairSyncStatus::Cancelled);
+                }
+            }
+        }
         return Ok(());
     }
     state.view = state.sync_all.return_to.unwrap_or(View::Dashboard);

--- a/crates/cli/tests/settings_layout_test.rs
+++ b/crates/cli/tests/settings_layout_test.rs
@@ -1196,7 +1196,10 @@ async fn sync_all_view_renders_rows_and_returns_on_enter() {
     .await;
     account::apply_sync_message(
         &mut state,
-        account::SyncMessage::SyncAllFinished { failed: 0 },
+        account::SyncMessage::SyncAllFinished {
+            failed: 0,
+            cancelled: false,
+        },
     )
     .await;
     assert!(state.sync_all.done);

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -132,6 +132,32 @@ impl OpenCourseConfig {
     }
 }
 
+/// Merges pairs known to the server (created on the web or another device)
+/// into the local config. Returns the ids of the pairs that were added, in
+/// server order. Existing pairs are left untouched.
+pub fn merge_remote_pairs(
+    config: &mut OpenCourseConfig,
+    remote: &[open_course_core::sync_protocol::PairInfoResponse],
+) -> Vec<String> {
+    let mut added = Vec::new();
+    for pair in remote {
+        if config.pairs.iter().any(|p| p.id == pair.pair_id) {
+            continue;
+        }
+        config.pairs.push(LanguagePair {
+            id: pair.pair_id.clone(),
+            profile: UserProfile {
+                native_language: pair.native_lang.clone(),
+                target_language: pair.target_lang.clone(),
+                age: pair.age.and_then(|a| u32::try_from(a).ok()),
+                self_assessed_cefr: pair.self_assessed_cefr.clone(),
+            },
+        });
+        added.push(pair.pair_id.clone());
+    }
+    added
+}
+
 fn default_version() -> u32 {
     2
 }
@@ -250,4 +276,73 @@ pub fn ensure_open_course_gitignore(cwd: &std::path::Path) -> Result<()> {
         std::fs::write(&path, "*\n")?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use open_course_core::sync_protocol::PairInfoResponse;
+
+    fn remote_pair(pair_id: &str, native: &str, target: &str) -> PairInfoResponse {
+        PairInfoResponse {
+            pair_id: pair_id.to_string(),
+            native_lang: native.to_string(),
+            target_lang: target.to_string(),
+            revision: 1,
+            age: Some(30),
+            self_assessed_cefr: Some("B1".to_string()),
+            batch_size: 3,
+            topic_count: 0,
+        }
+    }
+
+    fn test_config() -> OpenCourseConfig {
+        OpenCourseConfig::new(
+            ProviderId::OpenAi,
+            ProviderConfig::ApiKey {
+                api_key: None,
+                model: "gpt-4o-mini".to_string(),
+                base_url: None,
+                endpoint: None,
+                reasoning_effort: None,
+                enable_thinking: None,
+            },
+            UserProfile {
+                native_language: "en".to_string(),
+                target_language: "de".to_string(),
+                age: None,
+                self_assessed_cefr: None,
+            },
+        )
+    }
+
+    #[test]
+    fn merge_remote_pairs_adds_only_unknown_pairs() {
+        let mut config = test_config();
+        let remote = vec![
+            remote_pair("en-de", "en", "de"),
+            remote_pair("en-fr", "en", "fr"),
+            remote_pair("en-es", "en", "es"),
+        ];
+        let added = merge_remote_pairs(&mut config, &remote);
+        assert_eq!(added, vec!["en-fr".to_string(), "en-es".to_string()]);
+        assert_eq!(config.pairs.len(), 3);
+        let fr = config.find_pair("en-fr").unwrap();
+        assert_eq!(fr.profile.native_language, "en");
+        assert_eq!(fr.profile.target_language, "fr");
+        assert_eq!(fr.profile.age, Some(30));
+        assert_eq!(fr.profile.self_assessed_cefr.as_deref(), Some("B1"));
+        // The pre-existing pair is untouched.
+        assert_eq!(config.pairs[0].id, "en-de");
+        assert_eq!(config.active_pair, "en-de");
+    }
+
+    #[test]
+    fn merge_remote_pairs_is_idempotent() {
+        let mut config = test_config();
+        let remote = vec![remote_pair("en-fr", "en", "fr")];
+        assert_eq!(merge_remote_pairs(&mut config, &remote).len(), 1);
+        assert!(merge_remote_pairs(&mut config, &remote).is_empty());
+        assert_eq!(config.pairs.len(), 2);
+    }
 }

--- a/crates/core/src/sync_protocol.rs
+++ b/crates/core/src/sync_protocol.rs
@@ -127,6 +127,24 @@ pub struct MeResponse {
     pub subscription_status: String,
 }
 
+/// `GET {base}/v1/pairs` response item: one pair owned by the account,
+/// created on any surface (CLI, web).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct PairInfoResponse {
+    pub pair_id: String,
+    pub native_lang: String,
+    pub target_lang: String,
+    pub revision: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub age: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_assessed_cefr: Option<String>,
+    pub batch_size: i32,
+    pub topic_count: i64,
+}
+
 /// Outbox op strings (snake_case) to wire strings (camelCase).
 pub fn op_to_wire(op: &str) -> &str {
     match op {

--- a/crates/db/src/curriculum.rs
+++ b/crates/db/src/curriculum.rs
@@ -168,6 +168,32 @@ impl CurriculumTable {
         Ok(())
     }
 
+    /// Bulk upsert: one delete + one add for the whole batch — applying a
+    /// sync pull row by row (two commits per row) is prohibitively slow on
+    /// real datasets.
+    pub async fn upsert_many_with_timestamps(&self, topics: &[Topic]) -> Result<()> {
+        if topics.is_empty() {
+            return Ok(());
+        }
+        self.table
+            .delete(&crate::util::in_predicate(
+                "id",
+                topics.iter().map(|t| t.id.as_str()),
+            ))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let batches = topics
+            .iter()
+            .map(topic_to_record_batch)
+            .collect::<Result<Vec<_>>>()?;
+        self.table
+            .add(batches)
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
     /// Soft-delete: the row stays as a tombstone so sync can propagate the
     /// deletion; reads filter it out.
     pub async fn delete_by_topic_id(&self, topic_id: &str) -> Result<()> {

--- a/crates/db/src/forms.rs
+++ b/crates/db/src/forms.rs
@@ -89,6 +89,32 @@ impl FormsTable {
         Ok(())
     }
 
+    /// Bulk upsert: one delete + one add for the whole batch — applying a
+    /// sync pull row by row (two commits per row) is prohibitively slow on
+    /// real datasets.
+    pub async fn upsert_many_with_timestamps(&self, forms: &[Form]) -> Result<()> {
+        if forms.is_empty() {
+            return Ok(());
+        }
+        self.table
+            .delete(&crate::util::in_predicate(
+                "id",
+                forms.iter().map(|f| f.id.as_str()),
+            ))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let batches = forms
+            .iter()
+            .map(form_to_record_batch)
+            .collect::<Result<Vec<_>>>()?;
+        self.table
+            .add(batches)
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
     /// Soft-delete: the row stays as a tombstone so sync can propagate the
     /// deletion; reads filter it out.
     pub async fn delete_by_id(&self, id: &str) -> Result<()> {

--- a/crates/db/src/history.rs
+++ b/crates/db/src/history.rs
@@ -105,8 +105,19 @@ impl HistoryTable {
     /// Appends a summary exactly as given — used when applying synced
     /// changes whose timestamps must be preserved.
     pub async fn append_with_timestamps(&self, summary: &SessionSummary) -> Result<()> {
+        self.append_many_with_timestamps(std::slice::from_ref(summary))
+            .await
+    }
+
+    /// Bulk append: one read + one rewrite for the whole batch — applying a
+    /// sync pull row by row (a full-table rewrite per row) is prohibitively
+    /// slow on real datasets.
+    pub async fn append_many_with_timestamps(&self, summaries: &[SessionSummary]) -> Result<()> {
+        if summaries.is_empty() {
+            return Ok(());
+        }
         let mut all = self.read_all().await?;
-        all.push(summary.clone());
+        all.extend(summaries.iter().cloned());
         let total = all.len();
         if total > MAX_HISTORY_ENTRIES {
             all = all.into_iter().skip(total - MAX_HISTORY_ENTRIES).collect();

--- a/crates/db/src/learning_items.rs
+++ b/crates/db/src/learning_items.rs
@@ -93,6 +93,32 @@ impl LearningItemsTable {
         Ok(())
     }
 
+    /// Bulk upsert: one delete + one add for the whole batch — applying a
+    /// sync pull row by row (two commits per row) is prohibitively slow on
+    /// real datasets.
+    pub async fn upsert_many_with_timestamps(&self, items: &[LearningItem]) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        self.table
+            .delete(&crate::util::in_predicate(
+                "id",
+                items.iter().map(|i| i.id.as_str()),
+            ))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let batches = items
+            .iter()
+            .map(learning_item_to_record_batch)
+            .collect::<Result<Vec<_>>>()?;
+        self.table
+            .add(batches)
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
     /// Soft-delete: the row stays as a tombstone so sync can propagate the
     /// deletion; reads filter it out.
     pub async fn delete_by_id(&self, id: &str) -> Result<()> {

--- a/crates/db/src/lemmas.rs
+++ b/crates/db/src/lemmas.rs
@@ -116,6 +116,32 @@ impl LemmasTable {
         Ok(())
     }
 
+    /// Bulk upsert: one delete + one add for the whole batch — applying a
+    /// sync pull row by row (two commits per row) is prohibitively slow on
+    /// real datasets.
+    pub async fn upsert_many_with_timestamps(&self, lemmas: &[Lemma]) -> Result<()> {
+        if lemmas.is_empty() {
+            return Ok(());
+        }
+        self.table
+            .delete(&crate::util::in_predicate(
+                "id",
+                lemmas.iter().map(|l| l.id.as_str()),
+            ))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let batches = lemmas
+            .iter()
+            .map(lemma_to_record_batch)
+            .collect::<Result<Vec<_>>>()?;
+        self.table
+            .add(batches)
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
     /// Soft-delete: the row stays as a tombstone so sync can propagate the
     /// deletion; reads filter it out.
     pub async fn delete_by_id(&self, id: &str) -> Result<()> {

--- a/crates/db/src/progress.rs
+++ b/crates/db/src/progress.rs
@@ -206,6 +206,32 @@ impl ProgressTable {
         Ok(())
     }
 
+    /// Bulk upsert: one delete + one add for the whole batch — applying a
+    /// sync pull row by row (two commits per row) is prohibitively slow on
+    /// real datasets.
+    pub async fn upsert_many_with_timestamps(&self, topics: &[ProgressTopic]) -> Result<()> {
+        if topics.is_empty() {
+            return Ok(());
+        }
+        self.table
+            .delete(&crate::util::in_predicate(
+                "topic_id",
+                topics.iter().map(|t| t.topic_id.as_str()),
+            ))
+            .await
+            .map_err(crate::error::DbError::from)?;
+        let batches = topics
+            .iter()
+            .map(progress_topic_to_record_batch)
+            .collect::<Result<Vec<_>>>()?;
+        self.table
+            .add(batches)
+            .execute()
+            .await
+            .map_err(crate::error::DbError::from)?;
+        Ok(())
+    }
+
     pub async fn write_all(&self, data: &ProgressData) -> Result<()> {
         let mut data = data.clone();
         let now = crate::util::now_rfc3339();

--- a/crates/db/src/util.rs
+++ b/crates/db/src/util.rs
@@ -13,6 +13,19 @@ pub fn eq_predicate(column: &str, value: &str) -> String {
     format!("{} = '{}'", column, sql_escape(value))
 }
 
+/// `column IN ('a', 'b', ...)` for bulk operations. Empty input yields
+/// `1 = 0` (matches nothing).
+pub fn in_predicate<'a>(column: &str, values: impl Iterator<Item = &'a str>) -> String {
+    let list = values
+        .map(|v| format!("'{}'", sql_escape(v)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if list.is_empty() {
+        return "1 = 0".to_string();
+    }
+    format!("{column} IN ({list})")
+}
+
 /// Current time as RFC3339 — the timestamp format of `updated_at` /
 /// `deleted_at` columns.
 pub(crate) fn now_rfc3339() -> String {

--- a/crates/sync/src/client.rs
+++ b/crates/sync/src/client.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use reqwest::{RequestBuilder, Response, StatusCode};
 
 use crate::error::SyncError;
-use crate::protocol::{DeviceCodeResponse, ErrorBody, MeResponse, TokenSet};
+use crate::protocol::{DeviceCodeResponse, ErrorBody, MeResponse, PairInfoResponse, TokenSet};
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -117,6 +117,16 @@ impl SyncClient {
     pub async fn me(&self) -> Result<MeResponse, SyncError> {
         let resp = self
             .send_with_retry(|| self.authorized(self.http.get(self.url("/v1/me"))))
+            .await?;
+        let resp = check_status(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    /// `GET {base}/v1/pairs` — every pair owned by the account, including
+    /// pairs created on other surfaces (web, other devices).
+    pub async fn list_pairs(&self) -> Result<Vec<PairInfoResponse>, SyncError> {
+        let resp = self
+            .send_with_retry(|| self.authorized(self.http.get(self.url("/v1/pairs"))))
             .await?;
         let resp = check_status(resp).await?;
         Ok(resp.json().await?)

--- a/crates/sync/src/client.rs
+++ b/crates/sync/src/client.rs
@@ -123,10 +123,13 @@ impl SyncClient {
     }
 
     /// `GET {base}/v1/pairs` — every pair owned by the account, including
-    /// pairs created on other surfaces (web, other devices).
+    /// pairs created on other surfaces (web, other devices). Uses the short
+    /// timeout and no retries: discovery is best-effort and runs on the
+    /// event loop, so it must fail fast when the server is unreachable.
     pub async fn list_pairs(&self) -> Result<Vec<PairInfoResponse>, SyncError> {
         let resp = self
-            .send_with_retry(|| self.authorized(self.http.get(self.url("/v1/pairs"))))
+            .authorized(self.http_short.get(self.url("/v1/pairs")))
+            .send()
             .await?;
         let resp = check_status(resp).await?;
         Ok(resp.json().await?)

--- a/crates/sync/src/engine.rs
+++ b/crates/sync/src/engine.rs
@@ -148,12 +148,164 @@ async fn apply_pull(db: &Database, pull: &PullResponse) -> Result<(), SyncError>
             .await?;
     }
 
+    // Each table is read ONCE into a cache instead of re-reading it for
+    // every change: a first full pull replays thousands of changes, and a
+    // full table scan per change is quadratic — on real datasets it looked
+    // like an infinite hang.
+    let mut caches = PullCaches::load(db).await?;
+    let mut pending = PendingWrites::default();
     let mut changes: Vec<&Change> = pull.changes.iter().collect();
     changes.sort_by_key(|c| c.seq);
     for change in changes {
-        apply_change(db, change).await?;
+        if op_is_tombstone_reset(&change.op) {
+            // Deletes and resets must not overtake buffered upserts.
+            pending.flush(db).await?;
+            apply_tombstone_reset(db, change, &mut caches).await?;
+        } else if op_is_delete(&change.op) {
+            pending.flush(db).await?;
+            apply_delete(db, change, &mut caches).await?;
+        } else if op_is_upsert(&change.op) {
+            buffer_upsert(change, &mut caches, &mut pending)?;
+        } else {
+            return Err(SyncError::Protocol(format!("unknown op: {}", change.op)));
+        }
     }
+    pending.flush(db).await?;
     Ok(())
+}
+
+/// Winning rows buffered while replaying a pull feed, written in bulk at
+/// flush points (before any delete/reset and at the end). Per-row writes
+/// cost two Lance commits each — batching turns a first full pull from
+/// hours into seconds.
+#[derive(Default)]
+struct PendingWrites {
+    topics: Vec<open_course_core::curriculum::Topic>,
+    progress: Vec<open_course_core::progress::ProgressTopic>,
+    sessions: Vec<open_course_core::history::SessionSummary>,
+    learning_items: Vec<open_course_core::learning_items::LearningItem>,
+    lemmas: Vec<open_course_core::vocabulary::Lemma>,
+    forms: Vec<open_course_core::vocabulary::Form>,
+    metadata: Vec<(String, String)>,
+}
+
+impl PendingWrites {
+    async fn flush(&mut self, db: &Database) -> Result<(), SyncError> {
+        // The feed can update one row several times (e.g. the echo of our
+        // own push followed by another device's edit); a bulk insert must
+        // contain only the last version of each id, or rows duplicate.
+        keep_last_by_id(&mut self.topics, |t| &t.id);
+        keep_last_by_id(&mut self.progress, |p| &p.topic_id);
+        keep_last_by_id(&mut self.learning_items, |i| &i.id);
+        keep_last_by_id(&mut self.lemmas, |l| &l.id);
+        keep_last_by_id(&mut self.forms, |f| &f.id);
+        db.curriculum()
+            .upsert_many_with_timestamps(&self.topics)
+            .await?;
+        self.topics.clear();
+        db.progress()
+            .upsert_many_with_timestamps(&self.progress)
+            .await?;
+        self.progress.clear();
+        db.history()
+            .append_many_with_timestamps(&self.sessions)
+            .await?;
+        self.sessions.clear();
+        db.learning_items()
+            .upsert_many_with_timestamps(&self.learning_items)
+            .await?;
+        self.learning_items.clear();
+        db.lemmas()
+            .upsert_many_with_timestamps(&self.lemmas)
+            .await?;
+        self.lemmas.clear();
+        db.forms().upsert_many_with_timestamps(&self.forms).await?;
+        self.forms.clear();
+        for (key, value) in std::mem::take(&mut self.metadata) {
+            db.metadata().set(&key, &value).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Drops all but the last occurrence of each id, preserving order.
+fn keep_last_by_id<T>(rows: &mut Vec<T>, id: impl Fn(&T) -> &str) {
+    let mut seen = std::collections::HashSet::new();
+    let mut keep = vec![true; rows.len()];
+    for (i, row) in rows.iter().enumerate().rev() {
+        if !seen.insert(id(row).to_string()) {
+            keep[i] = false;
+        }
+    }
+    let mut i = 0;
+    rows.retain(|_| {
+        let k = keep[i];
+        i += 1;
+        k
+    });
+}
+
+/// Local rows preloaded for one pull application, keyed for O(1) lookups.
+#[derive(Default)]
+struct PullCaches {
+    topics: std::collections::HashMap<String, open_course_core::curriculum::Topic>,
+    progress: std::collections::HashMap<String, open_course_core::progress::ProgressTopic>,
+    sessions: std::collections::HashSet<String>,
+    learning_items:
+        std::collections::HashMap<String, open_course_core::learning_items::LearningItem>,
+    lemmas: std::collections::HashMap<String, open_course_core::vocabulary::Lemma>,
+    forms: std::collections::HashMap<String, open_course_core::vocabulary::Form>,
+}
+
+impl PullCaches {
+    async fn load(db: &Database) -> Result<Self, SyncError> {
+        Ok(Self {
+            topics: db
+                .curriculum()
+                .read_all()
+                .await?
+                .topics
+                .into_iter()
+                .map(|t| (t.id.clone(), t))
+                .collect(),
+            progress: db
+                .progress()
+                .read_all()
+                .await?
+                .topics
+                .into_iter()
+                .map(|p| (p.topic_id.clone(), p))
+                .collect(),
+            sessions: db
+                .history()
+                .read_all()
+                .await?
+                .into_iter()
+                .map(|s| s.id)
+                .collect(),
+            learning_items: db
+                .learning_items()
+                .read_all()
+                .await?
+                .into_iter()
+                .map(|i| (i.id.clone(), i))
+                .collect(),
+            lemmas: db
+                .lemmas()
+                .read_all()
+                .await?
+                .into_iter()
+                .map(|l| (l.id.clone(), l))
+                .collect(),
+            forms: db
+                .forms()
+                .read_all()
+                .await?
+                .into_iter()
+                .map(|f| (f.id.clone(), f))
+                .collect(),
+        })
+    }
 }
 
 async fn reset_all(db: &Database) -> Result<(), SyncError> {
@@ -166,16 +318,112 @@ async fn reset_all(db: &Database) -> Result<(), SyncError> {
     Ok(())
 }
 
-async fn apply_change(db: &Database, change: &Change) -> Result<(), SyncError> {
-    if op_is_upsert(&change.op) {
-        apply_upsert(db, change).await
-    } else if op_is_delete(&change.op) {
-        apply_delete(db, change).await
-    } else if op_is_tombstone_reset(&change.op) {
-        apply_tombstone_reset(db, change).await
-    } else {
-        Err(SyncError::Protocol(format!("unknown op: {}", change.op)))
+/// Decides an upsert by last-writer-wins against the preloaded caches and
+/// buffers the winner for the next bulk flush. Pure decision logic: no I/O.
+fn buffer_upsert(
+    change: &Change,
+    caches: &mut PullCaches,
+    pending: &mut PendingWrites,
+) -> Result<(), SyncError> {
+    let Some(payload) = &change.payload else {
+        return Err(SyncError::Protocol(format!(
+            "upsert without payload for {} {}",
+            change.entity, change.entity_id
+        )));
+    };
+    match change.entity.as_str() {
+        "topic" => {
+            let incoming: open_course_core::curriculum::Topic =
+                serde_json::from_value(payload.clone())?;
+            let local_updated = caches
+                .topics
+                .get(&change.entity_id)
+                .and_then(|t| t.updated_at.as_deref());
+            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
+                caches.topics.insert(incoming.id.clone(), incoming.clone());
+                pending.topics.push(incoming);
+            }
+        }
+        "progress" => {
+            let incoming: open_course_core::progress::ProgressTopic =
+                serde_json::from_value(payload.clone())?;
+            let local_updated = caches
+                .progress
+                .get(&change.entity_id)
+                .and_then(|t| t.updated_at.as_deref());
+            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
+                caches
+                    .progress
+                    .insert(incoming.topic_id.clone(), incoming.clone());
+                pending.progress.push(incoming);
+            }
+        }
+        "session" => {
+            let incoming: open_course_core::history::SessionSummary =
+                serde_json::from_value(payload.clone())?;
+            // Sessions are append-only with unique ids; a duplicate pull is
+            // a no-op.
+            if caches.sessions.insert(incoming.id.clone()) {
+                pending.sessions.push(incoming);
+            }
+        }
+        entity if entity_is_learning_item(entity) => {
+            let incoming: open_course_core::learning_items::LearningItem =
+                serde_json::from_value(payload.clone())?;
+            let local_updated = caches
+                .learning_items
+                .get(&change.entity_id)
+                .and_then(|i| i.updated_at.as_deref());
+            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
+                caches
+                    .learning_items
+                    .insert(incoming.id.clone(), incoming.clone());
+                pending.learning_items.push(incoming);
+            }
+        }
+        entity if entity_is_lemma(entity) => {
+            let incoming: open_course_core::vocabulary::Lemma =
+                serde_json::from_value(payload.clone())?;
+            let local_updated = caches
+                .lemmas
+                .get(&change.entity_id)
+                .and_then(|l| l.updated_at.as_deref());
+            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
+                caches.lemmas.insert(incoming.id.clone(), incoming.clone());
+                pending.lemmas.push(incoming);
+            }
+        }
+        entity if entity_is_form(entity) => {
+            let incoming: open_course_core::vocabulary::Form =
+                serde_json::from_value(payload.clone())?;
+            let local_updated = caches
+                .forms
+                .get(&change.entity_id)
+                .and_then(|f| f.updated_at.as_deref());
+            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
+                caches.forms.insert(incoming.id.clone(), incoming.clone());
+                pending.forms.push(incoming);
+            }
+        }
+        "metadata" => {
+            // Metadata payload shape: { "key": ..., "value": ... }.
+            let key = payload
+                .get("key")
+                .and_then(|k| k.as_str())
+                .ok_or_else(|| SyncError::Protocol("metadata upsert without key".to_string()))?;
+            let value = payload
+                .get("value")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            pending.metadata.push((key.to_string(), value.to_string()));
+        }
+        _ => {
+            // Forward compatibility: an entity introduced by a newer client
+            // is skipped instead of failing the whole pull, so one unknown
+            // entity cannot wedge sync forever (the cursor still advances).
+        }
     }
+    Ok(())
 }
 
 /// Last-writer-wins per row: the incoming row wins when the local row or
@@ -194,131 +442,34 @@ fn future_threshold() -> String {
     (chrono::Utc::now() + FUTURE_SKEW).to_rfc3339()
 }
 
-async fn apply_upsert(db: &Database, change: &Change) -> Result<(), SyncError> {
-    let Some(payload) = &change.payload else {
-        return Err(SyncError::Protocol(format!(
-            "upsert without payload for {} {}",
-            change.entity, change.entity_id
-        )));
-    };
-    match change.entity.as_str() {
-        "topic" => {
-            let incoming: open_course_core::curriculum::Topic =
-                serde_json::from_value(payload.clone())?;
-            let local = db
-                .curriculum()
-                .read_all()
-                .await?
-                .topics
-                .into_iter()
-                .find(|t| t.id == change.entity_id);
-            let local_updated = local.as_ref().and_then(|t| t.updated_at.as_deref());
-            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
-                db.curriculum().upsert_with_timestamps(&incoming).await?;
-            }
-        }
-        "progress" => {
-            let incoming: open_course_core::progress::ProgressTopic =
-                serde_json::from_value(payload.clone())?;
-            let local = db.progress().get_by_topic_id(&change.entity_id).await?;
-            let local_updated = local.as_ref().and_then(|t| t.updated_at.as_deref());
-            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
-                db.progress().upsert_with_timestamps(&incoming).await?;
-            }
-        }
-        "session" => {
-            let incoming: open_course_core::history::SessionSummary =
-                serde_json::from_value(payload.clone())?;
-            // Sessions are append-only with unique ids; a duplicate pull is
-            // a no-op.
-            let exists = db
-                .history()
-                .read_all()
-                .await?
-                .iter()
-                .any(|s| s.id == incoming.id);
-            if !exists {
-                db.history().append_with_timestamps(&incoming).await?;
-            }
-        }
-        entity if entity_is_learning_item(entity) => {
-            let incoming: open_course_core::learning_items::LearningItem =
-                serde_json::from_value(payload.clone())?;
-            let local = db
-                .learning_items()
-                .read_all()
-                .await?
-                .into_iter()
-                .find(|i| i.id == change.entity_id);
-            let local_updated = local.as_ref().and_then(|i| i.updated_at.as_deref());
-            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
-                db.learning_items()
-                    .upsert_with_timestamps(&incoming)
-                    .await?;
-            }
-        }
-        entity if entity_is_lemma(entity) => {
-            let incoming: open_course_core::vocabulary::Lemma =
-                serde_json::from_value(payload.clone())?;
-            let local = db
-                .lemmas()
-                .read_all()
-                .await?
-                .into_iter()
-                .find(|l| l.id == change.entity_id);
-            let local_updated = local.as_ref().and_then(|l| l.updated_at.as_deref());
-            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
-                db.lemmas().upsert_with_timestamps(&incoming).await?;
-            }
-        }
-        entity if entity_is_form(entity) => {
-            let incoming: open_course_core::vocabulary::Form =
-                serde_json::from_value(payload.clone())?;
-            let local = db
-                .forms()
-                .read_all()
-                .await?
-                .into_iter()
-                .find(|f| f.id == change.entity_id);
-            let local_updated = local.as_ref().and_then(|f| f.updated_at.as_deref());
-            if incoming_wins(local_updated, incoming.updated_at.as_deref()) {
-                db.forms().upsert_with_timestamps(&incoming).await?;
-            }
-        }
-        "metadata" => {
-            // Metadata payload shape: { "key": ..., "value": ... }.
-            let key = payload
-                .get("key")
-                .and_then(|k| k.as_str())
-                .ok_or_else(|| SyncError::Protocol("metadata upsert without key".to_string()))?;
-            let value = payload
-                .get("value")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default();
-            db.metadata().set(key, value).await?;
-        }
-        _ => {
-            // Forward compatibility: an entity introduced by a newer client
-            // is skipped instead of failing the whole pull, so one unknown
-            // entity cannot wedge sync forever (the cursor still advances).
-        }
-    }
-    Ok(())
-}
-
-async fn apply_delete(db: &Database, change: &Change) -> Result<(), SyncError> {
+async fn apply_delete(
+    db: &Database,
+    change: &Change,
+    caches: &mut PullCaches,
+) -> Result<(), SyncError> {
     match change.entity.as_str() {
         "topic" => {
             db.curriculum()
                 .delete_by_topic_id(&change.entity_id)
-                .await?
+                .await?;
+            caches.topics.remove(&change.entity_id);
         }
-        "progress" => db.progress().delete_by_topic_id(&change.entity_id).await?,
+        "progress" => {
+            db.progress().delete_by_topic_id(&change.entity_id).await?;
+            caches.progress.remove(&change.entity_id);
+        }
         entity if entity_is_learning_item(entity) => {
-            db.learning_items().delete_by_id(&change.entity_id).await?
+            db.learning_items().delete_by_id(&change.entity_id).await?;
+            caches.learning_items.remove(&change.entity_id);
         }
-        entity if entity_is_lemma(entity) => db.lemmas().delete_by_id(&change.entity_id).await?,
-        entity if entity_is_form(entity) => db.forms().delete_by_id(&change.entity_id).await?,
+        entity if entity_is_lemma(entity) => {
+            db.lemmas().delete_by_id(&change.entity_id).await?;
+            caches.lemmas.remove(&change.entity_id);
+        }
+        entity if entity_is_form(entity) => {
+            db.forms().delete_by_id(&change.entity_id).await?;
+            caches.forms.remove(&change.entity_id);
+        }
         // Sessions are append-only and never deleted; metadata keys have no
         // delete operation.
         _ => {}
@@ -326,20 +477,45 @@ async fn apply_delete(db: &Database, change: &Change) -> Result<(), SyncError> {
     Ok(())
 }
 
-async fn apply_tombstone_reset(db: &Database, change: &Change) -> Result<(), SyncError> {
+async fn apply_tombstone_reset(
+    db: &Database,
+    change: &Change,
+    caches: &mut PullCaches,
+) -> Result<(), SyncError> {
     let reset_at = change
         .updated_at
         .clone()
         .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
     match change.entity.as_str() {
-        "topic" => db.curriculum().reset().await?,
-        "progress" => db.progress().reset().await?,
-        "session" => db.history().reset().await?,
-        entity if entity_is_learning_item(entity) => db.learning_items().reset().await?,
-        entity if entity_is_lemma(entity) => db.lemmas().reset().await?,
-        entity if entity_is_form(entity) => db.forms().reset().await?,
+        "topic" => {
+            db.curriculum().reset().await?;
+            caches.topics.clear();
+        }
+        "progress" => {
+            db.progress().reset().await?;
+            caches.progress.clear();
+        }
+        "session" => {
+            db.history().reset().await?;
+            caches.sessions.clear();
+        }
+        entity if entity_is_learning_item(entity) => {
+            db.learning_items().reset().await?;
+            caches.learning_items.clear();
+        }
+        entity if entity_is_lemma(entity) => {
+            db.lemmas().reset().await?;
+            caches.lemmas.clear();
+        }
+        entity if entity_is_form(entity) => {
+            db.forms().reset().await?;
+            caches.forms.clear();
+        }
         // An explicit "*" entity still wipes all synced tables.
-        "*" => reset_all(db).await?,
+        "*" => {
+            reset_all(db).await?;
+            *caches = PullCaches::default();
+        }
         // Forward compatibility: a tombstone reset for an entity this client
         // does not know is a no-op — resetting everything here would wipe
         // unrelated local data on every new entity rollout. The reset

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -16,7 +16,7 @@ pub use bind::{BindScenario, MergeReport, ProgressMerge, backfill_outbox};
 pub use client::{PollResult, SyncClient};
 pub use error::{PushError, SyncError};
 pub use protocol::{
-    Change, CurriculumPayload, DeviceCodeResponse, MeResponse, PullResponse, PushRequest,
-    PushResponse, TokenSet,
+    Change, CurriculumPayload, DeviceCodeResponse, MeResponse, PairInfoResponse, PullResponse,
+    PushRequest, PushResponse, TokenSet,
 };
 pub use tokens::TokenStore;

--- a/crates/sync/tests/contract.rs
+++ b/crates/sync/tests/contract.rs
@@ -679,6 +679,50 @@ async fn pull_with_timeout_fails_fast_on_slow_server() {
     );
 }
 
+/// A first full pull replays the whole history. Applying it must be linear
+/// (each table is read once), not a full table scan per change — the
+/// quadratic version looked like an infinite hang on real datasets.
+#[tokio::test]
+async fn pull_bulk_history_applies_linearly() {
+    let (state, base) = start_mock().await;
+    let (_dir, db) = temp_db().await;
+    const CHANGES: i64 = 2_000;
+    {
+        let mut st = state.lock().unwrap();
+        for seq in 1..=CHANGES {
+            let t = topic(
+                &format!("topic-{seq}"),
+                &format!("Topic {seq}"),
+                Some("2024-01-01T00:00:00Z"),
+            );
+            st.changes.push(wire_upsert_topic(seq, &t));
+        }
+        st.revision = CHANGES;
+    }
+
+    let start = std::time::Instant::now();
+    let revision = client(&base).pull(&db, "ru-es").await.unwrap();
+    assert_eq!(revision, CHANGES);
+    assert_eq!(
+        db.curriculum().read_all().await.unwrap().topics.len(),
+        CHANGES as usize
+    );
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(30),
+        "bulk pull of {CHANGES} changes took {:?} (regression: quadratic apply)",
+        start.elapsed()
+    );
+
+    // Re-applying the same full feed is a no-op (LWW against the preloaded
+    // caches).
+    db.metadata().set_last_pulled_seq(0).await.unwrap();
+    client(&base).pull(&db, "ru-es").await.unwrap();
+    assert_eq!(
+        db.curriculum().read_all().await.unwrap().topics.len(),
+        CHANGES as usize
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Roundtrip: two clients against one server
 // ---------------------------------------------------------------------------

--- a/crates/sync/tests/contract.rs
+++ b/crates/sync/tests/contract.rs
@@ -109,6 +109,23 @@ async fn me_handler(headers: HeaderMap) -> Response {
     .into_response()
 }
 
+async fn list_pairs_handler(headers: HeaderMap) -> Response {
+    if !authorized(&headers) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    Json(vec![open_course_sync::PairInfoResponse {
+        pair_id: "en-de".to_string(),
+        native_lang: "en".to_string(),
+        target_lang: "de".to_string(),
+        revision: 3,
+        age: Some(30),
+        self_assessed_cefr: Some("B1".to_string()),
+        batch_size: 3,
+        topic_count: 5,
+    }])
+    .into_response()
+}
+
 async fn sync_push(
     State(state): State<Shared>,
     headers: HeaderMap,
@@ -216,6 +233,7 @@ async fn start_mock() -> (Shared, String) {
         .route("/auth/device", post(auth_device))
         .route("/auth/device/poll", post(auth_poll))
         .route("/v1/me", get(me_handler))
+        .route("/v1/pairs", get(list_pairs_handler))
         .route("/v1/sync/push", post(sync_push))
         .route("/v1/sync/pull", get(sync_pull))
         .with_state(state.clone());
@@ -331,6 +349,25 @@ async fn me_returns_profile_and_rejects_bad_token() {
 
     let anon = SyncClient::new(&base).unwrap();
     assert!(matches!(anon.me().await, Err(SyncError::Unauthorized)));
+}
+
+#[tokio::test]
+async fn list_pairs_returns_account_pairs_and_rejects_bad_token() {
+    let (_state, base) = start_mock().await;
+    let pairs = client(&base).list_pairs().await.unwrap();
+    assert_eq!(pairs.len(), 1);
+    assert_eq!(pairs[0].pair_id, "en-de");
+    assert_eq!(pairs[0].native_lang, "en");
+    assert_eq!(pairs[0].target_lang, "de");
+    assert_eq!(pairs[0].age, Some(30));
+    assert_eq!(pairs[0].self_assessed_cefr.as_deref(), Some("B1"));
+    assert_eq!(pairs[0].topic_count, 5);
+
+    let anon = SyncClient::new(&base).unwrap();
+    assert!(matches!(
+        anon.list_pairs().await,
+        Err(SyncError::Unauthorized)
+    ));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sync/tests/live.rs
+++ b/crates/sync/tests/live.rs
@@ -1,0 +1,139 @@
+//! Live end-to-end test against a real sync server. Skipped unless the env
+//! vars are set:
+//!
+//! ```sh
+//! OPEN_COURSE_SYNC_URL=http://localhost:8080 OC_LIVE_TOKEN=<bearer> \
+//! OC_LIVE_PAIR_WITH_TOPICS=ru-fr OC_LIVE_PAIR_EMPTY=ru-es \
+//!     cargo test -p open-course-sync --test live
+//! ```
+//!
+//! `OC_LIVE_PAIR_WITH_TOPICS` must exist on the server with at least one
+//! topic; `OC_LIVE_PAIR_EMPTY` must exist with an empty canonical curriculum
+//! (e.g. created via `POST /v1/pairs`, like the web app does).
+
+use open_course_core::curriculum::Topic;
+use open_course_db::Database;
+use open_course_sync::{BindScenario, PushError, SyncClient, backfill_outbox};
+
+fn client() -> Option<SyncClient> {
+    let base = std::env::var("OPEN_COURSE_SYNC_URL").ok()?;
+    let token = std::env::var("OC_LIVE_TOKEN").ok()?;
+    Some(SyncClient::new(base).ok()?.with_access_token(token))
+}
+
+fn topic(id: &str, native: &str, target: &str) -> Topic {
+    Topic {
+        id: id.to_string(),
+        name: format!("Topic {id}"),
+        description: "live test".to_string(),
+        difficulty: "beginner".to_string(),
+        level: None,
+        order: None,
+        tags: vec![],
+        target_lang: target.to_string(),
+        native_lang: native.to_string(),
+        version: 1,
+        updated_at: Some(chrono::Utc::now().to_rfc3339()),
+        deleted_at: None,
+    }
+}
+
+async fn temp_db(dir: &tempfile::TempDir) -> Database {
+    Database::connect(&dir.path().join("db")).await.unwrap()
+}
+
+/// `GET /v1/pairs` parses and returns the account's pairs — the discovery
+/// feed for pairs created on the web.
+#[tokio::test]
+async fn list_pairs_parses() {
+    let Some(client) = client() else {
+        eprintln!("OPEN_COURSE_SYNC_URL/OC_LIVE_TOKEN unset, skipping");
+        return;
+    };
+    let pairs = client.list_pairs().await.unwrap();
+    assert!(!pairs.is_empty(), "expected at least one pair");
+    let pair = &pairs[0];
+    assert!(pair.pair_id.contains('-'));
+    assert!(!pair.native_lang.is_empty());
+    assert!(!pair.target_lang.is_empty());
+}
+
+/// Binding an empty local database to a pair that has cloud topics:
+/// FreshCloud, then pull applies the topic.
+#[tokio::test]
+async fn bind_pulls_web_created_pair() {
+    let Some(client) = client() else {
+        eprintln!("OPEN_COURSE_SYNC_URL/OC_LIVE_TOKEN unset, skipping");
+        return;
+    };
+    let pair_id = std::env::var("OC_LIVE_PAIR_WITH_TOPICS").unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let db = temp_db(&dir).await;
+
+    let scenario = client.first_bind_choices(&db, &pair_id).await.unwrap();
+    assert!(
+        matches!(scenario, BindScenario::FreshCloud),
+        "expected FreshCloud, got {scenario:?}"
+    );
+    let revision = client.pull(&db, &pair_id).await.unwrap();
+    assert!(revision > 0);
+    let curriculum = db.curriculum().read_all().await.unwrap();
+    assert!(
+        !curriculum.topics.is_empty(),
+        "pull must apply the cloud topics"
+    );
+}
+
+/// A pair created on the web has an existing but possibly EMPTY canonical
+/// curriculum (`canonical_topics = '[]'`), so the first push of local topics
+/// is a 409 by design (`base_revision = 0` + existing canon). The client
+/// must resolve it with `merge_bind`, not fail.
+#[tokio::test]
+async fn first_push_against_empty_canon_conflicts_then_merges() {
+    let Some(client) = client() else {
+        eprintln!("OPEN_COURSE_SYNC_URL/OC_LIVE_TOKEN unset, skipping");
+        return;
+    };
+    let pair_id = std::env::var("OC_LIVE_PAIR_EMPTY").unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let db = temp_db(&dir).await;
+
+    // Unique per run: the pair's canon accumulates the merged topics.
+    let topic_id = format!("live-local-{}", chrono::Utc::now().timestamp_millis());
+    db.curriculum()
+        .upsert_with_timestamps(&topic(&topic_id, "ru", "es"))
+        .await
+        .unwrap();
+    backfill_outbox(&db, true).await.unwrap();
+
+    match client.push(&db, &pair_id).await {
+        Err(PushError::CurriculumConflict(canonical)) => {
+            assert!(
+                !canonical.topics.iter().any(|t| t.id == topic_id),
+                "the canon must not contain the unpushed topic"
+            );
+        }
+        other => panic!("expected a curriculum conflict, got {other:?}"),
+    }
+
+    let report = client.merge_bind(&db, &pair_id).await.unwrap();
+    assert!(report.topics_local_only >= 1);
+    let curriculum = db.curriculum().read_all().await.unwrap();
+    assert!(curriculum.topics.iter().any(|t| t.id == topic_id));
+}
+
+/// Pulling a pair the account does not have yields revision 0 and no
+/// changes instead of an error — the client must not mistake that for
+/// "synced".
+#[tokio::test]
+async fn unknown_pair_pull_is_empty() {
+    let Some(client) = client() else {
+        eprintln!("OPEN_COURSE_SYNC_URL/OC_LIVE_TOKEN unset, skipping");
+        return;
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let db = temp_db(&dir).await;
+    let revision = client.pull(&db, "no-such-pair").await.unwrap();
+    assert_eq!(revision, 0);
+    assert!(db.curriculum().read_all().await.unwrap().topics.is_empty());
+}


### PR DESCRIPTION
## Problem

1. **Web-created pairs never reached the CLI.** Pairs from the web app are persisted server-side (`POST /v1/pairs`), but the CLI never called `GET /v1/pairs`: sync iterated only the local config (`pair_ids()` in `app/sync.rs`). `/v1/sync/pull` silently returns an empty feed for unknown pair ids, so the CLI had no signal the pairs existed.
2. **Sync never finished on real data (root cause of the "infinite spinner").** `apply_pull` re-read the whole table for *every* change (quadratic full LanceDB scans) and wrote every winning row with a delete+add commit pair. A first full pull of a real account (thousands of changes) took hours, looking like an infinite hang — and wedging the sync scheduler behind it, so later "Sync now" clicks coalesced into a pending trigger that never ran (all rows "pending", no spinner).
3. **A panicking sync task wedged everything.** No terminating message was ever sent — the SyncAll view spun forever and the scheduler stayed active for the rest of the session; the view also ignored all keys.
4. **Permanent bind failure for web-created pairs.** `POST /v1/pairs` creates the pair with an existing but empty canon (`canonical_topics = '[]'`), so the first CLI push of local topics is a 409 by design; `bind_and_sync` FreshLocal surfaced it as a failure on every sync.

## Fix

- **Pair discovery**: on `AfterLogin` and `Manual` triggers the orchestrator fetches `GET /v1/pairs` first (short-timeout, fail-fast, best-effort) and merges unknown pairs into the local config; the run then binds and pulls them (`FreshCloud`). Discovered pairs get rows in the SyncAll view.
- **Bulk pull application**: tables are preloaded once into keyed caches (LWW decisions are pure lookups), winning rows are buffered and written in bulk — one delete + one add per table via new `upsert_many_with_timestamps` / `append_many_with_timestamps` methods. Deletes/resets flush the buffer first, preserving seq order; buffered rows are deduped by id (own echo + another device's edit would otherwise duplicate rows).
- **Esc cancellation**: the SyncAll view aborts the run on Esc, marks unfinished rows cancelled, drops queued re-triggers, finalizes with a "sync cancelled" summary.
- **Panic-proof supervisor + per-pair timeouts**: sync-all and pull-on-start run under a supervisor that always sends the terminating message (a panic is reported on the pair row); each pair step is bounded (15s pull-on-start, 120s sync-all) — a hung pair fails visibly instead of wedging the scheduler.
- **Empty-canon merge**: FreshLocal push 409 falls back to `merge_bind`.
- **Diagnostics**: timestamped step log at `.open-course-cli/sync-debug.log` (schedule triggers, discovery results, bind scenarios, per-pair statuses) — this log pinpointed the quadratic `apply_pull`.

## Verification

- `cargo test --workspace` — all green, incl. new unit tests (`merge_remote_pairs`), a contract test for `GET /v1/pairs`, and a bulk-pull regression test (2000 changes applied in seconds; the contract suite runs in ~4s).
- Env-gated live suite `crates/sync/tests/live.rs` run against a real local server: pair listing, FreshCloud pull of a web-created pair with topics, empty-canon 409 → merge, empty pull of an unknown pair.
- `cargo clippy --workspace --all-targets` — clean; `cargo fmt --check` — clean.
