### PR TITLE
feat(dashboard): place Next topic and Weak topics side by side

### DIFF
--- a/crates/cli/src/ui/views/dashboard.rs
+++ b/crates/cli/src/ui/views/dashboard.rs
@@ -172,9 +172,10 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, state: &mut AppState) {
     draw_hint_bar(frame.buffer_mut(), hint_area, state, labels);
 
     // The page content is sized by its blocks, never squeezed: the activity
-    // calendar needs `calendar_height` rows, the next-topic block 6, the
-    // progress block 10, the weak block 7. If it exceeds the viewport, it is
-    // rendered offscreen and the mouse wheel scrolls the visible window.
+    // calendar needs `calendar_height` rows, the progress block 10, and the
+    // next-topic/weak-topics row the taller of its two blocks (6 and 7). If
+    // it exceeds the viewport, it is rendered offscreen and the mouse wheel
+    // scrolls the visible window.
     let today = chrono::Local::now().date_naive();
     let calendar_height = activity_calendar::block_height(today);
     let narrow = content_area.width < 90;
@@ -183,38 +184,40 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, state: &mut AppState) {
     } else {
         calendar_height.max(PROGRESS_HEIGHT)
     };
-    let content_height = TOP_HEIGHT + NEXT_HEIGHT + middle_height + WEAK_HEIGHT;
+    let next_weak_height = if narrow {
+        NEXT_HEIGHT + WEAK_HEIGHT
+    } else {
+        NEXT_HEIGHT.max(WEAK_HEIGHT)
+    };
+    let content_height = TOP_HEIGHT + next_weak_height + middle_height;
 
     if content_height <= content_area.height {
         state.dashboard.scroll_offset = 0;
         state.dashboard.max_scroll = 0;
-        let [top_area, next_area, middle_area, weak_area] = Layout::vertical([
+        let [top_area, next_weak_area, middle_area] = Layout::vertical([
             Constraint::Length(TOP_HEIGHT),
-            Constraint::Length(NEXT_HEIGHT),
-            Constraint::Length(middle_height),
-            Constraint::Min(0),
+            Constraint::Length(next_weak_height),
+            Constraint::Min(middle_height),
         ])
         .areas(content_area);
         let buf = frame.buffer_mut();
         draw_top(buf, top_area, state, labels, narrow);
-        draw_next_topic(buf, next_area, state, labels);
+        draw_next_weak(buf, next_weak_area, state, labels, narrow);
         draw_middle(buf, middle_area, state, labels, calendar_height, narrow);
-        draw_weak_topics(buf, weak_area, state, labels);
     } else {
         let max_scroll = content_height - content_area.height;
         state.dashboard.max_scroll = max_scroll;
         state.dashboard.scroll_offset = state.dashboard.scroll_offset.min(max_scroll);
 
         let mut offscreen = Buffer::empty(Rect::new(0, 0, content_area.width, content_height));
-        let [top_area, next_area, middle_area, weak_area] = Layout::vertical([
+        let [top_area, next_weak_area, middle_area] = Layout::vertical([
             Constraint::Length(TOP_HEIGHT),
-            Constraint::Length(NEXT_HEIGHT),
+            Constraint::Length(next_weak_height),
             Constraint::Length(middle_height),
-            Constraint::Length(WEAK_HEIGHT),
         ])
         .areas(offscreen.area);
         draw_top(&mut offscreen, top_area, state, labels, narrow);
-        draw_next_topic(&mut offscreen, next_area, state, labels);
+        draw_next_weak(&mut offscreen, next_weak_area, state, labels, narrow);
         draw_middle(
             &mut offscreen,
             middle_area,
@@ -223,7 +226,6 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, state: &mut AppState) {
             calendar_height,
             narrow,
         );
-        draw_weak_topics(&mut offscreen, weak_area, state, labels);
 
         blit(
             &offscreen,
@@ -410,6 +412,29 @@ fn profile_info_lines(state: &AppState, labels: ReportLabels) -> Vec<Line<'stati
 
 fn profile_info(state: &AppState, labels: ReportLabels) -> Paragraph<'static> {
     Paragraph::new(Text::from(profile_info_lines(state, labels))).alignment(Alignment::Right)
+}
+
+fn draw_next_weak(
+    buf: &mut Buffer,
+    area: Rect,
+    state: &AppState,
+    labels: ReportLabels,
+    narrow: bool,
+) {
+    let chunks = if narrow {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(NEXT_HEIGHT), Constraint::Min(0)])
+            .split(area)
+    } else {
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(area)
+    };
+
+    draw_next_topic(buf, chunks[0], state, labels);
+    draw_weak_topics(buf, chunks[1], state, labels);
 }
 
 fn draw_middle(

--- a/crates/cli/tests/settings_layout_test.rs
+++ b/crates/cli/tests/settings_layout_test.rs
@@ -263,6 +263,62 @@ async fn dashboard_header_shows_update_hint() {
 }
 
 #[tokio::test]
+async fn dashboard_next_and_weak_share_a_row_on_wide_terminal() {
+    let mut state = setup_state().await;
+    state.view = View::Dashboard;
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| dashboard::draw(f, f.area(), &mut state))
+        .unwrap();
+
+    let text = buffer_text(&terminal);
+    let row = text
+        .lines()
+        .find(|line| line.contains("Следующая тема"))
+        .expect("Next topic block title should render");
+    let next_col = row.find("Следующая тема").unwrap();
+    let weak_col = row
+        .find("Слабые темы")
+        .expect("Weak topics block title should share the row");
+    assert!(
+        next_col < weak_col,
+        "Next topic should be left of Weak topics: {row}"
+    );
+    assert!(
+        weak_col >= 60,
+        "Weak topics should start in the right half: {row}"
+    );
+}
+
+#[tokio::test]
+async fn dashboard_next_and_weak_stack_on_narrow_terminal() {
+    let mut state = setup_state().await;
+    state.view = View::Dashboard;
+
+    let backend = TestBackend::new(80, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| dashboard::draw(f, f.area(), &mut state))
+        .unwrap();
+
+    let text = buffer_text(&terminal);
+    let next_row = text
+        .lines()
+        .position(|line| line.contains("Следующая тема"))
+        .expect("Next topic block title should render");
+    let weak_row = text
+        .lines()
+        .position(|line| line.contains("Слабые темы"))
+        .expect("Weak topics block title should render");
+    assert!(
+        weak_row > next_row,
+        "Blocks should stack vertically on narrow terminals: next row {next_row}, weak row {weak_row}"
+    );
+}
+
+#[tokio::test]
 async fn update_available_prompt_renders() {
     use open_course_cli::ui::views::update;
 


### PR DESCRIPTION
## What

The **Next topic** block (added in #117, already merged) and the **Weak topics** block now share a single two-column row on the dashboard — Next topic on the left, Weak topics on the right (50/50) — mirroring how the Activity and Progress blocks already form a two-column row below them.

Note: this was originally planned as a stack on #117, but #117 merged into `main` first, so this PR is based on `main` and contains only the layout change.

## How

- New `draw_next_weak` helper in `crates/cli/src/ui/views/dashboard.rs` splits the row horizontally (`Percentage(50)`/`Percentage(50)`); on narrow terminals (< 90 columns) the blocks stack vertically, matching the Activity/Progress narrow behavior.
- Row height is `max(NEXT_HEIGHT, WEAK_HEIGHT)` (= 7) when side by side and `NEXT_HEIGHT + WEAK_HEIGHT` when stacked.
- Both render paths — the fitted path and the scrollable offscreen path — use the same height computation, so `content_height`/scroll math stays consistent.
- In the fitted path the Activity/Progress row now absorbs leftover vertical space (`Min(middle_height)`); the Progress block already has an expanded layout for taller areas, so the Next/Weak row stays compact instead of stretching into a large empty box mid-screen.
- Block content (badges, topic name, description, "Press N to start" hint) is rendered with `Paragraph`, which clips at the area boundary, so it truncates gracefully at half width.

## Tests

- Added `dashboard_next_and_weak_share_a_row_on_wide_terminal` and `dashboard_next_and_weak_stack_on_narrow_terminal` render tests (TestBackend) in `crates/cli/tests/settings_layout_test.rs`.
- Verified: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p open-course-cli` — all pass.
- Manually inspected rendered buffers at 80x24, 80x20, 80x30, 120x40 (incl. scrolled states) via the `layout_debug` helper.