### PR TITLE
feat(llm): migrate rig-core 0.20 → rig 0.42 and adopt native capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5685,6 +5685,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
+ "http",
  "open-course-config",
  "open-course-core",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5682,13 +5682,11 @@ name = "open-course-llm"
 version = "0.8.0"
 dependencies = [
  "async-trait",
- "bytes",
  "chrono",
  "futures-util",
  "http",
  "open-course-config",
  "open-course-core",
- "regex",
  "reqwest 0.13.5",
  "rig",
  "schemars 1.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +18,7 @@ dependencies = [
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -40,6 +30,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -151,6 +159,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +275,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
@@ -394,6 +428,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +555,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey 0.1.1",
+ "rayon",
+ "thiserror 2.0.19",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,9 +674,21 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bigdecimal"
@@ -627,6 +748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +772,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -692,15 +828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +858,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,10 +876,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
+name = "bytecheck"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+checksum = "26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
+]
 
 [[package]]
 name = "bytemuck"
@@ -761,6 +911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,15 +929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -853,16 +1000,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clap"
 version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,7 +1018,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -890,7 +1027,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -903,10 +1040,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -929,6 +1091,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -956,6 +1119,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -989,6 +1165,15 @@ name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1181,6 +1366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db756b5eb7d81d31f31f660f4132f8cf5698de52fca144c143d0ae0cbb5f2e06"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,7 +1401,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.119",
 ]
 
@@ -1223,7 +1414,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.119",
 ]
 
@@ -1250,6 +1441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1462,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "datafusion"
@@ -1566,7 +1772,7 @@ checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64",
+ "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
@@ -1936,47 +2142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
-name = "deluxe"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed332aaf752b459088acf3dd4eca323e3ef4b83c70a84ca48fb0ec5305f1488"
-dependencies = [
- "deluxe-core",
- "deluxe-macros",
- "once_cell",
- "proc-macro2",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "deluxe-core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddada51c8576df9d6a8450c351ff63042b092c9458b8ac7d20f89cbd0ffd313"
-dependencies = [
- "arrayvec",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "deluxe-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87546d9c837f0b7557e47b8bd6eae52c3c223141b76aa233c345c9ab41d9117"
-dependencies = [
- "deluxe-core",
- "heck 0.4.1",
- "if_chain",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,7 +2196,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2097,25 +2262,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecb"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding"
@@ -2200,6 +2368,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2402,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "ethnum"
@@ -2263,6 +2457,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,10 +2496,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fastembed"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c269a76bfc6cea69553b7d040acb16c793119cebd97c756d21e08d0f075ff8"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "image",
+ "ndarray",
+ "ort",
+ "ort-sys",
+ "rayon",
+ "serde_json",
+ "tokenizers",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -2374,21 +2617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,10 +2626,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsst"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f4a8c268d4d18be0f79a897c758f4eb6b074cc5c4bab56e828f0657d6bd521"
+dependencies = [
+ "arrow-array",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "fsst"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd0ce0249ac12fd44fcde62d435c36d881952c2f0df4d1de24b45e1dbba5ddb"
 dependencies = [
  "arrow-array",
  "rand 0.9.5",
@@ -2498,6 +2742,10 @@ name = "futures-timer"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -2590,10 +2838,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "h2"
@@ -2671,12 +2941,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2692,6 +2956,26 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-hub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "rand 0.9.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "ureq",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "http"
@@ -2780,23 +3064,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2805,7 +3073,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2967,10 +3235,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "if_chain"
-version = "1.0.3"
+name = "image"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
@@ -2996,22 +3298,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
 ]
 
 [[package]]
@@ -3022,6 +3327,17 @@ checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3159,6 +3475,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,17 +3625,17 @@ dependencies = [
  "half",
  "humantime",
  "itertools 0.13.0",
- "lance-arrow",
- "lance-core",
- "lance-datafusion",
- "lance-encoding",
- "lance-file",
- "lance-index",
- "lance-io",
- "lance-linalg",
- "lance-namespace",
- "lance-table",
- "lance-tokenizer",
+ "lance-arrow 6.0.0",
+ "lance-core 6.0.0",
+ "lance-datafusion 6.0.0",
+ "lance-encoding 6.0.0",
+ "lance-file 6.0.0",
+ "lance-index 6.0.0",
+ "lance-io 6.0.0",
+ "lance-linalg 6.0.0",
+ "lance-namespace 6.0.0",
+ "lance-table 6.0.0",
+ "lance-tokenizer 6.0.0",
  "log",
  "moka",
  "object_store 0.12.5",
@@ -3280,6 +3645,78 @@ dependencies = [
  "prost-build",
  "prost-types",
  "rand 0.9.5",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944aca86f4c78f4da04af1c2bf33e664a2826b7af72972ad200d6b9de59019f"
+dependencies = [
+ "arc-swap",
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "async_cell",
+ "bitpacking",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "dashmap",
+ "datafusion",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "deepsize",
+ "either",
+ "futures",
+ "half",
+ "humantime",
+ "itertools 0.13.0",
+ "lance-arrow 7.0.0",
+ "lance-core 7.0.0",
+ "lance-datafusion 7.0.0",
+ "lance-encoding 7.0.0",
+ "lance-file 7.0.0",
+ "lance-index 7.0.0",
+ "lance-io 7.0.0",
+ "lance-linalg 7.0.0",
+ "lance-namespace 7.0.0",
+ "lance-table 7.0.0",
+ "lance-tokenizer 7.0.0",
+ "log",
+ "moka",
+ "object_store 0.13.2",
+ "permutation",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.5",
+ "rayon",
  "roaring",
  "semver",
  "serde",
@@ -3317,10 +3754,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-arrow"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "253f4a0a70580c985b91e65e9ca6cad644825a4078de28d8efbacf3ffbd7ecdc"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "half",
+ "jsonb",
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
 name = "lance-bitpacking"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c04b043c89e46ed3548f3b6423dcbdfac485e636c6e670d642424e954cfab66"
+dependencies = [
+ "arrayref",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
+name = "lance-bitpacking"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c4d12521b1945041dd515a56aa0854973138e7ac12111c92572e33e4ecb593"
 dependencies = [
  "arrayref",
  "paste",
@@ -3345,13 +3815,50 @@ dependencies = [
  "deepsize",
  "futures",
  "itertools 0.13.0",
- "lance-arrow",
+ "lance-arrow 6.0.0",
  "libc",
  "log",
  "mock_instant",
  "moka",
  "num_cpus",
  "object_store 0.12.5",
+ "pin-project",
+ "prost",
+ "rand 0.9.5",
+ "roaring",
+ "serde_json",
+ "snafu 0.9.1",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-core"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f84020da5a484e2f07dd1796e09785ed7cd889857ebc4cb77e32ef214ee594"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common",
+ "datafusion-sql",
+ "deepsize",
+ "futures",
+ "itertools 0.13.0",
+ "lance-arrow 7.0.0",
+ "libc",
+ "log",
+ "moka",
+ "num_cpus",
+ "object_store 0.13.2",
  "pin-project",
  "prost",
  "rand 0.9.5",
@@ -3387,9 +3894,9 @@ dependencies = [
  "datafusion-physical-expr",
  "futures",
  "jsonb",
- "lance-arrow",
- "lance-core",
- "lance-datagen",
+ "lance-arrow 6.0.0",
+ "lance-core 6.0.0",
+ "lance-datagen 6.0.0",
  "log",
  "pin-project",
  "prost",
@@ -3400,10 +3907,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-datafusion"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7460597a66534a75987993d4dac5bc330586d99c5b79ae73367dbcbd4e29e576"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "chrono",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "futures",
+ "jsonb",
+ "lance-arrow 7.0.0",
+ "lance-core 7.0.0",
+ "lance-datagen 7.0.0",
+ "log",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lance-datagen"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d904119ec5682fdf5729dd943bfdeea78e43585d07a13cce34b2bcee41328b"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "futures",
+ "half",
+ "hex",
+ "rand 0.9.5",
+ "rand_distr",
+ "rand_xoshiro",
+ "random_word",
+]
+
+[[package]]
+name = "lance-datagen"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046f5506ed2271cd941a050de7bf535dd3aedc291aadec836a63fa56c5926e3b"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3435,14 +3994,14 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "bytes",
- "fsst",
+ "fsst 6.0.0",
  "futures",
  "hex",
  "hyperloglogplus",
  "itertools 0.13.0",
- "lance-arrow",
- "lance-bitpacking",
- "lance-core",
+ "lance-arrow 6.0.0",
+ "lance-bitpacking 6.0.0",
+ "lance-core 6.0.0",
  "log",
  "lz4",
  "num-traits",
@@ -3451,6 +4010,43 @@ dependencies = [
  "prost-types",
  "rand 0.9.5",
  "snafu 0.9.1",
+ "strum 0.26.3",
+ "tokio",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+]
+
+[[package]]
+name = "lance-encoding"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af54edf43dcf9d6a56cc636eb35d457e68373c6448dca3f0891b3325b4a24e6"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "bytemuck",
+ "byteorder",
+ "bytes",
+ "fsst 7.0.0",
+ "futures",
+ "hex",
+ "hyperloglogplus",
+ "itertools 0.13.0",
+ "lance-arrow 7.0.0",
+ "lance-bitpacking 7.0.0",
+ "lance-core 7.0.0",
+ "log",
+ "lz4",
+ "num-traits",
+ "prost",
+ "prost-build",
+ "rand 0.9.5",
  "strum 0.26.3",
  "tokio",
  "tracing",
@@ -3477,10 +4073,10 @@ dependencies = [
  "datafusion-common",
  "deepsize",
  "futures",
- "lance-arrow",
- "lance-core",
- "lance-encoding",
- "lance-io",
+ "lance-arrow 6.0.0",
+ "lance-core 6.0.0",
+ "lance-encoding 6.0.0",
+ "lance-io 6.0.0",
  "log",
  "num-traits",
  "object_store 0.12.5",
@@ -3488,6 +4084,39 @@ dependencies = [
  "prost-build",
  "prost-types",
  "snafu 0.9.1",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-file"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772ae2d6207995dc1eb28aff9507f78e90b3362b58f311da001e9dc25f3d736"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common",
+ "deepsize",
+ "futures",
+ "lance-arrow 7.0.0",
+ "lance-core 7.0.0",
+ "lance-encoding 7.0.0",
+ "lance-io 7.0.0",
+ "log",
+ "num-traits",
+ "object_store 0.13.2",
+ "prost",
+ "prost-build",
+ "prost-types",
  "tokio",
  "tracing",
 ]
@@ -3525,16 +4154,16 @@ dependencies = [
  "itertools 0.13.0",
  "jieba-rs",
  "jsonb",
- "lance-arrow",
- "lance-core",
- "lance-datafusion",
- "lance-datagen",
- "lance-encoding",
- "lance-file",
- "lance-io",
- "lance-linalg",
- "lance-table",
- "lance-tokenizer",
+ "lance-arrow 6.0.0",
+ "lance-core 6.0.0",
+ "lance-datafusion 6.0.0",
+ "lance-datagen 6.0.0",
+ "lance-encoding 6.0.0",
+ "lance-file 6.0.0",
+ "lance-io 6.0.0",
+ "lance-linalg 6.0.0",
+ "lance-table 6.0.0",
+ "lance-tokenizer 6.0.0",
  "libm",
  "log",
  "ndarray",
@@ -3552,6 +4181,72 @@ dependencies = [
  "serde_json",
  "smallvec",
  "snafu 0.9.1",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "twox-hash",
+ "uuid",
+]
+
+[[package]]
+name = "lance-index"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71fbfb51096a903cb524fe0da716f5f15fbc4a6b6f84cd6dec21abf319c5e84"
+dependencies = [
+ "arc-swap",
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-channel",
+ "async-recursion",
+ "async-trait",
+ "bitpacking",
+ "bitvec",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "deepsize",
+ "dirs",
+ "fst",
+ "futures",
+ "half",
+ "itertools 0.13.0",
+ "jieba-rs",
+ "jsonb",
+ "lance-arrow 7.0.0",
+ "lance-core 7.0.0",
+ "lance-datafusion 7.0.0",
+ "lance-datagen 7.0.0",
+ "lance-encoding 7.0.0",
+ "lance-file 7.0.0",
+ "lance-io 7.0.0",
+ "lance-linalg 7.0.0",
+ "lance-table 7.0.0",
+ "lance-tokenizer 7.0.0",
+ "libm",
+ "log",
+ "ndarray",
+ "num-traits",
+ "object_store 0.13.2",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.5",
+ "rand_distr",
+ "rangemap",
+ "rayon",
+ "roaring",
+ "serde",
+ "serde_json",
+ "smallvec",
  "tempfile",
  "tokio",
  "tracing",
@@ -3582,9 +4277,9 @@ dependencies = [
  "futures",
  "http",
  "io-uring",
- "lance-arrow",
- "lance-core",
- "lance-namespace",
+ "lance-arrow 6.0.0",
+ "lance-core 6.0.0",
+ "lance-namespace 6.0.0",
  "libc",
  "log",
  "moka",
@@ -3595,6 +4290,46 @@ dependencies = [
  "rand 0.9.5",
  "serde",
  "snafu 0.9.1",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-io"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab8c98ef1b870b20541d27f3ca4efdf7c9f5c25214233be07d231ba88900219"
+dependencies = [
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "http",
+ "io-uring",
+ "lance-arrow 7.0.0",
+ "lance-core 7.0.0",
+ "lance-namespace 7.0.0",
+ "log",
+ "moka",
+ "object_store 0.13.2",
+ "path_abs",
+ "pin-project",
+ "prost",
+ "rand 0.9.5",
+ "serde",
  "tempfile",
  "tokio",
  "tracing",
@@ -3613,8 +4348,26 @@ dependencies = [
  "cc",
  "deepsize",
  "half",
- "lance-arrow",
- "lance-core",
+ "lance-arrow 6.0.0",
+ "lance-core 6.0.0",
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "lance-linalg"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4c51cad0ac780b02dc4da48528479e7693c03e8d05390510bbc69ca2a9a1f1"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "cc",
+ "deepsize",
+ "half",
+ "lance-arrow 7.0.0",
+ "lance-core 7.0.0",
  "num-traits",
  "rand 0.9.5",
 ]
@@ -3628,9 +4381,23 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "lance-core",
+ "lance-core 6.0.0",
  "lance-namespace-reqwest-client",
  "serde",
+ "snafu 0.9.1",
+]
+
+[[package]]
+name = "lance-namespace"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014e8332ca0615506342e0d3af608639864b68396973be14239f09c9f21f1fc2"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "lance-core 7.0.0",
+ "lance-namespace-reqwest-client",
  "snafu 0.9.1",
 ]
 
@@ -3647,13 +4414,13 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "lance",
- "lance-core",
- "lance-index",
- "lance-io",
- "lance-linalg",
- "lance-namespace",
- "lance-table",
+ "lance 6.0.0",
+ "lance-core 6.0.0",
+ "lance-index 6.0.0",
+ "lance-io 6.0.0",
+ "lance-linalg 6.0.0",
+ "lance-namespace 6.0.0",
+ "lance-table 6.0.0",
  "log",
  "object_store 0.12.5",
  "rand 0.9.5",
@@ -3664,12 +4431,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-namespace-impls"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d1231906a3cf92dd3dcda7d14a09c4835af6cd2bcd76dfd2481e87f20a282d"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-trait",
+ "bytes",
+ "futures",
+ "lance 7.0.0",
+ "lance-core 7.0.0",
+ "lance-index 7.0.0",
+ "lance-io 7.0.0",
+ "lance-linalg 7.0.0",
+ "lance-namespace 7.0.0",
+ "lance-table 7.0.0",
+ "log",
+ "object_store 0.13.2",
+ "rand 0.9.5",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "lance-namespace-reqwest-client"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6369eee4682fb11edf538388b43c61ce288b8302fe89bb40944d7daa7faaae99"
 dependencies = [
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3694,12 +4488,51 @@ dependencies = [
  "chrono",
  "deepsize",
  "futures",
- "lance-arrow",
- "lance-core",
- "lance-file",
- "lance-io",
+ "lance-arrow 6.0.0",
+ "lance-core 6.0.0",
+ "lance-file 6.0.0",
+ "lance-io 6.0.0",
  "log",
  "object_store 0.12.5",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.5",
+ "rangemap",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-table"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16f1355904aea4ebb04ffc70c58c97901e10bde44452b4b021de4a1f329250d"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "lance-arrow 7.0.0",
+ "lance-core 7.0.0",
+ "lance-file 7.0.0",
+ "lance-io 7.0.0",
+ "log",
+ "object_store 0.13.2",
  "prost",
  "prost-build",
  "prost-types",
@@ -3724,7 +4557,20 @@ checksum = "cf17e430caece4d5eb72e8ed76a61b05afc56ae66e79f2abe0945a9794a861d9"
 dependencies = [
  "arrow-array",
  "arrow-schema",
- "lance-arrow",
+ "lance-arrow 6.0.0",
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "lance-testing"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3094c2aacbd1fa093d809fc54fa911e3498671ba451041341d7caaa18460e6b2"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "lance-arrow 7.0.0",
  "num-traits",
  "rand 0.9.5",
 ]
@@ -3736,7 +4582,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "810ae0847a16b92629c2d894843b9666d2d975d8a7c3bd3ce21ad19c7900b140"
 dependencies = [
  "jieba-rs",
- "lindera",
+ "lindera 0.44.1",
+ "rust-stemmers",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "lance-tokenizer"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39b7f5ed9d0c0b716bf599b559d888267ed1dfe4c4e29d3648b51d2a28940cf"
+dependencies = [
+ "jieba-rs",
+ "lindera 3.0.7",
  "rust-stemmers",
  "serde",
  "unicode-normalization",
@@ -3771,20 +4630,20 @@ dependencies = [
  "datafusion-sql",
  "futures",
  "half",
- "lance",
- "lance-arrow",
- "lance-core",
- "lance-datafusion",
- "lance-datagen",
- "lance-encoding",
- "lance-file",
- "lance-index",
- "lance-io",
- "lance-linalg",
- "lance-namespace",
- "lance-namespace-impls",
- "lance-table",
- "lance-testing",
+ "lance 6.0.0",
+ "lance-arrow 6.0.0",
+ "lance-core 6.0.0",
+ "lance-datafusion 6.0.0",
+ "lance-datagen 6.0.0",
+ "lance-encoding 6.0.0",
+ "lance-file 6.0.0",
+ "lance-index 6.0.0",
+ "lance-io 6.0.0",
+ "lance-linalg 6.0.0",
+ "lance-namespace 6.0.0",
+ "lance-namespace-impls 6.0.0",
+ "lance-table 6.0.0",
+ "lance-testing 6.0.0",
  "lazy_static",
  "log",
  "moka",
@@ -3805,10 +4664,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "lancedb"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db595d8da6c1fbf41ef6a547f27a73cc1105d83a837e8c76ce08743a3c09260"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-sql",
+ "futures",
+ "half",
+ "lance 7.0.0",
+ "lance-arrow 7.0.0",
+ "lance-core 7.0.0",
+ "lance-datafusion 7.0.0",
+ "lance-datagen 7.0.0",
+ "lance-encoding 7.0.0",
+ "lance-file 7.0.0",
+ "lance-index 7.0.0",
+ "lance-io 7.0.0",
+ "lance-linalg 7.0.0",
+ "lance-namespace 7.0.0",
+ "lance-namespace-impls 7.0.0",
+ "lance-table 7.0.0",
+ "lance-testing 7.0.0",
+ "lazy_static",
+ "log",
+ "moka",
+ "num-traits",
+ "object_store 0.13.2",
+ "pin-project",
+ "rand 0.9.5",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "snafu 0.8.9",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "lexical-core"
@@ -3874,6 +4801,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,7 +4837,7 @@ dependencies = [
  "csv",
  "kanaria",
  "lindera-cc-cedict",
- "lindera-dictionary",
+ "lindera-dictionary 0.44.1",
  "lindera-ipadic",
  "lindera-ipadic-neologd",
  "lindera-ko-dic",
@@ -3919,6 +4856,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "lindera"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74cda79d7161e99b414e4d292ff673cc3f8d22f070d8be3b6185c033363a9216"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "kanaria",
+ "lindera-dictionary 3.0.7",
+ "log",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "url",
+]
+
+[[package]]
 name = "lindera-cc-cedict"
 version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3926,7 +4890,7 @@ checksum = "5d77e7a0830fd60f23828ad914439997288c1d2cdd9e269be67f967c27b56350"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
- "lindera-dictionary",
+ "lindera-dictionary 0.44.1",
  "once_cell",
  "tokio",
 ]
@@ -3952,12 +4916,39 @@ dependencies = [
  "memmap2",
  "once_cell",
  "rand 0.9.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "tar",
  "thiserror 2.0.19",
  "tokio",
  "yada",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2385456ca9fe87c29072c5f156b52fdd5e28d5b5738ddfb3979501dbd736530"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "derive_builder",
+ "encoding_rs",
+ "encoding_rs_io",
+ "glob",
+ "log",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "regex",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3968,7 +4959,7 @@ checksum = "78870521431dfaf0f94ddd3484fa08367e9d354fc8c708572f2f00007225ddfa"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
- "lindera-dictionary",
+ "lindera-dictionary 0.44.1",
  "once_cell",
  "tokio",
 ]
@@ -3981,7 +4972,7 @@ checksum = "abcb3dc3056e5c683e12c2c5e8d40076f7ecfd7bd46f5fc0e4ae9e58152b5d85"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
- "lindera-dictionary",
+ "lindera-dictionary 0.44.1",
  "once_cell",
  "tokio",
 ]
@@ -3994,7 +4985,7 @@ checksum = "e99316158bab14f0256d912055521ca784f76c63e7460db8a74775c5dc1f8bc2"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
- "lindera-dictionary",
+ "lindera-dictionary 0.44.1",
  "once_cell",
  "tokio",
 ]
@@ -4007,7 +4998,7 @@ checksum = "52672945166c14276bbba25e4ec79d7e126db1b503c0a6aa07ffc0141ae15cfa"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
- "lindera-dictionary",
+ "lindera-dictionary 0.44.1",
  "once_cell",
  "tokio",
 ]
@@ -4074,33 +5065,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "lopdf"
-version = "0.36.0"
+name = "loop9"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fa2559e99ba0f26a12458aabc754432c805bbb8cba516c427825a997af1fb7"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
- "aes",
- "bitflags 2.13.1",
- "cbc",
- "chrono",
- "ecb",
- "encoding_rs",
- "flate2",
- "indexmap 2.14.0",
- "itoa",
- "jiff",
- "log",
- "md-5",
- "nom 8.0.0",
- "nom_locate",
- "rand 0.9.5",
- "rangemap",
- "rayon",
- "sha2",
- "stringprep",
- "thiserror 2.0.19",
- "time",
- "weezl",
+ "imgref",
 ]
 
 [[package]]
@@ -4157,6 +5127,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "pastey 0.2.3",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,6 +5168,16 @@ dependencies = [
  "once_cell",
  "rawpointer",
  "thread-tree",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -4301,26 +5297,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
+name = "munge"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
 dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4339,6 +5370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,6 +5386,15 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4371,15 +5417,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom_locate"
-version = "5.0.0"
+name = "noop_proc_macro"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
-dependencies = [
- "bytecount",
- "memchr",
- "nom 8.0.0",
-]
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4406,6 +5447,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -4432,6 +5474,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4463,6 +5516,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object_store"
@@ -4564,7 +5623,7 @@ dependencies = [
  "open-course-service",
  "open-course-sync",
  "ratatui",
- "reqwest",
+ "reqwest 0.13.5",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -4608,7 +5667,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "futures-util",
- "lancedb",
+ "lancedb 0.29.0",
  "open-course-core",
  "rand 0.9.5",
  "serde_json",
@@ -4629,8 +5688,8 @@ dependencies = [
  "open-course-config",
  "open-course-core",
  "regex",
- "reqwest",
- "rig-core",
+ "reqwest 0.13.5",
+ "rig",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -4661,7 +5720,7 @@ dependencies = [
  "chrono",
  "open-course-core",
  "open-course-db",
- "reqwest",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tempfile",
@@ -4670,47 +5729,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4734,6 +5756,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -4794,6 +5836,18 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path_abs"
@@ -5020,11 +6074,24 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -5088,21 +6155,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5112,6 +6169,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5130,7 +6206,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5166,6 +6242,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5183,6 +6279,50 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5219,6 +6359,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -5275,6 +6416,15 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rancor"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b534442d0fcdb55d66f373d9cac6d33b6293a2335bc2136dbd06ce0e87d2572"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -5486,6 +6636,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.5",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror 2.0.19",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5502,6 +6711,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,6 +6730,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -5587,12 +6813,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "rend"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -5603,13 +6838,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5621,7 +6854,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5630,45 +6862,89 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
+name = "reqwest"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom 7.1.3",
- "pin-project-lite",
- "reqwest",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "rig-core"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8936508ca562d20009e6b3c09cae85c93dcc675da5a86ddd1313745ea530c53c"
-dependencies = [
- "as-any",
- "async-stream",
- "base64",
+ "base64 0.23.1",
  "bytes",
- "futures",
- "glob",
- "lopdf",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
  "mime_guess",
- "ordered-float 5.3.0",
- "rayon",
- "reqwest",
- "reqwest-eventsource",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "rig"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b989f4060e5f3c1ea4b8b6999f6759949d820704286cc6976b7a688cc0133029"
+dependencies = [
+ "rig-agent",
+ "rig-core",
+ "rig-derive",
+ "rig-fastembed",
+ "rig-helixdb",
+ "rig-lancedb",
+ "rig-milvus",
+]
+
+[[package]]
+name = "rig-agent"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66477c0d0a786358d078e7e3541a73089dd9009100d6e2b3fe3b0d730e8550f"
+dependencies = [
+ "async-stream",
+ "fastrand",
+ "futures",
+ "http",
+ "indexmap 2.14.0",
+ "rig-core",
  "rig-derive",
  "schemars 1.2.1",
  "serde",
@@ -5676,23 +6952,109 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "rig-core"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "432d83e0facf16749f91fe729cbffca84437e8062d2f4e92f4f12e903693922d"
+dependencies = [
+ "as-any",
+ "async-stream",
+ "base64 0.22.1",
+ "bytes",
+ "eventsource-stream",
+ "fastrand",
+ "futures",
+ "futures-timer",
+ "glob",
+ "http",
+ "indexmap 2.14.0",
+ "mime",
+ "mime_guess",
+ "ordered-float 5.3.0",
+ "pin-project-lite",
+ "reqwest 0.13.5",
+ "rig-derive",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-futures",
  "url",
 ]
 
 [[package]]
 name = "rig-derive"
-version = "0.1.15"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8cfe9976743132bf13d44d3b7b1aade835c54f49c94baf895e8ec018f90553"
+checksum = "de0a33f1bac45f16e50146c248bcbbfaa44518c7252d274e972c7f4ad71aaba7"
 dependencies = [
- "convert_case",
- "deluxe",
- "indoc",
- "proc-macro-crate 3.5.0",
+ "convert_case 0.11.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "rig-fastembed"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dff99f9bea13108bb14df5431b6fc0738beb87f1fe5ebfcf26ae9fe54a188d"
+dependencies = [
+ "fastembed",
+ "rig-core",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "rig-helixdb"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fa2b188a1e9e65d29c34738c97465f0822c57540d6d45fd4f04dad906c966a"
+dependencies = [
+ "reqwest 0.13.5",
+ "rig-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rig-lancedb"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5fe3555202c5bd4e30948414c2e234fddd9260d4520046733fcf0d58718f3a1"
+dependencies = [
+ "arrow-array",
+ "futures",
+ "lancedb 0.30.0",
+ "rig-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rig-milvus"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9c7b7ff7ed9c16da983a21f1e81f425c9805355427a92f4d2d97ba1fe2aa12"
+dependencies = [
+ "reqwest 0.13.5",
+ "rig-core",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -5707,6 +7069,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -5738,7 +7130,7 @@ checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -5792,6 +7184,8 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5823,11 +7217,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5942,6 +7364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6041,7 +7469,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -6078,6 +7506,30 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -6144,6 +7596,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6191,7 +7662,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6203,7 +7674,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6217,6 +7688,29 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -6265,23 +7759,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
 
 [[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
-]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6320,7 +7797,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6333,7 +7810,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6345,7 +7822,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6529,7 +8006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
@@ -6623,6 +8100,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6689,6 +8180,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.5",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.19",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6717,16 +8241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6749,6 +8263,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6763,12 +8293,6 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -6778,25 +8302,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -6805,7 +8318,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -6893,6 +8406,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6944,6 +8469,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6971,12 +8514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-blocks"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6998,10 +8535,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-properties"
-version = "0.1.4"
+name = "unicode-normalization-alignments"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -7027,6 +8567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7043,6 +8589,25 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -7111,16 +8676,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -7246,6 +8816,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7263,6 +8846,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -7323,7 +8924,7 @@ checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float 4.6.0",
- "strsim 0.11.1",
+ "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]
@@ -7459,7 +9060,25 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -7477,14 +9096,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7494,10 +9130,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7506,10 +9154,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7518,10 +9178,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7530,19 +9202,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.5.40"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7589,6 +9264,12 @@ name = "xxhash-rust"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yada"
@@ -7746,4 +9427,28 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ futures-util = "0.3"
 async-trait = "0.1"
 
 # LLM
-rig-core = { version = "0.20", features = ["all", "reqwest-rustls"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+rig = "0.42"
+reqwest = { version = "0.13", features = ["json", "rustls", "query"] }
 bytes = "1"
 
 # Database

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -9,7 +9,6 @@ open-course-core = { workspace = true }
 open-course-config = { workspace = true }
 rig = { workspace = true }
 reqwest = { workspace = true }
-bytes = { workspace = true }
 tokio = { workspace = true }
 futures-util = { workspace = true }
 async-trait = { workspace = true }
@@ -17,7 +16,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
 chrono = { workspace = true }
-regex = { workspace = true }
 
 [dev-dependencies]
 http = "1"

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 open-course-core = { workspace = true }
 open-course-config = { workspace = true }
-rig-core = { workspace = true }
+rig = { workspace = true }
 reqwest = { workspace = true }
 bytes = { workspace = true }
 tokio = { workspace = true }

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -18,3 +18,6 @@ serde_json = { workspace = true }
 schemars = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
+
+[dev-dependencies]
+http = "1"

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -194,6 +194,27 @@ fn anthropic_disable_thinking_params() -> serde_json::Value {
     serde_json::json!({ "thinking": { "type": "disabled" } })
 }
 
+/// `additional_params` that keep thinking off on Gemini models for speed
+/// and cost: Gemini 3 models take `thinkingLevel: "minimal"` (the only
+/// level that fully suppresses thought tokens — "low" still thinks), and
+/// Gemini 2.5 models take `thinkingBudget: 0`. The two knobs are mutually
+/// exclusive and each family rejects the other's, so the choice is
+/// family-gated; unknown families get nothing rather than a field their
+/// API version might reject.
+fn gemini_disable_thinking_params(model: &str) -> Option<serde_json::Value> {
+    if model.starts_with("gemini-3") {
+        Some(serde_json::json!({
+            "generationConfig": { "thinkingConfig": { "thinkingLevel": "minimal" } }
+        }))
+    } else if model.starts_with("gemini-2.5") {
+        Some(serde_json::json!({
+            "generationConfig": { "thinkingConfig": { "thinkingBudget": 0 } }
+        }))
+    } else {
+        None
+    }
+}
+
 #[async_trait]
 pub trait LlmClient: Send + Sync + Any {
     async fn prompt(&self, prompt: &str, system: Option<&str>, max_tokens: u32) -> Result<String>;
@@ -284,11 +305,24 @@ impl RigClient {
         // the same way unless the config overrides either field. Named
         // providers keep the plain request by default: some reject unknown
         // fields, and the server only adds controls on retry there.
+        //
+        // The default is `enable_thinking: false` and nothing else:
+        // gateways may give `reasoning_effort` precedence over
+        // `enable_thinking` (Aliyun Model Studio re-enables thinking when
+        // both are sent), so pairing the two would silently keep thinking
+        // on.
         let custom_openai = provider_id == ProviderId::Custom && config.endpoint() != "messages";
         let reasoning_effort = config
             .reasoning_effort()
             .map(|s| s.to_string())
-            .or_else(|| custom_openai.then(|| "low".to_string()));
+            .or_else(|| {
+                // OpenAI's gpt-5/o-series families reason at medium effort
+                // by default, burning tokens and latency on our structured
+                // workloads; other OpenAI models reject `reasoning_effort`
+                // with a 400, so the low-effort default is family-gated.
+                (openai_native && crate::provider::is_openai_reasoning_model(&model))
+                    .then(|| "low".to_string())
+            });
         // OpenAI rejects unknown parameters with a 400, and enable_thinking
         // is a Qwen/Aliyun extension — drop it for the real OpenAI API.
         let enable_thinking = if openai_native {
@@ -375,12 +409,16 @@ impl RigClient {
 
     /// Extra request fields for OpenAI-compatible providers on the rig
     /// (non-streaming) paths: the Qwen/Aliyun `enable_thinking` toggle and
-    /// the `reasoning_effort` control. The manual streaming body carries
-    /// the same fields (`streaming::build_openai_request_body`).
+    /// the `reasoning_effort` control. Streaming sends the same fields via
+    /// `stream_model`'s `additional_params`.
     fn openai_additional_params(&self) -> Option<serde_json::Value> {
         let mut params = serde_json::Map::new();
         if self.enable_thinking == Some(false) {
             params.insert("enable_thinking".to_string(), serde_json::json!(false));
+            // Thinking explicitly off: reasoning_effort is not just moot but
+            // harmful — gateways that give it precedence (Aliyun Model
+            // Studio) would turn thinking back on.
+            return Some(serde_json::Value::Object(params));
         }
         if let Some(effort) = &self.reasoning_effort {
             params.insert("reasoning_effort".to_string(), serde_json::json!(effort));
@@ -390,6 +428,16 @@ impl RigClient {
         } else {
             Some(serde_json::Value::Object(params))
         }
+    }
+
+    /// Gemini request params that keep thinking off for speed and cost.
+    /// An explicit `enable_thinking: true` in the config wins (thinking
+    /// stays at the provider default); `false` and unset both disable.
+    fn gemini_thinking_params(&self) -> Option<serde_json::Value> {
+        if self.enable_thinking == Some(true) {
+            return None;
+        }
+        gemini_disable_thinking_params(&self.model)
     }
 
     pub(crate) async fn extract_typed_impl<
@@ -455,9 +503,12 @@ impl RigClient {
                     extractor.build().extract(prompt).await
                 }
                 RigClientInner::Gemini(client) => {
-                    let extractor = client
+                    let mut extractor = client
                         .extractor::<T>(&self.model)
                         .max_tokens(max_tokens as u64);
+                    if let Some(params) = self.gemini_thinking_params() {
+                        extractor = extractor.additional_params(params);
+                    }
                     extractor.build().extract(prompt).await
                 }
             };
@@ -510,9 +561,15 @@ impl RigClient {
                     .await
             }
             RigClientInner::Gemini(client) => {
-                Self::gemini_agent(client, &self.model, None, max_tokens)
-                    .prompt_typed::<T>(prompt)
-                    .await
+                Self::gemini_agent(
+                    client,
+                    &self.model,
+                    None,
+                    max_tokens,
+                    self.gemini_thinking_params(),
+                )
+                .prompt_typed::<T>(prompt)
+                .await
             }
         }
     }
@@ -562,8 +619,12 @@ impl RigClient {
         model: &str,
         system: Option<&str>,
         max_tokens: u32,
+        additional_params: Option<serde_json::Value>,
     ) -> Agent {
         let mut builder = client.agent(model).max_tokens(max_tokens as u64);
+        if let Some(params) = additional_params {
+            builder = builder.additional_params(params);
+        }
         if let Some(system) = system {
             builder = builder.preamble(system);
         }
@@ -626,9 +687,15 @@ impl LlmClient for RigClient {
                     .await
                 }
                 RigClientInner::Gemini(client) => {
-                    Self::gemini_agent(client, &self.model, system, max_tokens)
-                        .prompt(prompt)
-                        .await
+                    Self::gemini_agent(
+                        client,
+                        &self.model,
+                        system,
+                        max_tokens,
+                        self.gemini_thinking_params(),
+                    )
+                    .prompt(prompt)
+                    .await
                 }
             };
 
@@ -680,7 +747,14 @@ impl LlmClient for RigClient {
             }
             RigClientInner::Gemini(client) => {
                 let model = client.completion_model(self.model.clone());
-                Self::stream_model(model, system, prompt, max_tokens, None).await
+                Self::stream_model(
+                    model,
+                    system,
+                    prompt,
+                    max_tokens,
+                    self.gemini_thinking_params(),
+                )
+                .await
             }
         }
     }
@@ -770,17 +844,34 @@ mod tests {
     fn custom_openai_provider_disables_thinking_by_default() {
         // Mirrors the server: custom OpenAI-compatible gateways always get
         // thinking controls, because their models often default to thinking
-        // mode (Aliyun MaaS, DashScope).
+        // mode (Aliyun MaaS, DashScope). Only enable_thinking is sent —
+        // gateways may give reasoning_effort precedence over it.
         let cfg = config(Some("key"), Some("https://example.com/v1"), None);
         let client = RigClient::from_config(&cfg, ProviderId::Custom).expect("should build");
         assert_eq!(client.enable_thinking, Some(false));
-        assert_eq!(client.reasoning_effort.as_deref(), Some("low"));
+        assert_eq!(client.reasoning_effort, None);
         assert_eq!(
             client.openai_additional_params(),
-            Some(serde_json::json!({
-                "enable_thinking": false,
-                "reasoning_effort": "low",
-            }))
+            Some(serde_json::json!({ "enable_thinking": false }))
+        );
+    }
+
+    #[test]
+    fn disabled_thinking_wins_over_configured_reasoning_effort() {
+        // An explicit enable_thinking=false must not be undone by a
+        // reasoning_effort the gateway would give precedence to.
+        let mut cfg = config(Some("key"), Some("https://example.com/v1"), None);
+        let ProviderConfig::ApiKey {
+            enable_thinking,
+            reasoning_effort,
+            ..
+        } = &mut cfg;
+        *enable_thinking = Some(false);
+        *reasoning_effort = Some("low".to_string());
+        let client = RigClient::from_config(&cfg, ProviderId::Custom).expect("should build");
+        assert_eq!(
+            client.openai_additional_params(),
+            Some(serde_json::json!({ "enable_thinking": false }))
         );
     }
 
@@ -974,6 +1065,105 @@ mod tests {
         *model = "gemini-2.5-flash".to_string();
         let client = RigClient::from_config(&cfg, ProviderId::Custom).expect("should build");
         assert_eq!(client.model, "gemini-2.5-flash");
+    }
+
+    #[test]
+    fn openai_reasoning_models_default_to_low_effort() {
+        for model in ["gpt-5-mini", "gpt-5", "gpt-5.2", "o3-mini", "o1"] {
+            let mut cfg = config(Some("openai-key"), None, None);
+            let ProviderConfig::ApiKey { model: m, .. } = &mut cfg;
+            *m = model.to_string();
+            let client = RigClient::from_config(&cfg, ProviderId::OpenAi).expect("should build");
+            assert_eq!(
+                client.openai_additional_params(),
+                Some(serde_json::json!({ "reasoning_effort": "low" })),
+                "model {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn openai_reasoning_effort_default_respects_config_override() {
+        let mut cfg = config(Some("openai-key"), None, None);
+        let ProviderConfig::ApiKey {
+            model,
+            reasoning_effort,
+            ..
+        } = &mut cfg;
+        *model = "gpt-5-mini".to_string();
+        *reasoning_effort = Some("high".to_string());
+        let client = RigClient::from_config(&cfg, ProviderId::OpenAi).expect("should build");
+        assert_eq!(
+            client.openai_additional_params(),
+            Some(serde_json::json!({ "reasoning_effort": "high" }))
+        );
+    }
+
+    #[test]
+    fn openai_non_reasoning_models_get_no_effort_default() {
+        // gpt-4o-class models reject `reasoning_effort` with a 400 — they
+        // must keep the plain request.
+        for model in ["gpt-4o-mini", "gpt-4o", "gpt-45-turbo", "test-model"] {
+            let mut cfg = config(Some("openai-key"), None, None);
+            let ProviderConfig::ApiKey { model: m, .. } = &mut cfg;
+            *m = model.to_string();
+            let client = RigClient::from_config(&cfg, ProviderId::OpenAi).expect("should build");
+            assert_eq!(client.openai_additional_params(), None, "model {model}");
+        }
+    }
+
+    #[test]
+    fn gemini_3_models_disable_thinking_via_thinking_level() {
+        let mut cfg = config(Some("gemini-key"), None, None);
+        let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+        *model = "gemini-3.6-flash".to_string();
+        let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
+        assert_eq!(
+            client.gemini_thinking_params(),
+            Some(serde_json::json!({
+                "generationConfig": { "thinkingConfig": { "thinkingLevel": "minimal" } }
+            }))
+        );
+    }
+
+    #[test]
+    fn gemini_2_5_models_disable_thinking_via_budget() {
+        // The retired 2.5-flash remaps to a 3.x replacement, but other
+        // 2.5-family models keep the budget knob (the families reject each
+        // other's thinking field).
+        let mut cfg = config(Some("gemini-key"), None, None);
+        let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+        *model = "gemini-2.5-pro".to_string();
+        let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
+        assert_eq!(
+            client.gemini_thinking_params(),
+            Some(serde_json::json!({
+                "generationConfig": { "thinkingConfig": { "thinkingBudget": 0 } }
+            }))
+        );
+    }
+
+    #[test]
+    fn gemini_unknown_family_gets_no_thinking_params() {
+        let mut cfg = config(Some("gemini-key"), None, None);
+        let ProviderConfig::ApiKey { model, .. } = &mut cfg;
+        *model = "gemini-1.5-flash".to_string();
+        let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
+        assert_eq!(client.gemini_thinking_params(), None);
+    }
+
+    #[test]
+    fn gemini_thinking_opt_in_keeps_provider_default() {
+        let mut cfg = config(Some("gemini-key"), None, None);
+        let ProviderConfig::ApiKey {
+            model,
+            enable_thinking,
+            ..
+        } = &mut cfg;
+        *model = "gemini-3.6-flash".to_string();
+        *enable_thinking = Some(true);
+        let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
+        assert_eq!(client.gemini_thinking_params(), None);
     }
 
     #[test]

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -455,14 +455,9 @@ impl RigClient {
                     extractor.build().extract(prompt).await
                 }
                 RigClientInner::Gemini(client) => {
-                    let mut extractor = client
+                    let extractor = client
                         .extractor::<T>(&self.model)
                         .max_tokens(max_tokens as u64);
-                    if let Some(params) =
-                        ProviderMeta::for_provider(ProviderId::Google).rig_additional_params()
-                    {
-                        extractor = extractor.additional_params(params);
-                    }
                     extractor.build().extract(prompt).await
                 }
             };
@@ -569,10 +564,6 @@ impl RigClient {
         max_tokens: u32,
     ) -> Agent {
         let mut builder = client.agent(model).max_tokens(max_tokens as u64);
-        if let Some(params) = ProviderMeta::for_provider(ProviderId::Google).rig_additional_params()
-        {
-            builder = builder.additional_params(params);
-        }
         if let Some(system) = system {
             builder = builder.preamble(system);
         }
@@ -689,8 +680,7 @@ impl LlmClient for RigClient {
             }
             RigClientInner::Gemini(client) => {
                 let model = client.completion_model(self.model.clone());
-                let params = ProviderMeta::for_provider(ProviderId::Google).rig_additional_params();
-                Self::stream_model(model, system, prompt, max_tokens, params).await
+                Self::stream_model(model, system, prompt, max_tokens, None).await
             }
         }
     }

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -7,8 +7,8 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use rig::agent::Agent;
-use rig::client::{AgentClientExt, AgentModelExt};
-use rig::completion::Prompt;
+use rig::client::{AgentClientExt, AgentModelExt, CompletionClient};
+use rig::completion::{CompletionModel, Prompt};
 use rig::extractor::ExtractorBuilder;
 use rig::providers::{anthropic, gemini, openai};
 
@@ -43,7 +43,7 @@ fn provider_error_message(msg: &str) -> String {
     msg.to_string()
 }
 
-fn classify_llm_error<E: std::fmt::Display>(e: E) -> AppError {
+pub(crate) fn classify_llm_error<E: std::fmt::Display>(e: E) -> AppError {
     let msg = e.to_string();
     if is_provider_unavailable(&msg) {
         AppError::ProviderUnavailable(provider_error_message(&msg))
@@ -109,14 +109,8 @@ enum RigClientInner {
 pub struct RigClient {
     inner: RigClientInner,
     model: String,
-    base_url: String,
-    api_key: String,
     reasoning_effort: Option<String>,
     enable_thinking: Option<bool>,
-    /// True for the real OpenAI API (not OpenAI-compatible gateways):
-    /// requires `max_completion_tokens` and rejects unknown parameters such
-    /// as the Qwen/Aliyun `enable_thinking` extension.
-    openai_native: bool,
     /// Anthropic-family providers (Anthropic, MiniMax, and custom
     /// `messages` endpoints) are asked to keep thinking off for speed via
     /// the `thinking: {"type": "disabled"}` request field; newer Claude
@@ -170,7 +164,7 @@ impl RigClient {
             config.enable_thinking().or(custom_openai.then_some(false))
         };
 
-        let (inner, base_url) = match provider_id {
+        let inner = match provider_id {
             ProviderId::Anthropic => {
                 let base_url = base_url.unwrap_or("https://api.anthropic.com");
                 let client = anthropic::Client::builder()
@@ -178,7 +172,7 @@ impl RigClient {
                     .base_url(base_url)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
-                (RigClientInner::Anthropic(client), base_url.to_string())
+                RigClientInner::Anthropic(client)
             }
             ProviderId::Google => {
                 let base_url = base_url.unwrap_or("https://generativelanguage.googleapis.com");
@@ -187,7 +181,7 @@ impl RigClient {
                     .base_url(base_url)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
-                (RigClientInner::Gemini(client), base_url.to_string())
+                RigClientInner::Gemini(client)
             }
             ProviderId::Custom if config.endpoint() == "messages" => {
                 let base_url = base_url.ok_or_else(|| {
@@ -201,10 +195,7 @@ impl RigClient {
                     .base_url(anthropic_base)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
-                (
-                    RigClientInner::Anthropic(client),
-                    anthropic_base.to_string(),
-                )
+                RigClientInner::Anthropic(client)
             }
             ProviderId::MiniMax => {
                 // Rows saved before the move to the Anthropic-compatible
@@ -221,7 +212,7 @@ impl RigClient {
                     .base_url(base_url)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
-                (RigClientInner::Anthropic(client), base_url.to_string())
+                RigClientInner::Anthropic(client)
             }
             _ => {
                 let base_url = base_url.ok_or_else(|| {
@@ -234,7 +225,7 @@ impl RigClient {
                     .base_url(base_url)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
-                (RigClientInner::OpenAi(client), base_url.to_string())
+                RigClientInner::OpenAi(client)
             }
         };
 
@@ -243,11 +234,8 @@ impl RigClient {
         Ok(Self {
             inner,
             model,
-            base_url,
-            api_key,
             reasoning_effort,
             enable_thinking,
-            openai_native,
             disable_thinking,
         })
     }
@@ -391,6 +379,32 @@ impl RigClient {
         }
         builder.build()
     }
+
+    /// One-shot streaming prompt over any rig completion model: same
+    /// preamble/max_tokens/additional_params wiring as the agent builders,
+    /// with rig's native SSE handling behind it.
+    async fn stream_model<M>(
+        model: M,
+        system: Option<&str>,
+        prompt: &str,
+        max_tokens: u32,
+        additional_params: Option<serde_json::Value>,
+    ) -> Result<LlmStream>
+    where
+        M: CompletionModel + Clone + 'static,
+    {
+        let mut builder = model
+            .completion_request(prompt)
+            .max_tokens(max_tokens as u64);
+        if let Some(system) = system {
+            builder = builder.preamble(system.to_string());
+        }
+        if let Some(params) = additional_params {
+            builder = builder.additional_params(params);
+        }
+        let response = builder.stream().await.map_err(classify_llm_error)?;
+        Ok(crate::streaming::into_llm_stream(response))
+    }
 }
 
 #[async_trait]
@@ -455,35 +469,28 @@ impl LlmClient for RigClient {
         max_tokens: u32,
     ) -> Result<LlmStream> {
         match &self.inner {
-            RigClientInner::OpenAi(_) => {
-                crate::streaming::stream_openai_compatible(
-                    &self.base_url,
-                    &self.api_key,
-                    &self.model,
-                    system,
-                    prompt,
-                    self.reasoning_effort.as_deref(),
-                    self.enable_thinking,
-                    max_tokens,
-                    self.openai_native,
-                )
-                .await
-            }
-            RigClientInner::Anthropic(_) => {
-                crate::streaming::stream_anthropic_messages(
-                    &self.base_url,
-                    &self.api_key,
-                    &self.model,
+            RigClientInner::OpenAi(client) => {
+                let model = openai::completion::CompletionModel::new(client.clone(), &self.model);
+                Self::stream_model(
+                    model,
                     system,
                     prompt,
                     max_tokens,
-                    self.disable_thinking,
+                    self.openai_additional_params(),
                 )
                 .await
             }
-            RigClientInner::Gemini(_) => {
-                let text = self.prompt(prompt, system, max_tokens).await?;
-                Ok(crate::streaming::stream_from_text(text))
+            RigClientInner::Anthropic(client) => {
+                let model = client.completion_model(self.model.clone());
+                let params = self
+                    .disable_thinking
+                    .then(anthropic_disable_thinking_params);
+                Self::stream_model(model, system, prompt, max_tokens, params).await
+            }
+            RigClientInner::Gemini(client) => {
+                let model = client.completion_model(self.model.clone());
+                let params = ProviderMeta::for_provider(ProviderId::Google).rig_additional_params();
+                Self::stream_model(model, system, prompt, max_tokens, params).await
             }
         }
     }
@@ -532,6 +539,16 @@ mod tests {
         }
     }
 
+    /// Base URL the constructed rig client will actually call — what the
+    /// removed `RigClient::base_url` field used to record.
+    fn inner_base_url(client: &RigClient) -> &str {
+        match &client.inner {
+            RigClientInner::OpenAi(c) => c.base_url(),
+            RigClientInner::Anthropic(c) => c.base_url(),
+            RigClientInner::Gemini(c) => c.base_url(),
+        }
+    }
+
     #[test]
     fn missing_api_key_without_env_var_errors() {
         with_env_var("ANTHROPIC_API_KEY", None, || {
@@ -545,22 +562,8 @@ mod tests {
     fn env_var_fallback_allows_construction_without_configured_key() {
         with_env_var("ANTHROPIC_API_KEY", Some("env-anthropic-key"), || {
             let cfg = config(None, None, None);
-            let client = RigClient::from_config(&cfg, ProviderId::Anthropic)
+            RigClient::from_config(&cfg, ProviderId::Anthropic)
                 .expect("should fall back to env var");
-            assert_eq!(client.api_key, "env-anthropic-key");
-        });
-    }
-
-    #[test]
-    fn configured_key_takes_priority_over_env_var() {
-        with_env_var("OPENAI_API_KEY", Some("env-openai-key"), || {
-            let cfg = config(
-                Some("configured-key"),
-                Some("https://api.openai.com/v1"),
-                None,
-            );
-            let client = RigClient::from_config(&cfg, ProviderId::OpenAi).expect("should build");
-            assert_eq!(client.api_key, "configured-key");
         });
     }
 
@@ -642,19 +645,21 @@ mod tests {
     fn google_builds_with_default_base_url() {
         let cfg = config(Some("gemini-key"), None, None);
         let client = RigClient::from_config(&cfg, ProviderId::Google).expect("should build");
-        assert_eq!(client.base_url, "https://generativelanguage.googleapis.com");
+        assert_eq!(
+            inner_base_url(&client),
+            "https://generativelanguage.googleapis.com"
+        );
         assert!(matches!(client.inner, RigClientInner::Gemini(_)));
     }
 
     #[test]
-    fn openai_drops_enable_thinking_and_marks_native_api() {
+    fn openai_drops_enable_thinking() {
         let mut cfg = config(Some("openai-key"), None, None);
         let ProviderConfig::ApiKey {
             enable_thinking, ..
         } = &mut cfg;
         *enable_thinking = Some(false);
         let client = RigClient::from_config(&cfg, ProviderId::OpenAi).expect("should build");
-        assert!(client.openai_native);
         assert_eq!(client.enable_thinking, None);
 
         // Custom gateways keep the configured enable_thinking.
@@ -664,7 +669,6 @@ mod tests {
         } = &mut custom_cfg;
         *enable_thinking = Some(false);
         let custom = RigClient::from_config(&custom_cfg, ProviderId::Custom).expect("should build");
-        assert!(!custom.openai_native);
         assert_eq!(custom.enable_thinking, Some(false));
     }
 
@@ -673,7 +677,10 @@ mod tests {
         with_env_var("MINIMAX_API_KEY", None, || {
             let cfg = config(Some("minimax-key"), None, None);
             let client = RigClient::from_config(&cfg, ProviderId::MiniMax).expect("should build");
-            assert_eq!(client.base_url, crate::provider::MINIMAX_DEFAULT_BASE_URL);
+            assert_eq!(
+                inner_base_url(&client),
+                crate::provider::MINIMAX_DEFAULT_BASE_URL
+            );
             assert!(matches!(client.inner, RigClientInner::Anthropic(_)));
             assert!(client.disable_thinking);
         });
@@ -716,7 +723,7 @@ mod tests {
                 let client =
                     RigClient::from_config(&cfg, ProviderId::MiniMax).expect("should build");
                 assert_eq!(
-                    client.base_url,
+                    inner_base_url(&client),
                     crate::provider::MINIMAX_DEFAULT_BASE_URL,
                     "stored base_url {stored:?}"
                 );
@@ -728,7 +735,10 @@ mod tests {
                 None,
             );
             let client = RigClient::from_config(&cfg, ProviderId::MiniMax).expect("should build");
-            assert_eq!(client.base_url, "https://proxy.example.com/anthropic");
+            assert_eq!(
+                inner_base_url(&client),
+                "https://proxy.example.com/anthropic"
+            );
         });
     }
 

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 
 use rig::agent::Agent;
 use rig::client::{AgentClientExt, AgentModelExt, CompletionClient};
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::{CompletionModel, Prompt, StructuredOutputError, TypedPrompt};
 use rig::extractor::ExtractorBuilder;
 use rig::providers::{anthropic, gemini, openai};
 
@@ -267,7 +267,39 @@ impl RigClient {
         max_tokens: u32,
     ) -> Result<T> {
         let mut last_err = None;
+        let mut native_supported = true;
         for attempt in 1..=LLM_MAX_RETRIES {
+            if native_supported {
+                match self.prompt_typed_native::<T>(prompt, max_tokens).await {
+                    Ok(value) => return Ok(value),
+                    Err(e) => {
+                        let app_err = classify_llm_error(e);
+                        if matches!(app_err, AppError::ProviderUnavailable(_)) {
+                            if attempt < LLM_MAX_RETRIES {
+                                tokio::time::sleep(Duration::from_millis(500 * attempt as u64))
+                                    .await;
+                                last_err = Some(app_err);
+                                continue;
+                            }
+                            return Err(app_err);
+                        }
+                        // A non-transient failure (e.g. the gateway rejects
+                        // response_format/output_config, or the constrained
+                        // output did not deserialize): degrade to the
+                        // submit-tool extractor for this and the remaining
+                        // attempts instead of failing the extraction.
+                        crate::debug_log::log_debug_event(
+                            "extract",
+                            &format!(
+                                "Native structured output failed ({app_err}), falling back to tool extraction"
+                            ),
+                            None,
+                        );
+                        native_supported = false;
+                    }
+                }
+            }
+
             let result = match &self.inner {
                 RigClientInner::OpenAi(client) => {
                     let mut extractor = ExtractorBuilder::<T>::new(
@@ -321,6 +353,39 @@ impl RigClient {
         Err(last_err.unwrap_or_else(|| {
             AppError::Llm("Failed to extract structured response after retries".to_string())
         }))
+    }
+
+    /// Native structured output: the provider is constrained by the JSON
+    /// schema of `T` (OpenAI `response_format`, Anthropic `output_config`,
+    /// Gemini `response_json_schema`) and rig deserializes the answer.
+    async fn prompt_typed_native<T: DeserializeOwned + JsonSchema + Send + 'static>(
+        &self,
+        prompt: &str,
+        max_tokens: u32,
+    ) -> std::result::Result<T, StructuredOutputError> {
+        match &self.inner {
+            RigClientInner::OpenAi(client) => {
+                Self::openai_agent(
+                    client,
+                    &self.model,
+                    None,
+                    max_tokens,
+                    self.openai_additional_params(),
+                )
+                .prompt_typed::<T>(prompt)
+                .await
+            }
+            RigClientInner::Anthropic(client) => {
+                Self::anthropic_agent(client, &self.model, None, max_tokens, self.disable_thinking)
+                    .prompt_typed::<T>(prompt)
+                    .await
+            }
+            RigClientInner::Gemini(client) => {
+                Self::gemini_agent(client, &self.model, None, max_tokens)
+                    .prompt_typed::<T>(prompt)
+                    .await
+            }
+        }
     }
 
     fn openai_agent(
@@ -784,5 +849,19 @@ mod tests {
         *model = "gemini-2.5-flash".to_string();
         let client = RigClient::from_config(&cfg, ProviderId::Custom).expect("should build");
         assert_eq!(client.model, "gemini-2.5-flash");
+    }
+
+    #[test]
+    fn schema_rejection_is_not_classified_as_unavailable() {
+        // A gateway rejecting response_format/output_config must downgrade
+        // to the submit-tool extractor, not burn the transient-retry budget.
+        let err = classify_llm_error("ProviderError: 400 response_format is not supported");
+        assert!(matches!(err, AppError::Llm(_)));
+    }
+
+    #[test]
+    fn provider_overload_stays_retryable() {
+        let err = classify_llm_error("server_error: provider overloaded");
+        assert!(matches!(err, AppError::ProviderUnavailable(_)));
     }
 }

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use rig::agent::Agent;
-use rig::client::CompletionClient;
+use rig::client::{AgentClientExt, AgentModelExt};
 use rig::completion::Prompt;
 use rig::extractor::ExtractorBuilder;
 use rig::providers::{anthropic, gemini, openai};
@@ -101,7 +101,7 @@ fn as_rig_client(client: &dyn LlmClient) -> Option<&RigClient> {
 }
 
 enum RigClientInner {
-    OpenAi(openai::Client),
+    OpenAi(openai::CompletionsClient),
     Anthropic(anthropic::Client),
     Gemini(gemini::Client),
 }
@@ -173,7 +173,8 @@ impl RigClient {
         let (inner, base_url) = match provider_id {
             ProviderId::Anthropic => {
                 let base_url = base_url.unwrap_or("https://api.anthropic.com");
-                let client = anthropic::ClientBuilder::new(&api_key)
+                let client = anthropic::Client::builder()
+                    .api_key(&api_key)
                     .base_url(base_url)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
@@ -181,7 +182,8 @@ impl RigClient {
             }
             ProviderId::Google => {
                 let base_url = base_url.unwrap_or("https://generativelanguage.googleapis.com");
-                let client = gemini::client::ClientBuilder::new(&api_key)
+                let client = gemini::Client::builder()
+                    .api_key(&api_key)
                     .base_url(base_url)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
@@ -194,7 +196,8 @@ impl RigClient {
                     ))
                 })?;
                 let anthropic_base = base_url.trim_end_matches("/v1").trim_end_matches('/');
-                let client = anthropic::ClientBuilder::new(&api_key)
+                let client = anthropic::Client::builder()
+                    .api_key(&api_key)
                     .base_url(anthropic_base)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
@@ -213,7 +216,8 @@ impl RigClient {
                     }
                     Some(custom) => custom,
                 };
-                let client = anthropic::ClientBuilder::new(&api_key)
+                let client = anthropic::Client::builder()
+                    .api_key(&api_key)
                     .base_url(base_url)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
@@ -225,7 +229,8 @@ impl RigClient {
                         "Provider {provider_id:?} requires a base URL"
                     ))
                 })?;
-                let client = openai::ClientBuilder::new(&api_key)
+                let client = openai::CompletionsClient::builder()
+                    .api_key(&api_key)
                     .base_url(base_url)
                     .build()
                     .map_err(|e| AppError::ProviderConfig(e.to_string()))?;
@@ -277,7 +282,7 @@ impl RigClient {
         for attempt in 1..=LLM_MAX_RETRIES {
             let result = match &self.inner {
                 RigClientInner::OpenAi(client) => {
-                    let mut extractor = ExtractorBuilder::<_, T>::new(
+                    let mut extractor = ExtractorBuilder::<T>::new(
                         openai::completion::CompletionModel::new(client.clone(), &self.model),
                     )
                     .max_tokens(max_tokens as u64);
@@ -331,12 +336,12 @@ impl RigClient {
     }
 
     fn openai_agent(
-        client: &openai::Client,
+        client: &openai::CompletionsClient,
         model: &str,
         system: Option<&str>,
         max_tokens: u32,
         additional_params: Option<serde_json::Value>,
-    ) -> Agent<openai::completion::CompletionModel> {
+    ) -> Agent {
         let builder =
             openai::completion::CompletionModel::new(client.clone(), model).into_agent_builder();
         let builder = builder.max_tokens(max_tokens as u64);
@@ -359,7 +364,7 @@ impl RigClient {
         system: Option<&str>,
         max_tokens: u32,
         disable_thinking: bool,
-    ) -> Agent<anthropic::completion::CompletionModel> {
+    ) -> Agent {
         let mut builder = client.agent(model).max_tokens(max_tokens as u64);
         if disable_thinking {
             builder = builder.additional_params(anthropic_disable_thinking_params());
@@ -375,7 +380,7 @@ impl RigClient {
         model: &str,
         system: Option<&str>,
         max_tokens: u32,
-    ) -> Agent<gemini::completion::CompletionModel> {
+    ) -> Agent {
         let mut builder = client.agent(model).max_tokens(max_tokens as u64);
         if let Some(params) = ProviderMeta::for_provider(ProviderId::Google).rig_additional_params()
         {

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -8,8 +8,10 @@ use serde::de::DeserializeOwned;
 
 use rig::agent::Agent;
 use rig::client::{AgentClientExt, AgentModelExt, CompletionClient};
-use rig::completion::{CompletionModel, Prompt, StructuredOutputError, TypedPrompt};
-use rig::extractor::ExtractorBuilder;
+use rig::completion::{
+    CompletionError, CompletionModel, Prompt, PromptError, StructuredOutputError, TypedPrompt,
+};
+use rig::extractor::{ExtractionError, ExtractorBuilder};
 use rig::providers::{anthropic, gemini, openai};
 
 use crate::provider::ProviderMeta;
@@ -18,6 +20,10 @@ use open_course_config::provider::{ProviderConfig, ProviderId};
 use open_course_core::error::{AppError, Result};
 
 const LLM_MAX_RETRIES: usize = 3;
+
+/// Ceiling applied to a provider-supplied `Retry-After` hint so a hostile
+/// or buggy value cannot park a retry loop for minutes.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
 
 pub const DEFAULT_MAX_TOKENS: u32 = 8192;
 
@@ -43,13 +49,140 @@ fn provider_error_message(msg: &str) -> String {
     msg.to_string()
 }
 
-pub(crate) fn classify_llm_error<E: std::fmt::Display>(e: E) -> AppError {
-    let msg = e.to_string();
-    if is_provider_unavailable(&msg) {
-        AppError::ProviderUnavailable(provider_error_message(&msg))
-    } else {
-        AppError::Llm(msg)
+/// Typed provider-error inspection backing [`classify_llm_error`]. rig's
+/// error types expose the HTTP status, response body, provider request id
+/// and rate-limit headers of the failed call; errors that carry no typed
+/// data (plain strings, our own messages) get the default `None`s and are
+/// classified by string-matching.
+pub(crate) trait TypedErrorInfo: std::fmt::Display {
+    fn status(&self) -> Option<u16> {
+        None
     }
+    fn body(&self) -> Option<&str> {
+        None
+    }
+    fn request_id(&self) -> Option<&str> {
+        None
+    }
+    fn retry_after(&self) -> Option<Duration> {
+        None
+    }
+}
+
+macro_rules! impl_typed_error_info {
+    ($ty:ty) => {
+        impl TypedErrorInfo for $ty {
+            fn status(&self) -> Option<u16> {
+                self.provider_response_status().map(|s| s.as_u16())
+            }
+            fn body(&self) -> Option<&str> {
+                self.provider_response_body()
+            }
+            fn request_id(&self) -> Option<&str> {
+                self.provider_request_id()
+            }
+            fn retry_after(&self) -> Option<Duration> {
+                // Only the delta-seconds form is useful; the HTTP-date form
+                // is ignored.
+                self.provider_response_headers()?
+                    .get("retry-after")?
+                    .to_str()
+                    .ok()?
+                    .parse::<u64>()
+                    .ok()
+                    .map(Duration::from_secs)
+            }
+        }
+    };
+}
+
+impl_typed_error_info!(CompletionError);
+impl_typed_error_info!(PromptError);
+impl_typed_error_info!(StructuredOutputError);
+
+impl TypedErrorInfo for ExtractionError {
+    fn status(&self) -> Option<u16> {
+        match self {
+            Self::CompletionError(e) => e.status(),
+            Self::PromptError(e) => e.status(),
+            _ => None,
+        }
+    }
+    fn body(&self) -> Option<&str> {
+        match self {
+            Self::CompletionError(e) => e.body(),
+            Self::PromptError(e) => e.body(),
+            _ => None,
+        }
+    }
+    fn request_id(&self) -> Option<&str> {
+        match self {
+            Self::CompletionError(e) => e.request_id(),
+            Self::PromptError(e) => e.request_id(),
+            _ => None,
+        }
+    }
+    fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::CompletionError(e) => e.retry_after(),
+            Self::PromptError(e) => e.retry_after(),
+            _ => None,
+        }
+    }
+}
+
+impl TypedErrorInfo for &str {}
+impl TypedErrorInfo for String {}
+
+/// Best human-readable message for an LLM failure: the provider's own
+/// `error.message` from the typed response body when there is one, else the
+/// legacy scrape of the Display output (which falls back to the full
+/// Display string).
+fn error_message<E: TypedErrorInfo>(e: &E) -> String {
+    if let Some(message) = e
+        .body()
+        .and_then(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+        .and_then(|value| {
+            value
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(|message| message.as_str())
+                .map(str::to_string)
+        })
+    {
+        return message;
+    }
+    provider_error_message(&e.to_string())
+}
+
+/// Classify an LLM failure into the crate error type, typed data first:
+/// 429/5xx are transient (`ProviderUnavailable`, drives the retry loops
+/// and the streaming→prompt fallback), auth failures and other statuses
+/// are not retried. With no typed status (connect errors, rig-generated
+/// diagnostics, our own strings) the substring heuristic decides. The
+/// provider request id is appended when the error carries one.
+pub(crate) fn classify_llm_error<E: TypedErrorInfo>(e: E) -> AppError {
+    let message = match e.request_id() {
+        Some(id) => format!("{} (provider request id: {id})", error_message(&e)),
+        None => error_message(&e),
+    };
+    match e.status() {
+        Some(429) | Some(500..=599) => AppError::ProviderUnavailable(message),
+        Some(status @ (401 | 403)) => AppError::Llm(format!(
+            "authentication failed (status {status}): {message}"
+        )),
+        Some(_) => AppError::Llm(message),
+        None if is_provider_unavailable(&e.to_string()) => AppError::ProviderUnavailable(message),
+        None => AppError::Llm(message),
+    }
+}
+
+/// Backoff before the next retry: the provider's `Retry-After` hint when
+/// one was captured (capped), else the fixed linear backoff.
+pub(crate) fn retry_delay(attempt: usize, retry_after: Option<Duration>) -> Duration {
+    retry_after
+        .map(|delay| delay.min(MAX_RETRY_AFTER))
+        .unwrap_or_else(|| Duration::from_millis(500 * attempt as u64))
 }
 
 /// `additional_params` that keep reasoning off on Anthropic-family APIs:
@@ -273,11 +406,11 @@ impl RigClient {
                 match self.prompt_typed_native::<T>(prompt, max_tokens).await {
                     Ok(value) => return Ok(value),
                     Err(e) => {
+                        let retry_after = e.retry_after();
                         let app_err = classify_llm_error(e);
                         if matches!(app_err, AppError::ProviderUnavailable(_)) {
                             if attempt < LLM_MAX_RETRIES {
-                                tokio::time::sleep(Duration::from_millis(500 * attempt as u64))
-                                    .await;
+                                tokio::time::sleep(retry_delay(attempt, retry_after)).await;
                                 last_err = Some(app_err);
                                 continue;
                             }
@@ -337,11 +470,12 @@ impl RigClient {
             match result {
                 Ok(value) => return Ok(value),
                 Err(e) => {
+                    let retry_after = e.retry_after();
                     let app_err = classify_llm_error(e);
                     if matches!(app_err, AppError::ProviderUnavailable(_))
                         && attempt < LLM_MAX_RETRIES
                     {
-                        tokio::time::sleep(Duration::from_millis(500 * attempt as u64)).await;
+                        tokio::time::sleep(retry_delay(attempt, retry_after)).await;
                         last_err = Some(app_err);
                         continue;
                     }
@@ -510,11 +644,12 @@ impl LlmClient for RigClient {
             match result {
                 Ok(text) => return Ok(text),
                 Err(e) => {
+                    let retry_after = e.retry_after();
                     let app_err = classify_llm_error(e);
                     if matches!(app_err, AppError::ProviderUnavailable(_))
                         && attempt < LLM_MAX_RETRIES
                     {
-                        tokio::time::sleep(Duration::from_millis(500 * attempt as u64)).await;
+                        tokio::time::sleep(retry_delay(attempt, retry_after)).await;
                         last_err = Some(app_err);
                         continue;
                     }
@@ -863,5 +998,119 @@ mod tests {
     fn provider_overload_stays_retryable() {
         let err = classify_llm_error("server_error: provider overloaded");
         assert!(matches!(err, AppError::ProviderUnavailable(_)));
+    }
+
+    fn http_error_with_retry_after(
+        status: http::StatusCode,
+        body: &str,
+        retry_after: &str,
+    ) -> CompletionError {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::RETRY_AFTER,
+            http::HeaderValue::from_str(retry_after).unwrap(),
+        );
+        CompletionError::from_http_response(status, body)
+            .with_response_headers(Some(Box::new(headers)))
+    }
+
+    #[test]
+    fn typed_429_is_unavailable_and_carries_retry_after() {
+        let err = http_error_with_retry_after(
+            http::StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":{"message":"rate limited"}}"#,
+            "7",
+        );
+        assert_eq!(err.retry_after(), Some(Duration::from_secs(7)));
+        match classify_llm_error(err) {
+            AppError::ProviderUnavailable(msg) => assert!(msg.contains("rate limited"), "{msg}"),
+            other => panic!("expected ProviderUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typed_5xx_is_unavailable_with_provider_message_and_request_id() {
+        let err = CompletionError::from_http_response_with_request_id(
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"error":{"message":"model overloaded"}}"#,
+            Some("req_abc123".to_string()),
+        );
+        match classify_llm_error(err) {
+            AppError::ProviderUnavailable(msg) => {
+                assert!(msg.contains("model overloaded"), "{msg}");
+                assert!(msg.contains("req_abc123"), "{msg}");
+            }
+            other => panic!("expected ProviderUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typed_auth_failure_is_not_retryable() {
+        for status in [http::StatusCode::UNAUTHORIZED, http::StatusCode::FORBIDDEN] {
+            let err =
+                CompletionError::from_http_response(status, r#"{"error":{"message":"bad key"}}"#);
+            match classify_llm_error(err) {
+                AppError::Llm(msg) => {
+                    assert!(msg.contains("authentication failed"), "{msg}");
+                    assert!(msg.contains("bad key"), "{msg}");
+                }
+                other => panic!("expected AppError::Llm for {status}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn typed_400_is_not_retryable() {
+        let err = CompletionError::from_http_response(
+            http::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"response_format is not supported"}}"#,
+        );
+        match classify_llm_error(err) {
+            AppError::Llm(msg) => assert!(msg.contains("response_format"), "{msg}"),
+            other => panic!("expected AppError::Llm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typed_error_data_survives_wrapper_errors() {
+        let completion = CompletionError::from_http_response_with_request_id(
+            http::StatusCode::BAD_GATEWAY,
+            "bad gateway",
+            Some("req_wrap".to_string()),
+        );
+        let prompt_err = PromptError::CompletionError(completion);
+        match classify_llm_error(prompt_err) {
+            AppError::ProviderUnavailable(msg) => assert!(msg.contains("req_wrap"), "{msg}"),
+            other => panic!("expected ProviderUnavailable, got {other:?}"),
+        }
+
+        let completion =
+            CompletionError::from_http_response(http::StatusCode::SERVICE_UNAVAILABLE, "down");
+        let extraction = ExtractionError::CompletionError(completion);
+        assert!(matches!(
+            classify_llm_error(extraction),
+            AppError::ProviderUnavailable(_)
+        ));
+    }
+
+    #[test]
+    fn string_classification_applies_without_typed_status() {
+        // Plain-string errors (no typed data) still use the substring
+        // heuristic, e.g. rig-generated diagnostics and connect failures.
+        let err = classify_llm_error("HttpError: error trying to connect: dns error");
+        assert!(matches!(err, AppError::Llm(_)));
+    }
+
+    #[test]
+    fn retry_delay_prefers_capped_retry_after_hint() {
+        assert_eq!(
+            retry_delay(1, Some(Duration::from_secs(5))),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            retry_delay(1, Some(Duration::from_secs(3600))),
+            MAX_RETRY_AFTER
+        );
+        assert_eq!(retry_delay(2, None), Duration::from_millis(1000));
     }
 }

--- a/crates/llm/src/model_listing.rs
+++ b/crates/llm/src/model_listing.rs
@@ -1,5 +1,9 @@
 use std::time::Duration;
 
+use rig::client::ModelListingClient;
+use rig::model::{Model, ModelList, ModelListingError};
+use rig::providers::{anthropic, gemini, openai};
+
 use crate::provider::ProviderMeta;
 use open_course_config::provider::ProviderId;
 use open_course_core::error::{AppError, Result};
@@ -16,16 +20,75 @@ pub async fn list_models(
     base_url: Option<&str>,
 ) -> Result<Vec<ModelInfo>> {
     match provider_id {
-        ProviderId::Anthropic => list_anthropic_models(api_key, base_url).await,
-        ProviderId::Google => list_gemini_models(api_key, base_url).await,
+        ProviderId::Anthropic => {
+            let base_url = base_url.unwrap_or("https://api.anthropic.com");
+            let api_key = api_key.ok_or_else(|| {
+                AppError::ProviderConfig("Anthropic requires an API key to list models".to_string())
+            })?;
+            let client = anthropic::Client::builder()
+                .api_key(api_key)
+                .base_url(base_url)
+                .http_client(http_client()?)
+                .build()
+                .map_err(|e| AppError::Llm(format!("Failed to build Anthropic client: {e}")))?;
+            map_model_list(client.list_models().await)
+        }
+        ProviderId::Google => {
+            let base_url = base_url.unwrap_or("https://generativelanguage.googleapis.com");
+            let api_key = api_key.ok_or_else(|| {
+                AppError::ProviderConfig("Gemini requires an API key to list models".to_string())
+            })?;
+            let client = gemini::Client::builder()
+                .api_key(api_key)
+                .base_url(base_url)
+                .http_client(http_client()?)
+                .build()
+                .map_err(|e| AppError::Llm(format!("Failed to build Gemini client: {e}")))?;
+            map_model_list(client.list_models().await)
+        }
         ProviderId::MiniMax => {
             // Chat moved to the Anthropic-compatible API, which serves
             // messages only; model listing stays on the OpenAI-compatible
             // endpoint. Configs carrying either known default map to it.
             let base_url = minimax_listing_base_url(base_url);
-            list_openai_models_at(base_url, api_key).await
+            list_openai_style_models(base_url, api_key).await
         }
-        _ => list_openai_compatible_models(provider_id, api_key, base_url).await,
+        _ => {
+            let meta = ProviderMeta::for_provider(provider_id);
+            let base_url = base_url.or(meta.default_base_url).ok_or_else(|| {
+                AppError::ProviderConfig(format!("{provider_id:?} requires a base URL"))
+            })?;
+            list_openai_style_models(base_url, api_key).await
+        }
+    }
+}
+
+/// List models from an OpenAI-style `GET {base_url}/models` endpoint via
+/// rig's OpenAI completions model lister. Covers OpenAI itself plus every
+/// OpenAI-compatible provider (DeepSeek, Mistral, OpenRouter, MiniMax,
+/// Ollama, Custom).
+async fn list_openai_style_models(base_url: &str, api_key: Option<&str>) -> Result<Vec<ModelInfo>> {
+    let client = openai::CompletionsClient::builder()
+        .api_key(api_key.unwrap_or_default())
+        .base_url(base_url)
+        .http_client(http_client()?)
+        .build()
+        .map_err(|e| AppError::Llm(format!("Failed to build OpenAI client: {e}")))?;
+    map_model_list(client.list_models().await)
+}
+
+fn map_model_list(
+    result: std::result::Result<ModelList, ModelListingError>,
+) -> Result<Vec<ModelInfo>> {
+    result
+        .map(|list| list.into_iter().map(model_info).collect())
+        .map_err(|e| AppError::Llm(e.to_string()))
+}
+
+fn model_info(model: Model) -> ModelInfo {
+    ModelInfo {
+        id: model.id,
+        label: model.name,
     }
 }
 
@@ -39,190 +102,11 @@ fn minimax_listing_base_url(base_url: Option<&str>) -> &str {
     }
 }
 
-async fn list_anthropic_models(
-    api_key: Option<&str>,
-    base_url: Option<&str>,
-) -> Result<Vec<ModelInfo>> {
-    let base_url = base_url
-        .unwrap_or("https://api.anthropic.com")
-        .trim_end_matches('/');
-    let url = format!("{base_url}/v1/models");
-    let api_key = api_key.ok_or_else(|| {
-        AppError::ProviderConfig("Anthropic requires an API key to list models".to_string())
-    })?;
-
-    let client = http_client()?;
-    let response = client
-        .get(&url)
-        .header("x-api-key", api_key)
-        .header("anthropic-version", "2023-06-01")
-        .send()
-        .await
-        .map_err(|e| AppError::Llm(format!("Failed to fetch Anthropic models: {e}")))?;
-
-    let status = response.status();
-    if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        return Err(AppError::Llm(format!(
-            "Anthropic model listing returned {status}: {body}"
-        )));
-    }
-
-    let payload: AnthropicModelList = response
-        .json()
-        .await
-        .map_err(|e| AppError::Llm(format!("Failed to parse Anthropic model list: {e}")))?;
-
-    let models: Vec<ModelInfo> = payload
-        .data
-        .into_iter()
-        .map(|m| ModelInfo {
-            id: m.id,
-            label: Some(m.display_name),
-        })
-        .collect();
-    Ok(models)
-}
-
-async fn list_gemini_models(
-    api_key: Option<&str>,
-    base_url: Option<&str>,
-) -> Result<Vec<ModelInfo>> {
-    let base_url = base_url
-        .unwrap_or("https://generativelanguage.googleapis.com")
-        .trim_end_matches('/');
-    let api_key = api_key.ok_or_else(|| {
-        AppError::ProviderConfig("Gemini requires an API key to list models".to_string())
-    })?;
-    let url = format!("{base_url}/v1beta/models?key={api_key}");
-
-    let client = http_client()?;
-    let response = client
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| AppError::Llm(format!("Failed to fetch Gemini models: {e}")))?;
-
-    let status = response.status();
-    if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        return Err(AppError::Llm(format!(
-            "Gemini model listing returned {status}: {body}"
-        )));
-    }
-
-    let payload: GeminiModelList = response
-        .json()
-        .await
-        .map_err(|e| AppError::Llm(format!("Failed to parse Gemini model list: {e}")))?;
-
-    let models: Vec<ModelInfo> = payload
-        .models
-        .into_iter()
-        .map(|m| {
-            let id = m
-                .name
-                .strip_prefix("models/")
-                .unwrap_or(&m.name)
-                .to_string();
-            ModelInfo {
-                id,
-                label: Some(m.display_name),
-            }
-        })
-        .collect();
-    Ok(models)
-}
-
-async fn list_openai_compatible_models(
-    provider_id: ProviderId,
-    api_key: Option<&str>,
-    base_url: Option<&str>,
-) -> Result<Vec<ModelInfo>> {
-    let meta = ProviderMeta::for_provider(provider_id);
-    let base_url = base_url
-        .or(meta.default_base_url)
-        .ok_or_else(|| AppError::ProviderConfig(format!("{provider_id:?} requires a base URL")))?;
-    list_openai_models_at(base_url, api_key).await
-}
-
-async fn list_openai_models_at(base_url: &str, api_key: Option<&str>) -> Result<Vec<ModelInfo>> {
-    let base_url = base_url.trim_end_matches('/');
-    let url = format!("{base_url}/models");
-
-    let client = http_client()?;
-    let mut request = client.get(&url);
-    if let Some(key) = api_key {
-        request = request.bearer_auth(key);
-    }
-
-    let response = request
-        .send()
-        .await
-        .map_err(|e| AppError::Llm(format!("Failed to fetch models: {e}")))?;
-
-    let status = response.status();
-    if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        return Err(AppError::Llm(format!(
-            "Model listing returned {status}: {body}"
-        )));
-    }
-
-    let payload: OpenAiModelList = response
-        .json()
-        .await
-        .map_err(|e| AppError::Llm(format!("Failed to parse model list: {e}")))?;
-
-    let models: Vec<ModelInfo> = payload
-        .data
-        .into_iter()
-        .map(|m| ModelInfo {
-            id: m.id,
-            label: None,
-        })
-        .collect();
-    Ok(models)
-}
-
 fn http_client() -> Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|e| AppError::Llm(format!("Failed to build HTTP client: {e}")))
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct AnthropicModelList {
-    data: Vec<AnthropicModel>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct AnthropicModel {
-    id: String,
-    display_name: String,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct GeminiModelList {
-    models: Vec<GeminiModel>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct GeminiModel {
-    name: String,
-    #[serde(rename = "displayName")]
-    display_name: String,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct OpenAiModelList {
-    data: Vec<OpenAiModel>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct OpenAiModel {
-    id: String,
 }
 
 #[cfg(test)]
@@ -250,5 +134,29 @@ mod tests {
             minimax_listing_base_url(Some("https://proxy.example.com/v1")),
             "https://proxy.example.com/v1"
         );
+    }
+
+    #[test]
+    fn model_info_maps_rig_model_fields() {
+        let named = model_info(Model::new("claude-sonnet-5", "Claude Sonnet 5"));
+        assert_eq!(named.id, "claude-sonnet-5");
+        assert_eq!(named.label.as_deref(), Some("Claude Sonnet 5"));
+
+        let anonymous = model_info(Model::from_id("gpt-5"));
+        assert_eq!(anonymous.id, "gpt-5");
+        assert_eq!(anonymous.label, None);
+    }
+
+    #[test]
+    fn listing_errors_map_to_app_error_llm() {
+        let err = map_model_list(Err(ModelListingError::api_error(401, "bad key")))
+            .expect_err("should propagate");
+        match err {
+            AppError::Llm(msg) => {
+                assert!(msg.contains("401"), "status should survive: {msg}");
+                assert!(msg.contains("bad key"), "message should survive: {msg}");
+            }
+            other => panic!("expected AppError::Llm, got {other:?}"),
+        }
     }
 }

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -106,13 +106,6 @@ impl ProviderMeta {
         }
     }
 
-    pub fn rig_additional_params(&self) -> Option<serde_json::Value> {
-        match self.id {
-            ProviderId::Google => Some(serde_json::json!({ "generationConfig": {} })),
-            _ => None,
-        }
-    }
-
     pub fn resolve_api_key(&self, configured: Option<&str>) -> Option<String> {
         if let Some(key) = configured
             && !key.is_empty()
@@ -211,24 +204,5 @@ mod tests {
         assert_eq!(meta.resolve_api_key(None), None);
         let meta = ProviderMeta::for_provider(ProviderId::Custom);
         assert_eq!(meta.resolve_api_key(None), None);
-    }
-
-    #[test]
-    fn google_requires_generation_config_workaround() {
-        let meta = ProviderMeta::for_provider(ProviderId::Google);
-        let params = meta
-            .rig_additional_params()
-            .expect("google needs additional_params");
-        assert!(params.get("generationConfig").is_some());
-    }
-
-    #[test]
-    fn non_google_providers_have_no_additional_params() {
-        for provider in all_providers() {
-            if *provider != ProviderId::Google {
-                let meta = ProviderMeta::for_provider(*provider);
-                assert_eq!(meta.rig_additional_params(), None);
-            }
-        }
     }
 }

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -19,6 +19,29 @@ pub const GOOGLE_RETIRED_MODELS: [&str; 2] = ["gemini-2.5-flash", "models/gemini
 /// Replacement served for every id in `GOOGLE_RETIRED_MODELS`.
 pub const GOOGLE_RETIRED_MODEL_REPLACEMENT: &str = "gemini-3.6-flash";
 
+/// True for OpenAI model families that reason by default and accept
+/// `reasoning_effort` (gpt-5 and up, and the o-series); other OpenAI
+/// models reject the field outright with a 400, so it must only be sent
+/// to these families. Mirrors rig's internal `is_openai_reasoning_model`
+/// classification (same families that require `max_completion_tokens`).
+pub fn is_openai_reasoning_model(model: &str) -> bool {
+    let numbered_gpt_5_plus = model
+        .strip_prefix("gpt-")
+        .and_then(|rest| rest.split(['.', '-']).next())
+        .filter(|major| major.len() == 1)
+        .and_then(|major| major.parse::<u32>().ok())
+        .is_some_and(|major| major >= 5);
+    let o_series = {
+        let mut chars = model.chars();
+        chars.next() == Some('o')
+            && chars.next().is_some_and(|c| c.is_ascii_digit())
+            && chars
+                .next()
+                .is_none_or(|next| next == '-' || next.is_ascii_digit())
+    };
+    numbered_gpt_5_plus || o_series
+}
+
 pub struct ProviderMeta {
     pub id: ProviderId,
     pub label: &'static str,

--- a/crates/llm/src/streaming.rs
+++ b/crates/llm/src/streaming.rs
@@ -1,12 +1,10 @@
 use std::pin::Pin;
-use std::task::{Context, Poll};
 
-use bytes::Bytes;
-use futures_util::Stream;
-use reqwest::Client;
-use serde_json::json;
+use futures_util::{Stream, StreamExt};
+use rig::completion::CompletionError;
+use rig::streaming::{StreamedAssistantContent, StreamingCompletionResponse};
 
-use open_course_core::error::{AppError, Result};
+use open_course_core::error::Result;
 
 #[derive(Debug, Clone)]
 pub enum StreamChunk {
@@ -16,356 +14,81 @@ pub enum StreamChunk {
 
 pub type LlmStream = Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>;
 
-struct SseStream {
-    bytes_stream: Pin<Box<dyn Stream<Item = std::result::Result<Bytes, reqwest::Error>> + Send>>,
-    buffer: Vec<u8>,
-    finished: bool,
-    parser: fn(&str) -> Option<StreamChunk>,
+/// Adapt a rig streaming completion into our chunk stream.
+///
+/// Dropping the returned stream drops rig's abort handle along with it,
+/// which aborts the underlying HTTP request.
+pub fn into_llm_stream(response: StreamingCompletionResponse) -> LlmStream {
+    Box::pin(response.filter_map(|item| async move { map_stream_item(item) }))
 }
 
-impl Stream for SseStream {
-    type Item = Result<StreamChunk>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        loop {
-            if let Some(frame) = extract_frame(&mut this.buffer) {
-                if let Some(content) = (this.parser)(&frame) {
-                    return Poll::Ready(Some(Ok(content)));
-                }
-                continue;
-            }
-            if this.finished {
-                return Poll::Ready(None);
-            }
-            match Pin::new(&mut this.bytes_stream).poll_next(cx) {
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(None) => {
-                    this.finished = true;
-                    continue;
-                }
-                Poll::Ready(Some(item)) => match item {
-                    Ok(bytes) => {
-                        this.buffer.extend_from_slice(&bytes);
-                        continue;
-                    }
-                    Err(e) => return Poll::Ready(Some(Err(classify_stream_error(e)))),
-                },
-            }
+/// Map one rig stream item to our chunk type. Text deltas and reasoning
+/// deltas are forwarded; everything else is dropped: completed reasoning
+/// blocks (they restate deltas already forwarded), tool calls (unused on
+/// our streaming paths), terminal records, and unknown provider items.
+fn map_stream_item(
+    item: std::result::Result<StreamedAssistantContent, CompletionError>,
+) -> Option<Result<StreamChunk>> {
+    match item {
+        Ok(StreamedAssistantContent::Text(text)) => Some(Ok(StreamChunk::Content(text.text))),
+        Ok(StreamedAssistantContent::ReasoningDelta { reasoning, .. }) => {
+            Some(Ok(StreamChunk::Reasoning(reasoning)))
         }
+        Ok(_) => None,
+        Err(e) => Some(Err(crate::client::classify_llm_error(e))),
     }
-}
-
-fn extract_frame(buffer: &mut Vec<u8>) -> Option<String> {
-    if let Some(pos) = buffer.windows(2).position(|w| w == b"\n\n") {
-        let frame_bytes = buffer[..pos].to_vec();
-        buffer.drain(..pos + 2);
-        String::from_utf8(frame_bytes).ok()
-    } else {
-        None
-    }
-}
-
-fn classify_stream_error<E: std::fmt::Display>(e: E) -> AppError {
-    let msg = e.to_string();
-    if msg.contains("Inference is temporarily unavailable")
-        || msg.contains("failover_exhausted")
-        || msg.contains("temporarily unavailable")
-        || msg.contains("server_error")
-    {
-        AppError::ProviderUnavailable(msg)
-    } else {
-        AppError::Llm(msg)
-    }
-}
-
-fn parse_sse_content(
-    frame: &str,
-    extract: impl Fn(&serde_json::Value) -> Option<StreamChunk>,
-) -> Option<StreamChunk> {
-    for line in frame.lines() {
-        if let Some(data) = line.strip_prefix("data: ") {
-            let data = data.trim();
-            if data == "[DONE]" {
-                return None;
-            }
-            if let Ok(value) = serde_json::from_str::<serde_json::Value>(data)
-                && let Some(chunk) = extract(&value)
-            {
-                return Some(chunk);
-            }
-        }
-    }
-    None
-}
-
-fn parse_openai_frame(frame: &str) -> Option<StreamChunk> {
-    parse_sse_content(frame, |value| {
-        let delta = value
-            .get("choices")
-            .and_then(|c| c.as_array())
-            .and_then(|c| c.first())
-            .and_then(|c| c.get("delta"));
-        // Some gateways (e.g. Aliyun Model Studio's compatible mode) put
-        // both keys in every delta, with `reasoning_content: ""` once the
-        // real content starts — an empty reasoning string must not swallow
-        // the content in the same frame.
-        if let Some(content) = delta
-            .and_then(|d| d.get("reasoning_content"))
-            .and_then(|c| c.as_str())
-            && !content.is_empty()
-        {
-            return Some(StreamChunk::Reasoning(content.to_string()));
-        }
-        if let Some(content) = delta
-            .and_then(|d| d.get("content"))
-            .and_then(|c| c.as_str())
-        {
-            return Some(StreamChunk::Content(content.to_string()));
-        }
-        None
-    })
-}
-
-fn parse_anthropic_frame(frame: &str) -> Option<StreamChunk> {
-    parse_sse_content(frame, |value| {
-        if let Some(text) = value
-            .get("delta")
-            .and_then(|d| d.get("thinking"))
-            .and_then(|t| t.as_str())
-        {
-            return Some(StreamChunk::Reasoning(text.to_string()));
-        }
-        if let Some(text) = value
-            .get("delta")
-            .and_then(|d| d.get("text"))
-            .and_then(|t| t.as_str())
-        {
-            return Some(StreamChunk::Content(text.to_string()));
-        }
-        None
-    })
-}
-
-fn build_openai_request_body(
-    model: &str,
-    system: Option<&str>,
-    prompt: &str,
-    reasoning_effort: Option<&str>,
-    enable_thinking: Option<bool>,
-    max_tokens: u32,
-    openai_native: bool,
-) -> serde_json::Value {
-    let mut messages = Vec::new();
-    if let Some(system) = system {
-        messages.push(json!({ "role": "system", "content": system }));
-    }
-    messages.push(json!({ "role": "user", "content": prompt }));
-    let mut body = json!({
-        "model": model,
-        "messages": messages,
-        "stream": true,
-    });
-    // OpenAI's gpt-5/o-series models reject `max_tokens` and require
-    // `max_completion_tokens`; OpenAI-compatible gateways expect
-    // `max_tokens`.
-    if openai_native {
-        body["max_completion_tokens"] = json!(max_tokens);
-    } else {
-        body["max_tokens"] = json!(max_tokens);
-    }
-    if let Some(effort) = reasoning_effort {
-        body["reasoning_effort"] = json!(effort);
-    }
-    // OpenAI rejects the Qwen/Aliyun `enable_thinking` extension with a 400.
-    if !openai_native && let Some(enable_thinking) = enable_thinking {
-        body["enable_thinking"] = json!(enable_thinking);
-    }
-    body
-}
-
-#[allow(clippy::too_many_arguments)]
-pub async fn stream_openai_compatible(
-    base_url: &str,
-    api_key: &str,
-    model: &str,
-    system: Option<&str>,
-    prompt: &str,
-    reasoning_effort: Option<&str>,
-    enable_thinking: Option<bool>,
-    max_tokens: u32,
-    openai_native: bool,
-) -> Result<LlmStream> {
-    let client = Client::new();
-    let body = build_openai_request_body(
-        model,
-        system,
-        prompt,
-        reasoning_effort,
-        enable_thinking,
-        max_tokens,
-        openai_native,
-    );
-    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
-
-    let mut request = client
-        .post(&url)
-        .header("Accept", "text/event-stream")
-        .json(&body);
-    if !api_key.is_empty() {
-        request = request.header("Authorization", format!("Bearer {api_key}"));
-    }
-
-    let response = request
-        .send()
-        .await
-        .map_err(|e| AppError::Llm(format!("OpenAI-compatible stream request failed: {e}")))?;
-
-    if !response.status().is_success() {
-        let text = response.text().await.unwrap_or_default();
-        return Err(classify_stream_error(text));
-    }
-
-    Ok(Box::pin(SseStream {
-        bytes_stream: Box::pin(response.bytes_stream()),
-        buffer: Vec::new(),
-        finished: false,
-        parser: parse_openai_frame,
-    }))
-}
-
-fn build_anthropic_request_body(
-    model: &str,
-    system: Option<&str>,
-    prompt: &str,
-    max_tokens: u32,
-    disable_thinking: bool,
-) -> serde_json::Value {
-    let mut body = json!({
-        "model": model,
-        "max_tokens": max_tokens,
-        "messages": [{"role": "user", "content": prompt}],
-        "stream": true,
-    });
-    if let Some(system) = system {
-        body["system"] = json!(system);
-    }
-    // Anthropic-family providers are asked to keep thinking off for speed:
-    // newer Claude models (e.g. claude-sonnet-5) enable adaptive thinking by
-    // default, and the explicit `disabled` guards MiniMax-M3 against a
-    // default change. Older models accept but ignore the field.
-    if disable_thinking {
-        body["thinking"] = json!({"type": "disabled"});
-    }
-    body
-}
-
-#[allow(clippy::too_many_arguments)]
-pub async fn stream_anthropic_messages(
-    base_url: &str,
-    api_key: &str,
-    model: &str,
-    system: Option<&str>,
-    prompt: &str,
-    max_tokens: u32,
-    disable_thinking: bool,
-) -> Result<LlmStream> {
-    let client = Client::new();
-    let body = build_anthropic_request_body(model, system, prompt, max_tokens, disable_thinking);
-    let url = format!("{}/v1/messages", base_url.trim_end_matches('/'));
-
-    let response = client
-        .post(&url)
-        .header("x-api-key", api_key)
-        .header("anthropic-version", "2023-06-01")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| AppError::Llm(format!("Anthropic stream request failed: {e}")))?;
-
-    if !response.status().is_success() {
-        let text = response.text().await.unwrap_or_default();
-        return Err(classify_stream_error(text));
-    }
-
-    Ok(Box::pin(SseStream {
-        bytes_stream: Box::pin(response.bytes_stream()),
-        buffer: Vec::new(),
-        finished: false,
-        parser: parse_anthropic_frame,
-    }))
-}
-
-pub fn stream_from_text(text: String) -> LlmStream {
-    Box::pin(futures_util::stream::once(async move {
-        Ok(StreamChunk::Content(text))
-    }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use open_course_core::error::AppError;
+    use rig::streaming::UnknownPayload;
 
     #[test]
-    fn request_body_omits_enable_thinking_when_unset() {
-        let body = build_openai_request_body("m", None, "hi", None, None, 100, false);
-        assert!(body.get("enable_thinking").is_none());
-        assert!(body.get("reasoning_effort").is_none());
-    }
-
-    #[test]
-    fn request_body_includes_enable_thinking_when_set() {
-        let body =
-            build_openai_request_body("m", Some("sys"), "hi", Some("low"), Some(false), 100, false);
-        assert_eq!(body["enable_thinking"], json!(false));
-        assert_eq!(body["reasoning_effort"], json!("low"));
-        assert_eq!(body["stream"], json!(true));
-        assert_eq!(body["max_tokens"], json!(100));
-        assert_eq!(body["messages"].as_array().unwrap().len(), 2);
-    }
-
-    #[test]
-    fn openai_native_body_uses_max_completion_tokens_and_drops_enable_thinking() {
-        let body = build_openai_request_body("m", None, "hi", Some("low"), Some(false), 100, true);
-        assert_eq!(body["max_completion_tokens"], json!(100));
-        assert!(body.get("max_tokens").is_none());
-        assert_eq!(body["reasoning_effort"], json!("low"));
-        assert!(body.get("enable_thinking").is_none());
-    }
-
-    #[test]
-    fn openai_frame_prefers_non_empty_reasoning() {
-        let frame =
-            r#"data: {"choices":[{"index":0,"delta":{"content":"","reasoning_content":"We"}}]}"#;
-        match parse_openai_frame(frame) {
-            Some(StreamChunk::Reasoning(text)) => assert_eq!(text, "We"),
-            other => panic!("expected reasoning chunk, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn openai_frame_empty_reasoning_does_not_swallow_content() {
-        // Aliyun-compatible gateways emit both keys in one delta, with
-        // `reasoning_content: ""` once the answer content starts.
-        let frame = r#"data: {"choices":[{"index":0,"delta":{"content":"STREAM_OK","reasoning_content":""}}]}"#;
-        match parse_openai_frame(frame) {
-            Some(StreamChunk::Content(text)) => assert_eq!(text, "STREAM_OK"),
+    fn text_delta_maps_to_content() {
+        let item = Ok(StreamedAssistantContent::text("hello"));
+        match map_stream_item(item) {
+            Some(Ok(StreamChunk::Content(text))) => assert_eq!(text, "hello"),
             other => panic!("expected content chunk, got {other:?}"),
         }
     }
 
     #[test]
-    fn anthropic_body_omits_thinking_by_default() {
-        let body = build_anthropic_request_body("m", Some("sys"), "hi", 100, false);
-        assert!(body.get("thinking").is_none());
-        assert_eq!(body["max_tokens"], json!(100));
-        assert_eq!(body["system"], json!("sys"));
+    fn reasoning_delta_maps_to_reasoning() {
+        let item = Ok(StreamedAssistantContent::ReasoningDelta {
+            id: "r1".to_string(),
+            provider_id: None,
+            reasoning: "thinking".to_string(),
+        });
+        match map_stream_item(item) {
+            Some(Ok(StreamChunk::Reasoning(text))) => assert_eq!(text, "thinking"),
+            other => panic!("expected reasoning chunk, got {other:?}"),
+        }
     }
 
     #[test]
-    fn anthropic_body_disables_thinking_when_requested() {
-        let body = build_anthropic_request_body("m", None, "hi", 100, true);
-        assert_eq!(body["thinking"], json!({"type": "disabled"}));
-        assert_eq!(body["stream"], json!(true));
+    fn unknown_provider_items_are_skipped() {
+        let item = Ok(StreamedAssistantContent::Unknown(UnknownPayload::new(
+            serde_json::json!({ "type": "web_search_call" }),
+        )));
+        assert!(map_stream_item(item).is_none());
+    }
+
+    #[test]
+    fn stream_errors_are_classified() {
+        let item = Err(CompletionError::ProviderError(
+            "server_error: provider overloaded".to_string(),
+        ));
+        match map_stream_item(item) {
+            Some(Err(AppError::ProviderUnavailable(_))) => {}
+            other => panic!("expected ProviderUnavailable, got {other:?}"),
+        }
+
+        let item = Err(CompletionError::ResponseError("bad json".to_string()));
+        match map_stream_item(item) {
+            Some(Err(AppError::Llm(msg))) => assert!(msg.contains("bad json")),
+            other => panic!("expected AppError::Llm, got {other:?}"),
+        }
     }
 }

--- a/crates/llm/tests/live.rs
+++ b/crates/llm/tests/live.rs
@@ -1,0 +1,292 @@
+//! Live integration tests against real LLM providers. Every test skips
+//! cleanly unless the matching env vars are set, so CI stays green without
+//! keys. Keys come from the environment only — never commit them.
+//!
+//! ```sh
+//! OC_LIVE_OPENAI_KEY=... OC_LIVE_GEMINI_KEY=... OC_LIVE_ALI_KEY=... \
+//!     cargo test -p open-course-llm --test live -- --nocapture
+//! ```
+//!
+//! Optional overrides: `OC_LIVE_OPENAI_MODEL`, `OC_LIVE_GEMINI_MODEL`,
+//! `OC_LIVE_ALI_BASE_URL`, `OC_LIVE_ALI_ANTHROPIC_BASE_URL`,
+//! `OC_LIVE_ALI_MODEL`, `OC_LIVE_ALI_ANTHROPIC_MODEL`.
+
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use open_course_config::provider::{ProviderConfig, ProviderId};
+use open_course_core::error::AppError;
+use open_course_llm::client::{LlmClient, RigClient, extract_typed};
+use open_course_llm::model_listing::list_models;
+use open_course_llm::streaming::StreamChunk;
+
+const SCENARIO_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+struct Cap {
+    capital: String,
+}
+
+fn config(
+    api_key: &str,
+    model: &str,
+    base_url: Option<&str>,
+    endpoint: Option<&str>,
+) -> ProviderConfig {
+    ProviderConfig::ApiKey {
+        api_key: Some(api_key.to_string()),
+        model: model.to_string(),
+        base_url: base_url.map(str::to_string),
+        endpoint: endpoint.map(str::to_string),
+        reasoning_effort: None,
+        enable_thinking: None,
+    }
+}
+
+fn client(provider: ProviderId, cfg: &ProviderConfig) -> RigClient {
+    RigClient::from_config(cfg, provider).expect("client should build")
+}
+
+/// 1. Model listing returns a non-empty list.
+async fn check_list_models(provider: ProviderId, api_key: &str, base_url: Option<&str>) {
+    let models = list_models(provider, Some(api_key), base_url)
+        .await
+        .expect("list_models should succeed");
+    assert!(!models.is_empty(), "model list must not be empty");
+    eprintln!(
+        "  list_models: {} models, first: {}",
+        models.len(),
+        models[0].id
+    );
+}
+
+/// 2. Non-streaming prompt returns sane text.
+async fn check_prompt(client: &dyn LlmClient) {
+    let text = client
+        .prompt("Reply with exactly: OK", None, 256)
+        .await
+        .expect("prompt should succeed");
+    assert!(!text.trim().is_empty(), "prompt reply must not be empty");
+    eprintln!("  prompt: {:?}", &text[..text.len().min(40)]);
+}
+
+/// 3. Streaming yields incremental chunks and finishes.
+async fn check_stream(client: &dyn LlmClient) {
+    let mut stream = client
+        .stream_prompt("Count from 1 to 10, separated by spaces.", None, 256)
+        .await
+        .expect("stream_prompt should open");
+    let mut chunks = 0usize;
+    let mut assembled = String::new();
+    while let Some(item) = stream.next().await {
+        match item.expect("stream chunk should not error") {
+            StreamChunk::Content(text) => {
+                chunks += 1;
+                assembled.push_str(&text);
+            }
+            StreamChunk::Reasoning(_) => {}
+        }
+    }
+    assert!(
+        chunks >= 2,
+        "expected multiple incremental chunks, got {chunks}"
+    );
+    assert!(
+        !assembled.trim().is_empty(),
+        "streamed text must not be empty"
+    );
+    eprintln!(
+        "  stream: {chunks} content chunks, {:?}",
+        &assembled[..assembled.len().min(40)]
+    );
+}
+
+/// 4. Typed structured extraction (native output_schema, possibly
+///    downgraded to the submit-tool extractor by the provider).
+async fn check_extract(client: &dyn LlmClient) {
+    let cap: Cap = extract_typed(
+        client,
+        "What is the capital of France? Answer with the structured data.",
+        1024,
+    )
+    .await
+    .expect("extract_typed should succeed");
+    assert!(
+        cap.capital.to_lowercase().contains("paris"),
+        "expected Paris, got {:?}",
+        cap.capital
+    );
+    eprintln!("  extract_typed: {:?}", cap.capital);
+}
+
+/// 5. A wrong API key must surface as a non-retryable failure (typed
+///    classification: 401/403 -> auth, never ProviderUnavailable).
+async fn check_wrong_key(provider: ProviderId, cfg: &ProviderConfig) {
+    let client = client(provider, cfg);
+    let err = client
+        .prompt("Reply with exactly: OK", None, 256)
+        .await
+        .expect_err("wrong key must fail");
+    assert!(
+        !matches!(err, AppError::ProviderUnavailable(_)),
+        "auth failure must not be classified as retryable: {err}"
+    );
+    eprintln!("  wrong key: {err}");
+}
+
+async fn run<Fut: std::future::Future>(name: &str, fut: Fut) -> Fut::Output {
+    tokio::time::timeout(SCENARIO_TIMEOUT, fut)
+        .await
+        .unwrap_or_else(|_| panic!("{name} timed out after {SCENARIO_TIMEOUT:?}"))
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI
+// ---------------------------------------------------------------------------
+
+fn openai_env() -> Option<(String, String)> {
+    let key = std::env::var("OC_LIVE_OPENAI_KEY").ok()?;
+    let model = std::env::var("OC_LIVE_OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string());
+    Some((key, model))
+}
+
+#[tokio::test]
+async fn openai_all_scenarios() {
+    let Some((key, model)) = openai_env() else {
+        eprintln!("OC_LIVE_OPENAI_KEY unset, skipping");
+        return;
+    };
+    let cfg = config(&key, &model, None, None);
+    let client = client(ProviderId::OpenAi, &cfg);
+    run("list", check_list_models(ProviderId::OpenAi, &key, None)).await;
+    run("prompt", check_prompt(&client)).await;
+    run("stream", check_stream(&client)).await;
+    run("extract", check_extract(&client)).await;
+}
+
+#[tokio::test]
+async fn openai_wrong_key_is_non_retryable() {
+    let Some((_, model)) = openai_env() else {
+        eprintln!("OC_LIVE_OPENAI_KEY unset, skipping");
+        return;
+    };
+    let cfg = config("sk-definitely-wrong", &model, None, None);
+    run("wrong_key", check_wrong_key(ProviderId::OpenAi, &cfg)).await;
+}
+
+// ---------------------------------------------------------------------------
+// Google Gemini
+// ---------------------------------------------------------------------------
+
+fn gemini_env() -> Option<(String, String)> {
+    let key = std::env::var("OC_LIVE_GEMINI_KEY").ok()?;
+    let model =
+        std::env::var("OC_LIVE_GEMINI_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+    Some((key, model))
+}
+
+#[tokio::test]
+async fn gemini_all_scenarios() {
+    let Some((key, model)) = gemini_env() else {
+        eprintln!("OC_LIVE_GEMINI_KEY unset, skipping");
+        return;
+    };
+    let cfg = config(&key, &model, None, None);
+    let client = client(ProviderId::Google, &cfg);
+    run("list", check_list_models(ProviderId::Google, &key, None)).await;
+    run("prompt", check_prompt(&client)).await;
+    run("stream", check_stream(&client)).await;
+    run("extract", check_extract(&client)).await;
+}
+
+#[tokio::test]
+async fn gemini_wrong_key_is_non_retryable() {
+    let Some((_, model)) = gemini_env() else {
+        eprintln!("OC_LIVE_GEMINI_KEY unset, skipping");
+        return;
+    };
+    let cfg = config("definitely-wrong-key", &model, None, None);
+    run("wrong_key", check_wrong_key(ProviderId::Google, &cfg)).await;
+}
+
+// ---------------------------------------------------------------------------
+// Alibaba ModelStudio, OpenAI-compatible endpoint (Custom provider)
+// ---------------------------------------------------------------------------
+
+const ALI_DEFAULT_BASE_URL: &str =
+    "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1";
+const ALI_DEFAULT_ANTHROPIC_BASE_URL: &str =
+    "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic";
+
+fn ali_env() -> Option<(String, String, String)> {
+    let key = std::env::var("OC_LIVE_ALI_KEY").ok()?;
+    let base =
+        std::env::var("OC_LIVE_ALI_BASE_URL").unwrap_or_else(|_| ALI_DEFAULT_BASE_URL.into());
+    let model = std::env::var("OC_LIVE_ALI_MODEL").unwrap_or_else(|_| "qwen3.6-flash".to_string());
+    Some((key, base, model))
+}
+
+#[tokio::test]
+async fn ali_openai_compatible_all_scenarios() {
+    let Some((key, base, model)) = ali_env() else {
+        eprintln!("OC_LIVE_ALI_KEY unset, skipping");
+        return;
+    };
+    let cfg = config(&key, &model, Some(&base), None);
+    let client = client(ProviderId::Custom, &cfg);
+    run(
+        "list",
+        check_list_models(ProviderId::Custom, &key, Some(&base)),
+    )
+    .await;
+    run("prompt", check_prompt(&client)).await;
+    run("stream", check_stream(&client)).await;
+    run("extract", check_extract(&client)).await;
+}
+
+#[tokio::test]
+async fn ali_openai_compatible_wrong_key_is_non_retryable() {
+    let Some((_, base, model)) = ali_env() else {
+        eprintln!("OC_LIVE_ALI_KEY unset, skipping");
+        return;
+    };
+    let cfg = config("sk-definitely-wrong", &model, Some(&base), None);
+    run("wrong_key", check_wrong_key(ProviderId::Custom, &cfg)).await;
+}
+
+// ---------------------------------------------------------------------------
+// Alibaba ModelStudio, Anthropic-compatible endpoint (Custom, messages)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ali_anthropic_compatible_all_scenarios() {
+    let Some(key) = std::env::var("OC_LIVE_ALI_KEY").ok() else {
+        eprintln!("OC_LIVE_ALI_KEY unset, skipping");
+        return;
+    };
+    let base = std::env::var("OC_LIVE_ALI_ANTHROPIC_BASE_URL")
+        .unwrap_or_else(|_| ALI_DEFAULT_ANTHROPIC_BASE_URL.into());
+    let model = std::env::var("OC_LIVE_ALI_ANTHROPIC_MODEL")
+        .unwrap_or_else(|_| "qwen3.6-flash".to_string());
+    let cfg = config(&key, &model, Some(&base), Some("messages"));
+    let client = client(ProviderId::Custom, &cfg);
+    // Anthropic-compatible endpoints serve messages only; listing goes
+    // through the OpenAI-compatible arm above.
+    run("prompt", check_prompt(&client)).await;
+    run("stream", check_stream(&client)).await;
+    run("extract", check_extract(&client)).await;
+}
+
+#[tokio::test]
+async fn ali_anthropic_compatible_wrong_key_is_non_retryable() {
+    let Some(_) = std::env::var("OC_LIVE_ALI_KEY").ok() else {
+        eprintln!("OC_LIVE_ALI_KEY unset, skipping");
+        return;
+    };
+    let base = std::env::var("OC_LIVE_ALI_ANTHROPIC_BASE_URL")
+        .unwrap_or_else(|_| ALI_DEFAULT_ANTHROPIC_BASE_URL.into());
+    let model = std::env::var("OC_LIVE_ALI_ANTHROPIC_MODEL")
+        .unwrap_or_else(|_| "qwen3.6-flash".to_string());
+    let cfg = config("sk-definitely-wrong", &model, Some(&base), Some("messages"));
+    run("wrong_key", check_wrong_key(ProviderId::Custom, &cfg)).await;
+}

--- a/crates/llm/tests/live.rs
+++ b/crates/llm/tests/live.rs
@@ -134,6 +134,54 @@ async fn check_wrong_key(provider: ProviderId, cfg: &ProviderConfig) {
     eprintln!("  wrong key: {err}");
 }
 
+/// 6. Realistic generation with thinking off: the output must stay
+///    well-formed and sensible, not just fast.
+async fn check_realistic_generation(client: &dyn LlmClient) {
+    let text = client
+        .prompt(
+            "Generate 3 B1-level discussion topics about travel as a JSON array of objects with id and name fields. Return only the JSON.",
+            Some("You are a language tutor. Return ONLY valid JSON. No markdown, no commentary."),
+            2048,
+        )
+        .await
+        .expect("generation should succeed");
+    let cleaned = open_course_llm::parse::clean_json_response(&text);
+    let value: serde_json::Value =
+        serde_json::from_str(&cleaned).expect("generation should parse as JSON");
+    let topics = value.as_array().expect("expected a JSON array");
+    assert_eq!(topics.len(), 3, "expected 3 topics: {cleaned}");
+    for topic in topics {
+        assert!(
+            topic["id"].is_string() || topic["id"].is_number(),
+            "topic missing id: {topic}"
+        );
+        assert!(topic["name"].is_string(), "topic missing name: {topic}");
+    }
+    eprintln!("  realistic generation: 3 well-formed topics");
+}
+
+/// Streaming with thinking disabled must not emit reasoning chunks.
+async fn check_stream_has_no_reasoning(client: &dyn LlmClient) {
+    let mut stream = client
+        .stream_prompt("Count from 1 to 10, separated by spaces.", None, 256)
+        .await
+        .expect("stream_prompt should open");
+    let mut reasoning_chunks = 0usize;
+    let mut content_chunks = 0usize;
+    while let Some(item) = stream.next().await {
+        match item.expect("stream chunk should not error") {
+            StreamChunk::Content(_) => content_chunks += 1,
+            StreamChunk::Reasoning(_) => reasoning_chunks += 1,
+        }
+    }
+    assert!(content_chunks > 0, "expected content chunks");
+    assert_eq!(
+        reasoning_chunks, 0,
+        "thinking disabled must not emit reasoning chunks"
+    );
+    eprintln!("  stream: {content_chunks} content chunks, 0 reasoning chunks");
+}
+
 async fn run<Fut: std::future::Future>(name: &str, fut: Fut) -> Fut::Output {
     tokio::time::timeout(SCENARIO_TIMEOUT, fut)
         .await
@@ -162,6 +210,7 @@ async fn openai_all_scenarios() {
     run("prompt", check_prompt(&client)).await;
     run("stream", check_stream(&client)).await;
     run("extract", check_extract(&client)).await;
+    run("generate", check_realistic_generation(&client)).await;
 }
 
 #[tokio::test]
@@ -197,6 +246,7 @@ async fn gemini_all_scenarios() {
     run("prompt", check_prompt(&client)).await;
     run("stream", check_stream(&client)).await;
     run("extract", check_extract(&client)).await;
+    run("generate", check_realistic_generation(&client)).await;
 }
 
 #[tokio::test]
@@ -242,6 +292,7 @@ async fn ali_openai_compatible_all_scenarios() {
     run("prompt", check_prompt(&client)).await;
     run("stream", check_stream(&client)).await;
     run("extract", check_extract(&client)).await;
+    run("generate", check_realistic_generation(&client)).await;
 }
 
 #[tokio::test]
@@ -252,6 +303,19 @@ async fn ali_openai_compatible_wrong_key_is_non_retryable() {
     };
     let cfg = config("sk-definitely-wrong", &model, Some(&base), None);
     run("wrong_key", check_wrong_key(ProviderId::Custom, &cfg)).await;
+}
+
+/// Custom OpenAI-compatible providers default to `enable_thinking: false`;
+/// the stream must not carry reasoning chunks.
+#[tokio::test]
+async fn ali_openai_compatible_stream_emits_no_reasoning() {
+    let Some((key, base, model)) = ali_env() else {
+        eprintln!("OC_LIVE_ALI_KEY unset, skipping");
+        return;
+    };
+    let cfg = config(&key, &model, Some(&base), None);
+    let client = client(ProviderId::Custom, &cfg);
+    run("stream", check_stream_has_no_reasoning(&client)).await;
 }
 
 // ---------------------------------------------------------------------------
@@ -275,6 +339,7 @@ async fn ali_anthropic_compatible_all_scenarios() {
     run("prompt", check_prompt(&client)).await;
     run("stream", check_stream(&client)).await;
     run("extract", check_extract(&client)).await;
+    run("generate", check_realistic_generation(&client)).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Upgrades the LLM framework from rig-core 0.20.0 to rig 0.42.0 (facade crate) and replaces in-house reimplementations with rig's now-native capabilities. Public API of `crates/llm` is unchanged — `crates/cli` / `crates/service` compile untouched.

## Phases (one commit each)

- **Phase 0** — mechanical bump: `rig-core 0.20 (all, reqwest-rustls)` → `rig 0.42` (default features); workspace `reqwest 0.12 → 0.13`; `Agent<M>` → erased `Agent`; fallible client builders; OpenAI client is now explicitly `CompletionsClient` (chat-completions wire behavior preserved for OpenAI and all compatible gateways).
- **Phase 1** — `model_listing.rs`: hand-rolled per-provider `GET /models` → rig `ModelLister` (Anthropic/Gemini listing now paginates fully; same base-URL/auth plumbing, 10s timeout kept). −182 lines.
- **Phase 2** — `streaming.rs` 371 → 104 lines: manual SSE parsing → `CompletionModel::stream()` with `StreamedAssistantContent` mapping; **Gemini gets real streaming** (was faked via non-streaming); the gpt-5 `max_completion_tokens` body hack deleted (rig maps it per-model upstream); reasoning deltas surfaced for all three wire families.
- **Phase 3** — structured output: native `prompt_typed::<T>` / `output_schema` first, graceful per-call downgrade to the submit-tool Extractor when a gateway rejects `response_format` (one logged extra request, then identical-to-before behavior).
- **Phase 4** — typed error classification (HTTP status, provider body, `Retry-After` honored and capped at 60s) replaces Display string-matching (kept only as fallback for status-less transports); provider request id surfaces in error messages/diagnostics.
- **Phase 5** — cleanup: obsolete Gemini `{generationConfig: {}}` workaround deleted (verified live against rig 0.42), orphaned `bytes`/`regex` deps dropped.

Also fixed for free by the upgrade: rig 0.20 silently dropped `max_tokens` on OpenAI; Gemini no longer gets a hidden `max_output_tokens: 4096`.

## Verification

- `cargo test --workspace` — 28/28 suites green; clippy and `cargo fmt --check` clean.
- New env-gated live suite `crates/llm/tests/live.rs` (skips without keys, CI-safe) run for real against user-supplied keys:

| Provider arm | list_models | prompt | stream | extract_typed | wrong key |
|---|---|---|---|---|---|
| OpenAI (gpt-4o-mini) | ✅ | ✅ | ✅ | ✅ native response_format | ✅ typed 401 + request id |
| Gemini (flash) | ✅ | ✅ | ✅ real streaming | ✅ native response_json_schema | ✅ non-retryable |
| Alibaba OpenAI-compatible (qwen) | ✅ | ✅ | ✅ | ✅ via downgrade (gateway rejects response_format unless prompt says "json") | ✅ typed 401 |
| Alibaba Anthropic-compatible | n/a | ✅ | ✅ | ✅ via downgrade | ✅ typed 401 |

## Notes

- rustls doesn't read the OS trust store — users behind corporate TLS-inspecting proxies may need custom certs (rig default since 0.31, now inherited by us).
- Follow-up idea (not in scope): the phase-3 downgrade debug event currently passes `data_dir: None`; thread a data_dir through `extract_typed` to make downgrades visible in debug logs.