### PR TITLE
feat(cli): render cloze translation sentence in orange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5609,7 +5609,7 @@ dependencies = [
 
 [[package]]
 name = "open-course-cli"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/src/ui/colors.rs
+++ b/crates/cli/src/ui/colors.rs
@@ -3,3 +3,4 @@ use ratatui::style::Color;
 pub const GREEN: Color = Color::from_u32(0x34dab7);
 pub const BLUE: Color = Color::from_u32(0x14539d);
 pub const YELLOW: Color = Color::from_u32(0xfcb05d);
+pub const ORANGE: Color = Color::from_u32(0xffa500);

--- a/crates/cli/src/ui/views/session.rs
+++ b/crates/cli/src/ui/views/session.rs
@@ -320,7 +320,7 @@ pub fn draw(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, state: &mut
                     card = card.line(Line::default());
                     card = card.line(Line::from(Span::styled(
                         item.translation.clone(),
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(colors::ORANGE),
                     )));
                     content_lines += 1 + wrapped_line_count(&item.translation, text_width);
                 }


### PR DESCRIPTION
## What

The native-language translation sentence in the cloze (fill-in-the-blank) exercise card is now rendered in **orange** instead of dark gray.

## Why

The translation (the sentence the learner must translate) was styled with `Color::DarkGray`, making it look like secondary/disabled text and easy to overlook next to the target-language gap sentence. Orange makes it clearly stand out.

## How

- Added `ORANGE: Color = Color::from_u32(0xffa500)` to the existing palette in `crates/cli/src/ui/colors.rs`, following the codebase's convention of RGB-from-u32 color constants.
- Switched the translation `Span` in the `Mode::Cloze` rendering (`crates/cli/src/ui/views/session.rs`) from `Color::DarkGray` to `colors::ORANGE`.

The translation line is rendered once per card, before the gap-word/options styling is applied, so it stays orange in both the unanswered and answered (correct/wrong) states — only the gap word and options get green/red highlighting.

Also includes a `Cargo.lock` sync (open-course-cli 0.22.0 -> 0.23.0) that `cargo` applied automatically; the lockfile was out of date relative to `Cargo.toml` on `main`.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p open-course-cli` — all tests pass (35 passed, 0 failed)

No snapshot/render tests cover the cloze view styling, so no test updates were needed.

## Manual check

In the TUI, start a session, reach the cloze stage, and confirm the translation sentence appears orange both before and after picking an answer.