### PR TITLE
fix(cli): reorder dashboard blocks into Next/Progress and Activity/Weak rows

### DIFF
--- a/crates/cli/src/ui/views/dashboard.rs
+++ b/crates/cli/src/ui/views/dashboard.rs
@@ -171,56 +171,66 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, state: &mut AppState) {
         Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(area);
     draw_hint_bar(frame.buffer_mut(), hint_area, state, labels);
 
-    // The page content is sized by its blocks, never squeezed: the activity
-    // calendar needs `calendar_height` rows, the progress block 10, and the
-    // next-topic/weak-topics row the taller of its two blocks (6 and 7). If
-    // it exceeds the viewport, it is rendered offscreen and the mouse wheel
+    // The page content is sized by its blocks, never squeezed: the
+    // next-topic/progress row needs the taller of its blocks (6 and 10), the
+    // activity/weak-topics row the taller of `calendar_height` and 7. If it
+    // exceeds the viewport, it is rendered offscreen and the mouse wheel
     // scrolls the visible window.
     let today = chrono::Local::now().date_naive();
     let calendar_height = activity_calendar::block_height(today);
     let narrow = content_area.width < 90;
-    let middle_height = if narrow {
-        calendar_height + PROGRESS_HEIGHT
+    let next_progress_height = if narrow {
+        NEXT_HEIGHT + PROGRESS_HEIGHT
     } else {
-        calendar_height.max(PROGRESS_HEIGHT)
+        NEXT_HEIGHT.max(PROGRESS_HEIGHT)
     };
-    let next_weak_height = if narrow {
-        NEXT_HEIGHT + WEAK_HEIGHT
+    let activity_weak_height = if narrow {
+        calendar_height + WEAK_HEIGHT
     } else {
-        NEXT_HEIGHT.max(WEAK_HEIGHT)
+        calendar_height.max(WEAK_HEIGHT)
     };
-    let content_height = TOP_HEIGHT + next_weak_height + middle_height;
+    let content_height = TOP_HEIGHT + next_progress_height + activity_weak_height;
 
     if content_height <= content_area.height {
         state.dashboard.scroll_offset = 0;
         state.dashboard.max_scroll = 0;
-        let [top_area, next_weak_area, middle_area] = Layout::vertical([
+        // The next/progress row absorbs leftover space so the progress block
+        // scales into its expanded layout on tall terminals, exactly as it
+        // did in the activity/progress row.
+        let [top_area, next_progress_area, activity_weak_area] = Layout::vertical([
             Constraint::Length(TOP_HEIGHT),
-            Constraint::Length(next_weak_height),
-            Constraint::Min(middle_height),
+            Constraint::Min(next_progress_height),
+            Constraint::Length(activity_weak_height),
         ])
         .areas(content_area);
         let buf = frame.buffer_mut();
         draw_top(buf, top_area, state, labels, narrow);
-        draw_next_weak(buf, next_weak_area, state, labels, narrow);
-        draw_middle(buf, middle_area, state, labels, calendar_height, narrow);
+        draw_next_progress(buf, next_progress_area, state, labels, narrow);
+        draw_activity_weak(
+            buf,
+            activity_weak_area,
+            state,
+            labels,
+            calendar_height,
+            narrow,
+        );
     } else {
         let max_scroll = content_height - content_area.height;
         state.dashboard.max_scroll = max_scroll;
         state.dashboard.scroll_offset = state.dashboard.scroll_offset.min(max_scroll);
 
         let mut offscreen = Buffer::empty(Rect::new(0, 0, content_area.width, content_height));
-        let [top_area, next_weak_area, middle_area] = Layout::vertical([
+        let [top_area, next_progress_area, activity_weak_area] = Layout::vertical([
             Constraint::Length(TOP_HEIGHT),
-            Constraint::Length(next_weak_height),
-            Constraint::Length(middle_height),
+            Constraint::Length(next_progress_height),
+            Constraint::Length(activity_weak_height),
         ])
         .areas(offscreen.area);
         draw_top(&mut offscreen, top_area, state, labels, narrow);
-        draw_next_weak(&mut offscreen, next_weak_area, state, labels, narrow);
-        draw_middle(
+        draw_next_progress(&mut offscreen, next_progress_area, state, labels, narrow);
+        draw_activity_weak(
             &mut offscreen,
-            middle_area,
+            activity_weak_area,
             state,
             labels,
             calendar_height,
@@ -414,7 +424,7 @@ fn profile_info(state: &AppState, labels: ReportLabels) -> Paragraph<'static> {
     Paragraph::new(Text::from(profile_info_lines(state, labels))).alignment(Alignment::Right)
 }
 
-fn draw_next_weak(
+fn draw_next_progress(
     buf: &mut Buffer,
     area: Rect,
     state: &AppState,
@@ -434,10 +444,10 @@ fn draw_next_weak(
     };
 
     draw_next_topic(buf, chunks[0], state, labels);
-    draw_weak_topics(buf, chunks[1], state, labels);
+    draw_progress(buf, chunks[1], state, labels);
 }
 
-fn draw_middle(
+fn draw_activity_weak(
     buf: &mut Buffer,
     area: Rect,
     state: &AppState,
@@ -453,12 +463,12 @@ fn draw_middle(
     } else {
         Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(area)
     };
 
     draw_session_dynamics(buf, chunks[0], state, labels);
-    draw_progress(buf, chunks[1], state, labels);
+    draw_weak_topics(buf, chunks[1], state, labels);
 }
 
 const COLOR_NEW: Color = colors::BLUE;

--- a/crates/cli/tests/settings_layout_test.rs
+++ b/crates/cli/tests/settings_layout_test.rs
@@ -263,7 +263,7 @@ async fn dashboard_header_shows_update_hint() {
 }
 
 #[tokio::test]
-async fn dashboard_next_and_weak_share_a_row_on_wide_terminal() {
+async fn dashboard_rows_pair_next_with_progress_and_activity_with_weak() {
     let mut state = setup_state().await;
     state.view = View::Dashboard;
 
@@ -274,26 +274,64 @@ async fn dashboard_next_and_weak_share_a_row_on_wide_terminal() {
         .unwrap();
 
     let text = buffer_text(&terminal);
-    let row = text
+    let row1 = text
         .lines()
         .find(|line| line.contains("Следующая тема"))
         .expect("Next topic block title should render");
-    let next_col = row.find("Следующая тема").unwrap();
-    let weak_col = row
-        .find("Слабые темы")
-        .expect("Weak topics block title should share the row");
+    let next_col = row1.find("Следующая тема").unwrap();
+    let progress_col = row1
+        .find("Прогресс")
+        .expect("Progress block title should share the first row");
     assert!(
-        next_col < weak_col,
-        "Next topic should be left of Weak topics: {row}"
+        next_col < progress_col,
+        "Next topic should be left of Progress: {row1}"
+    );
+    assert!(
+        progress_col >= 60,
+        "Progress should start in the right half: {row1}"
+    );
+
+    let row2 = text
+        .lines()
+        .find(|line| line.contains("Активность"))
+        .expect("Activity block title should render");
+    let activity_col = row2.find("Активность").unwrap();
+    let weak_col = row2
+        .find("Слабые темы")
+        .expect("Weak topics block title should share the second row");
+    assert!(
+        activity_col < weak_col,
+        "Activity should be left of Weak topics: {row2}"
     );
     assert!(
         weak_col >= 60,
-        "Weak topics should start in the right half: {row}"
+        "Weak topics should start in the right half: {row2}"
+    );
+
+    let row1_idx = text
+        .lines()
+        .position(|line| line.contains("Следующая тема"))
+        .unwrap();
+    let row2_idx = text
+        .lines()
+        .position(|line| line.contains("Активность"))
+        .unwrap();
+    assert!(
+        row1_idx < row2_idx,
+        "Next/Progress row should sit above Activity/Weak row"
+    );
+
+    // The Next/Progress row absorbs leftover height, so at 120x40 the
+    // progress block keeps its expanded layout (level rows with a dedicated
+    // bar line, " / " separators) instead of the compact one ("0/0/0").
+    assert!(
+        text.contains("A1: 0 / 0 / 0"),
+        "Progress should render its expanded layout on tall terminals"
     );
 }
 
 #[tokio::test]
-async fn dashboard_next_and_weak_stack_on_narrow_terminal() {
+async fn dashboard_blocks_stack_in_order_on_narrow_terminal() {
     let mut state = setup_state().await;
     state.view = View::Dashboard;
 
@@ -304,17 +342,19 @@ async fn dashboard_next_and_weak_stack_on_narrow_terminal() {
         .unwrap();
 
     let text = buffer_text(&terminal);
-    let next_row = text
-        .lines()
-        .position(|line| line.contains("Следующая тема"))
-        .expect("Next topic block title should render");
-    let weak_row = text
-        .lines()
-        .position(|line| line.contains("Слабые темы"))
-        .expect("Weak topics block title should render");
+    let title_row = |title: &str| {
+        text.lines()
+            .position(|line| line.contains(title))
+            .unwrap_or_else(|| panic!("{title} block title should render"))
+    };
+    let next_row = title_row("Следующая тема");
+    let progress_row = title_row("Прогресс");
+    let activity_row = title_row("Активность");
+    let weak_row = title_row("Слабые темы");
     assert!(
-        weak_row > next_row,
-        "Blocks should stack vertically on narrow terminals: next row {next_row}, weak row {weak_row}"
+        next_row < progress_row && progress_row < activity_row && activity_row < weak_row,
+        "Blocks should stack as Next, Progress, Activity, Weak: \
+         {next_row}, {progress_row}, {activity_row}, {weak_row}"
     );
 }
 


### PR DESCRIPTION
## What

Changes the TUI dashboard block order (web untouched) to:

```
header
Next topic | Progress
Activity  | Weak topics
```

Both rows split 50/50 on wide terminals. On narrow terminals (< 90 columns) the blocks stack in the order **Next, Progress, Activity, Weak**.

## Progress design preserved

The progress block keeps its previous appearance: the **Next/Progress row absorbs all leftover vertical space** (`Min(next_progress_height)`), so on tall terminals the progress block scales into its expanded layout (level rows with dedicated bar lines) exactly as it did in the old Activity/Progress row, and it never gets squeezed into the compact variant by the fixed-height Next topic block beside it. The height at which it switches between compact and expanded is unchanged from before this reorder.

The Activity/Weak row is sized by the taller of the activity calendar and the weak-topics list (`max(calendar_height, WEAK_HEIGHT)`), since neither scales with extra height.

## Implementation

- `crates/cli/src/ui/views/dashboard.rs`: replaced `draw_next_weak`/`draw_middle` with `draw_next_progress` and `draw_activity_weak`; both render paths (fitted + scrollable offscreen) compute row heights from the same `next_progress_height`/`activity_weak_height` values, so `content_height` and the scroll math stay consistent.
- `crates/cli/tests/settings_layout_test.rs`: replaced the #119-era Next/Weak pairing tests with:
  - `dashboard_rows_pair_next_with_progress_and_activity_with_weak` — wide-terminal pairing, left/right order, row order, and an assertion that the progress block renders its expanded layout (`A1: 0 / 0 / 0`) at 120x40.
  - `dashboard_blocks_stack_in_order_on_narrow_terminal` — narrow-terminal stacking order Next → Progress → Activity → Weak.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p open-course-cli` — all pass.
- Rendered buffers inspected at 120x40 (Next|Progress row above Activity|Weak row, expanded progress layout) and 80x24/80x20/80x30 (correct stacking order; scroll-to-bottom lands exactly on the Weak topics block border).
